### PR TITLE
Set up cloud dev environment + document non-obvious caveats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,3 +164,32 @@ Requires the document package's `mcp` extra: `pip install vera-cli "vera-doc[mcp
   public behavior is only documented in implementation code or tests.
 - Retrieval quality is tracked with `vera eval` against the query sets in
   [examples](examples); don't regress the baselines in the README.
+
+## Cursor Cloud specific instructions
+
+The startup update script already runs `uv sync --extra dev --extra ml --extra app --extra mcp`
+and `npm --prefix packages/vera-app install`, so dependencies are ready. Notes below are
+non-obvious caveats for this environment; standard commands live in the sections above,
+[README.md](README.md), and [docs/desktop-app-getting-started.md](docs/desktop-app-getting-started.md).
+
+- `uv` installs to `~/.local/bin`, which is not on `PATH` for non-interactive shells. It is
+  added to `~/.bashrc` (so interactive shells work); otherwise invoke it as
+  `~/.local/bin/uv` or `export PATH="$HOME/.local/bin:$PATH"`. The uv venv lives at
+  `/workspace/.venv`.
+- Standard checks: `uv run --extra dev python -m pytest -q` (or `npm test`) for Python,
+  `npm run app:typecheck` and `npm --prefix packages/vera-app run test:unit` for the app.
+- Desktop app on Linux: the root `npm run app:dev` script hardcodes `npm.cmd` and only works
+  on Windows. On Linux run the app directly: `npm --prefix packages/vera-app run dev`. Electron
+  spawns the Python sidecar as `python -m vera_app.sidecar`, so set
+  `VERA_APP_PYTHON=/workspace/.venv/bin/python` (the venv Python has numpy/pymupdf/pdfplumber);
+  otherwise the sidecar fails to import its deps. In the cloud VM also set `DISPLAY=:1` and
+  `ELECTRON_DISABLE_SANDBOX=1`. The dbus/GLib warnings Electron prints in the container are
+  harmless.
+- The desktop app's "Ask"/chat feature requires configuring an external or local LLM provider
+  (OpenAI/OpenRouter/Ollama/LM Studio) — there is no offline/extractive answer mode, so Ask is
+  blocked without a provider/API key. For fully offline testing use the left-sidebar **Search**
+  view (pure hybrid/semantic/keyword retrieval with grounded citations and highlights) or the
+  **Convert PDF** view; both run entirely through the sidecar with no LLM.
+- MCP server (optional): `uv run --extra mcp vera mcp` (long-running stdio; no `--json`).
+- There are no PDFs in the repo; generate one with the `reportlab` dev dependency when you need
+  a sample to `vera convert`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the full VERA development environment for Cursor Cloud agents, and records the non-obvious startup caveats discovered along the way in `AGENTS.md`.

No product code was changed — the only diff is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. Dependency refresh is handled by the environment update script (`uv sync --extra dev --extra ml --extra app --extra mcp` + `npm --prefix packages/vera-app install`).

## What was installed
- `uv` (installs to `~/.local/bin`) + Python deps via `uv sync` with the `dev`, `ml`, `app`, and `mcp` extras
- Desktop app npm deps via `npm --prefix packages/vera-app install`

## Services verified

| Surface | Command(s) | Result |
|---|---|---|
| Python core + CLI tests | `uv run --extra dev python -m pytest -q` | 261 passed |
| App typecheck | `npm run app:typecheck` | pass |
| App unit tests | `npm --prefix packages/vera-app run test:unit` (vitest) | 14 passed |
| CLI (`vera-cli`) | `vera convert / inspect / validate / search` | archive built + hybrid search returns correctly ranked cited results |
| Desktop app (Electron + sidecar) | `VERA_APP_PYTHON=/workspace/.venv/bin/python npm --prefix packages/vera-app run dev` | open document → Search view → ranked results → source page with grounded highlights |
| MCP server (optional) | `uv run --extra mcp vera mcp` | stdio `initialize` + `tools/list` succeed |

## Key non-obvious caveats (now in AGENTS.md)
- `uv` lands in `~/.local/bin` (not on `PATH` for non-interactive shells); venv is `/workspace/.venv`.
- Root `npm run app:dev` hardcodes `npm.cmd` (Windows-only). On Linux run `npm --prefix packages/vera-app run dev` and set `VERA_APP_PYTHON=/workspace/.venv/bin/python` so the Electron-spawned sidecar imports its deps. In the cloud VM also set `DISPLAY=:1` and `ELECTRON_DISABLE_SANDBOX=1`.
- The app's Ask/chat requires an external/local LLM provider (no offline answer mode). For offline testing use the sidebar **Search** or **Convert PDF** views.

## Demo

Desktop app: open `.vera` document → run hybrid Search → ranked results → click top result → source page shown with grounded highlight.

[vera_desktop_app_open_and_search.mp4](https://cursor.com/agents/bc-3a30e506-a9fb-4e90-9830-3969c7322a05/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvera_desktop_app_open_and_search.mp4)

[Ranked search results](https://cursor.com/agents/bc-3a30e506-a9fb-4e90-9830-3969c7322a05/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvera_search_results.webp)
[Selected result with source page highlighted](https://cursor.com/agents/bc-3a30e506-a9fb-4e90-9830-3969c7322a05/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvera_search_result_highlighted.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a30e506-a9fb-4e90-9830-3969c7322a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a30e506-a9fb-4e90-9830-3969c7322a05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

