### PR TITLE
feat: simplify providers dialog and add Hugging Face token settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy to `.env` for local CLI / tooling (optional). The desktop app stores
+# this token in Settings > Hugging Face instead of reading `.env`.
+#
+# Used by Hugging Face Hub downloads (Docling layout models, some embedders).
+# Create a token at https://huggingface.co/settings/tokens
+HF_TOKEN=
+
+# Optional aliases / related knobs:
+# HUGGING_FACE_HUB_TOKEN=
+# HF_HUB_OFFLINE=1
+# DOCLING_ARTIFACTS_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ node_modules/
 *.egg-info/
 examples/*.pdf
 site/
+.env
+.env.local
+.env.*.local

--- a/docs/desktop-app-getting-started.md
+++ b/docs/desktop-app-getting-started.md
@@ -53,9 +53,12 @@ Open a PDF from the app's Convert view to create a `.vera` archive, or use the
 native File menu to open an existing archive or document library.
 Desktop conversions use the supported PyMuPDF parser and deterministic
 local hashing embeddings. Use the CLI when you need a Sentence Transformers
-model or explicit OCR controls. Conversion progress and the current filename
-appear in the footer status bar, so progress remains visible when you switch
-away from the Convert view.
+model or explicit OCR controls. Some Hub downloads warn about unauthenticated
+requests; save an optional Hugging Face token under **File > LLM Providers →
+Hugging Face** (or set `HF_TOKEN` / copy `.env.example` to `.env`) to raise
+rate limits. Conversion progress and the current filename appear in the footer
+status bar, so progress remains visible when you switch away from the Convert
+view.
 
 Use the **Chat / Search** switch above the center workspace to choose between
 LLM-backed conversation and direct retrieval. Search supports hybrid, semantic,

--- a/docs/packages/vera-app.md
+++ b/docs/packages/vera-app.md
@@ -20,7 +20,10 @@ Download `VERA Setup <version>.exe` from the
 2. Use **File > Open Folder** to activate a document library.
 3. Open **Search** for fully local hybrid retrieval.
 4. To use **Ask**, configure a provider under **File > LLM Providers**.
-5. Select a citation in an answer to inspect the highlighted source passage.
+5. Optional: save a Hugging Face token under **File > LLM Providers → Hugging
+   Face** (or set `HF_TOKEN`) for Hub model downloads used by some converters
+   and embedders.
+6. Select a citation in an answer to inspect the highlighted source passage.
 
 Search and conversion do not require a model-provider account. A provider is
 only required for generated Ask responses.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -167,6 +167,10 @@ vera convert "input.pdf" --parser pymupdf
 
 Other parser names are not currently implemented.
 
+If Hugging Face Hub downloads warn about unauthenticated requests or hit rate
+limits, set `HF_TOKEN` (see `.env.example`) or save a token under **File >
+LLM Providers → Hugging Face** in the desktop app.
+
 ## Figures are missing or have no caption
 
 - Search with `--figures --json`; figure metadata is not shown in ordinary text

--- a/packages/vera-app/electron/main.ts
+++ b/packages/vera-app/electron/main.ts
@@ -174,6 +174,15 @@ class PythonSidecar {
     return true;
   }
 
+  /** Kill the sidecar so the next request respawns with updated env (e.g. HF_TOKEN). */
+  restart(): void {
+    const child = this.child;
+    if (!child) return;
+    this.child = null;
+    this.rejectPending(new Error('VERA sidecar restarted'), child);
+    child.kill();
+  }
+
   private rejectPending(reason: Error, child?: ChildProcessWithoutNullStreams): void {
     for (const [id, entry] of this.pending) {
       if (child && entry.child !== child) continue;
@@ -188,6 +197,7 @@ class PythonSidecar {
     }
 
     const env = { ...process.env };
+    applyHfTokenEnv(env);
     const packagedSidecar = join(process.resourcesPath, 'python', 'sidecar', 'vera-sidecar.exe');
     const executable = app.isPackaged ? packagedSidecar : process.env.VERA_APP_PYTHON || 'python';
     const args = app.isPackaged ? [] : ['-m', 'vera_app.sidecar'];
@@ -312,6 +322,9 @@ function secretPath(): string {
   return join(app.getPath('userData'), 'llm-api-keys.bin');
 }
 
+/** Reserved key inside the encrypted credential store (not a provider base URL). */
+const HF_TOKEN_SECRET_KEY = '__vera_hf_token__';
+
 function readApiKeys(): Record<string, string> {
   if (!safeStorage.isEncryptionAvailable() || !existsSync(secretPath())) {
     return {};
@@ -334,6 +347,27 @@ function credentialKey(baseUrl: unknown): string {
   return typeof baseUrl === 'string' ? baseUrl.trim().replace(/\/+$/, '').toLowerCase() : '';
 }
 
+function storedHfToken(): string {
+  const value = readApiKeys()[HF_TOKEN_SECRET_KEY];
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function environmentHfToken(): string {
+  return (process.env.HF_TOKEN || process.env.HUGGING_FACE_HUB_TOKEN || '').trim();
+}
+
+/** Prefer the app-stored token; fall back to process environment. */
+function resolveHfToken(): string {
+  return storedHfToken() || environmentHfToken();
+}
+
+function applyHfTokenEnv(env: NodeJS.ProcessEnv): void {
+  const token = resolveHfToken();
+  if (!token) return;
+  env.HF_TOKEN = token;
+  env.HUGGING_FACE_HUB_TOKEN = token;
+}
+
 function withRuntime(settings: AppSettings): AppSettings {
   const keys = readApiKeys();
   return {
@@ -342,6 +376,7 @@ function withRuntime(settings: AppSettings): AppSettings {
       ...profile,
       has_api_key: Boolean(keys[credentialKey(profile.base_url)]),
     })),
+    has_hf_token: Boolean(resolveHfToken()),
   };
 }
 
@@ -453,6 +488,31 @@ function clearApiKey(baseUrl: string): CredentialResult {
     writeApiKeys(keys);
   }
   return { ok: true, has_api_key: false };
+}
+
+function saveHfToken(token: string): CredentialResult {
+  if (!safeStorage.isEncryptionAvailable()) {
+    return { ok: false, has_api_key: false, error: 'Secure credential storage is unavailable on this system.' };
+  }
+  const trimmed = token.trim();
+  if (!trimmed) {
+    return { ok: false, has_api_key: false, error: 'Enter a Hugging Face token first.' };
+  }
+  const keys = readApiKeys();
+  keys[HF_TOKEN_SECRET_KEY] = trimmed;
+  writeApiKeys(keys);
+  sidecar.restart();
+  return { ok: true, has_api_key: true };
+}
+
+function clearHfToken(): CredentialResult {
+  const keys = readApiKeys();
+  if (HF_TOKEN_SECRET_KEY in keys) {
+    delete keys[HF_TOKEN_SECRET_KEY];
+    writeApiKeys(keys);
+  }
+  sidecar.restart();
+  return { ok: true, has_api_key: Boolean(environmentHfToken()) };
 }
 
 function withStoredApiKey(payload: SidecarPayload): SidecarPayload {
@@ -837,6 +897,8 @@ app.whenReady().then(() => {
   ipcMain.handle('vera:saveSettings', async (_event, settings: AppSettings) => writeSettings(settings));
   ipcMain.handle('vera:saveApiKey', async (_event, providerId: string, apiKey: string) => saveApiKey(providerId, apiKey));
   ipcMain.handle('vera:clearApiKey', async (_event, providerId: string) => clearApiKey(providerId));
+  ipcMain.handle('vera:saveHfToken', async (_event, token: string) => saveHfToken(token));
+  ipcMain.handle('vera:clearHfToken', async () => clearHfToken());
   ipcMain.handle('vera:pickArchive', async () => pickArchivePath());
   ipcMain.handle('vera:pickFolder', async () => pickFolderPath());
   ipcMain.handle('vera:listFolder', async (_event, dir: string) => listFolder(dir));

--- a/packages/vera-app/electron/preload.cts
+++ b/packages/vera-app/electron/preload.cts
@@ -13,6 +13,8 @@ contextBridge.exposeInMainWorld('vera', {
   saveSettings: (settings: AppSettings) => ipcRenderer.invoke('vera:saveSettings', settings),
   saveApiKey: (providerId: string, apiKey: string) => ipcRenderer.invoke('vera:saveApiKey', providerId, apiKey),
   clearApiKey: (providerId: string) => ipcRenderer.invoke('vera:clearApiKey', providerId),
+  saveHfToken: (token: string) => ipcRenderer.invoke('vera:saveHfToken', token),
+  clearHfToken: () => ipcRenderer.invoke('vera:clearHfToken'),
   getSessions: () => ipcRenderer.invoke('vera:getSessions'),
   saveSession: (session: Session) => ipcRenderer.invoke('vera:saveSession', session),
   deleteSession: (id: string) => ipcRenderer.invoke('vera:deleteSession', id),

--- a/packages/vera-app/src/renderer/components/ProviderManagers.tsx
+++ b/packages/vera-app/src/renderer/components/ProviderManagers.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import {
   CheckCircle2,
+  ChevronDown,
+  ChevronUp,
   KeyRound,
   ListChecks,
-  Pencil,
   Plus,
   RefreshCw,
   Search,
@@ -20,7 +21,6 @@ import {
   PROVIDER_PRESETS,
   providerDisplayName,
   providerPresetFor,
-  providerTypeLabel,
   type ProviderPreset,
   withPresetModels,
 } from '../lib/providers';
@@ -94,7 +94,7 @@ export function ModelManager({
           })}
         </div>
         <footer className="modalFooter">
-          <button className="modelManagerAdd" onClick={onAddProvider}><Plus size={14} />Add provider…</button>
+          <button className="modelManagerAdd" onClick={onAddProvider}><Plus size={14} />Add providerΓÇª</button>
           <span className="modalMessage">{message}</span>
         </footer>
       </div>
@@ -102,11 +102,22 @@ export function ModelManager({
   );
 }
 
+/** One entry in the flat provider list: a preset (configured or not) or a custom profile. */
+type ProviderRowInfo = {
+  key: string;
+  label: string;
+  description: string;
+  kind: 'hosted' | 'local' | 'custom';
+  preset: ProviderPreset | null;
+  profile: ProviderProfile | null;
+};
+
 export function ProviderManager({
   providers,
   activeProviderId,
   activeModel,
   activeModeId,
+  hasHfToken = false,
   onPersist,
   onRefresh,
   onClose,
@@ -115,6 +126,7 @@ export function ProviderManager({
   activeProviderId: string;
   activeModel: string;
   activeModeId: string;
+  hasHfToken?: boolean;
   onPersist: (next: AppSettings) => Promise<AppSettings>;
   onRefresh: () => Promise<AppSettings>;
   onClose: () => void;
@@ -122,25 +134,48 @@ export function ProviderManager({
   const [list, setList] = useState<ProviderProfile[]>(() => providers.map(withPresetModels));
   const [activeId, setActiveId] = useState(activeProviderId);
   const [activeModelLocal, setActiveModelLocal] = useState(activeModel);
-  const [selectedId, setSelectedId] = useState<string>(providers[0]?.id ?? '');
-  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [keyInputs, setKeyInputs] = useState<Record<string, string>>({});
+  const [hfTokenInput, setHfTokenInput] = useState('');
+  const [hfTokenStored, setHfTokenStored] = useState(hasHfToken);
   const [modelInput, setModelInput] = useState('');
   const [modelFilter, setModelFilter] = useState('');
   const [message, setMessage] = useState('');
   const [busy, setBusy] = useState(false);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
 
-  const selected = list.find((profile) => profile.id === selectedId) ?? null;
-  const selectedPreset = selected ? providerPresetFor(selected) : null;
-  const enabledModels = new Set(selected?.models ?? []);
+  // Flat Hermes-style row list: hosted presets, local presets, then customs.
+  const rows: ProviderRowInfo[] = [];
+  const matchedIds = new Set<string>();
+  const orderedPresets = [
+    ...PROVIDER_PRESETS.filter((preset) => preset.kind === 'hosted'),
+    ...PROVIDER_PRESETS.filter((preset) => preset.kind === 'local'),
+  ];
+  for (const preset of orderedPresets) {
+    const profile = list.find((entry) => !matchedIds.has(entry.id) && providerPresetFor(entry)?.key === preset.key) ?? null;
+    if (profile) matchedIds.add(profile.id);
+    rows.push({
+      key: preset.key,
+      label: profile ? providerDisplayName(profile) : preset.label,
+      description: preset.description,
+      kind: preset.kind,
+      preset,
+      profile,
+    });
+  }
+  for (const profile of list) {
+    if (matchedIds.has(profile.id)) continue;
+    rows.push({
+      key: profile.id,
+      label: providerDisplayName(profile),
+      description: 'Custom OpenAI-compatible endpoint.',
+      kind: 'custom',
+      preset: null,
+      profile,
+    });
+  }
+
   const normalizedModelFilter = modelFilter.trim().toLowerCase();
-  const modelOptions = Array.from(new Set([
-    ...(selected?.models ?? []),
-    ...(selected?.available_models ?? []),
-    ...availableModels,
-  ]))
-    .filter((model) => !normalizedModelFilter || model.toLowerCase().includes(normalizedModelFilter))
-    .sort((a, b) => a.localeCompare(b));
 
   function settingsPayload(overrides?: Partial<AppSettings>): AppSettings {
     const nextList = overrides?.providers ?? list;
@@ -159,51 +194,55 @@ export function ProviderManager({
     };
   }
 
-  function updateSelected(patch: Partial<ProviderProfile>) {
-    setList((prev) => prev.map((profile) => (profile.id === selectedId ? { ...profile, ...patch } : profile)));
+  /** Materialize a draft profile for an unconfigured preset row on first edit. */
+  function ensureProfile(row: ProviderRowInfo): { nextList: ProviderProfile[]; profile: ProviderProfile } {
+    if (row.profile) return { nextList: list, profile: row.profile };
+    const preset = row.preset!;
+    const profile: ProviderProfile = {
+      ...preset.value,
+      models: [...preset.value.models],
+      preset_key: preset.key,
+      id: newProviderId(),
+    };
+    return { nextList: [...list, profile], profile };
   }
 
-  function toggleModel(model: string) {
-    if (!selected) return;
-    const next = enabledModels.has(model)
-      ? selected.models.filter((value) => value !== model)
-      : [...selected.models, model];
-    updateSelected({ models: next });
+  function patchProfile(row: ProviderRowInfo, patch: Partial<ProviderProfile>) {
+    const { nextList, profile } = ensureProfile(row);
+    setList(nextList.map((entry) => (entry.id === profile.id ? { ...entry, ...patch } : entry)));
   }
 
-  function addManualModel() {
-    const model = modelInput.trim();
-    if (!selected || !model) return;
-    if (!selected.models.includes(model)) {
-      updateSelected({ models: [...selected.models, model] });
-    }
+  function toggleExpanded(rowKey: string) {
+    setExpandedKey((prev) => (prev === rowKey ? null : rowKey));
     setModelInput('');
-    setMessage(`Added model ${model}`);
-  }
-
-  function addProvider(preset?: ProviderPreset) {
-    const profile: ProviderProfile = preset
-      ? { ...preset.value, models: [...preset.value.models], preset_key: preset.key, id: newProviderId() }
-      : emptyProvider();
-    setList((prev) => [...prev, profile]);
-    setSelectedId(profile.id);
-    setApiKeyInput('');
-    setModelInput('');
+    setModelFilter('');
     setAvailableModels([]);
-    setMessage(`Added ${providerDisplayName(profile)}`);
   }
 
-  function deleteProvider(id: string) {
+  function addCustomProvider() {
+    const profile = emptyProvider();
+    setList((prev) => [...prev, profile]);
+    setExpandedKey(profile.id);
+    setModelInput('');
+    setModelFilter('');
+    setAvailableModels([]);
+  }
+
+  function removeProfile(row: ProviderRowInfo) {
+    const id = row.profile?.id;
+    if (!id) return;
     setList((prev) => prev.filter((profile) => profile.id !== id));
     if (activeId === id) {
       setActiveId('');
       setActiveModelLocal('');
     }
-    if (selectedId === id) setSelectedId('');
+    if (expandedKey === row.key) setExpandedKey(null);
     setMessage('Provider removed (Save to apply)');
   }
 
-  function setAsActive(profile: ProviderProfile) {
+  function setAsActive(row: ProviderRowInfo) {
+    const profile = row.profile;
+    if (!profile) return;
     if (activeId === profile.id) {
       setActiveId('');
       setActiveModelLocal('');
@@ -217,7 +256,7 @@ export function ProviderManager({
     setBusy(true);
     try {
       const saved = await onPersist(settingsPayload());
-      setList(saved.providers);
+      setList(saved.providers.map(withPresetModels));
       setActiveId(saved.active_provider_id);
       setActiveModelLocal(saved.active_model || '');
       setMessage('Settings saved');
@@ -227,76 +266,306 @@ export function ProviderManager({
     }
   }
 
-  async function saveKey() {
-    if (!selected) return;
-    if (!apiKeyInput.trim()) {
+  async function saveKey(row: ProviderRowInfo) {
+    const token = (keyInputs[row.key] ?? '').trim();
+    if (!token) {
       setMessage('Enter an API key first');
       return;
     }
+    const { nextList, profile } = ensureProfile(row);
+    setList(nextList);
     setBusy(true);
     try {
-      await onPersist(settingsPayload());
-      const result = await window.vera.saveApiKey(selected.base_url, apiKeyInput.trim());
+      await onPersist(settingsPayload({ providers: nextList }));
+      const result = await window.vera.saveApiKey(profile.base_url, token);
       if (!result.ok) {
         setMessage(result.error || 'Unable to save API key');
         return;
       }
-      setApiKeyInput('');
+      setKeyInputs((prev) => ({ ...prev, [row.key]: '' }));
       const refreshed = await onRefresh();
-      setList(refreshed.providers);
-      setMessage('API key saved');
+      setList(refreshed.providers.map(withPresetModels));
+      setMessage(`${row.label} key saved`);
     } finally {
       setBusy(false);
     }
   }
 
-  async function clearKey() {
-    if (!selected) return;
+  async function clearKey(row: ProviderRowInfo) {
+    if (!row.profile) return;
     setBusy(true);
     try {
-      await window.vera.clearApiKey(selected.base_url);
+      await window.vera.clearApiKey(row.profile.base_url);
       const refreshed = await onRefresh();
-      setList(refreshed.providers);
+      setList(refreshed.providers.map(withPresetModels));
       setMessage('API key cleared');
     } finally {
       setBusy(false);
     }
   }
 
-  async function fetchModels() {
-    if (!selected) return;
-    if (!selected.base_url.trim()) {
+  async function saveHfToken() {
+    if (!hfTokenInput.trim()) {
+      setMessage('Enter a Hugging Face token first');
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await window.vera.saveHfToken(hfTokenInput.trim());
+      if (!result.ok) {
+        setMessage(result.error || 'Unable to save Hugging Face token');
+        return;
+      }
+      setHfTokenInput('');
+      const refreshed = await onRefresh();
+      setHfTokenStored(Boolean(refreshed.has_hf_token));
+      setMessage('Hugging Face token saved');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function clearHfToken() {
+    setBusy(true);
+    try {
+      const result = await window.vera.clearHfToken();
+      if (!result.ok) {
+        setMessage(result.error || 'Unable to clear Hugging Face token');
+        return;
+      }
+      setHfTokenInput('');
+      const refreshed = await onRefresh();
+      setHfTokenStored(Boolean(refreshed.has_hf_token));
+      setMessage(result.has_api_key
+        ? 'App token cleared; process environment still provides HF_TOKEN'
+        : 'Hugging Face token cleared');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function fetchModels(row: ProviderRowInfo) {
+    const { nextList, profile } = ensureProfile(row);
+    setList(nextList);
+    if (!profile.base_url.trim()) {
       setMessage('Set a base URL first');
       return;
     }
     setBusy(true);
-    setMessage('Fetching models…');
+    setMessage('Fetching modelsΓÇª');
     try {
       const llm: Record<string, unknown> = {
-        provider: selected.provider,
-        base_url: selected.base_url,
-        api_key_env: selected.api_key_env,
-        auth_type: selected.auth_type,
+        provider: profile.provider,
+        base_url: profile.base_url,
+        api_key_env: profile.api_key_env,
+        auth_type: profile.auth_type,
       };
       // Use the just-typed key if present so fetch works before saving.
-      if (apiKeyInput.trim()) llm.api_key = apiKeyInput.trim();
+      const typedKey = (keyInputs[row.key] ?? '').trim();
+      if (typedKey) llm.api_key = typedKey;
       const response = await window.vera.request<{ models: string[] }>({ action: 'list_models', llm });
       if (!response.ok) {
         setAvailableModels([]);
         setMessage(response.error || 'Unable to fetch models');
         return;
       }
-      const models = filterDiscoveredModels(selected, response.result?.models ?? []);
+      const models = filterDiscoveredModels(profile, response.result?.models ?? []);
       setAvailableModels(models);
-      updateSelected({
-        available_models: models,
-        models_refreshed_at: Date.now(),
-        models: selected.models.length === 0 ? defaultEnabledModels(selected, models) : selected.models,
-      });
+      setList((prev) => prev.map((entry) => (entry.id === profile.id
+        ? {
+          ...entry,
+          available_models: models,
+          models_refreshed_at: Date.now(),
+          models: entry.models.length === 0 ? defaultEnabledModels(entry, models) : entry.models,
+        }
+        : entry)));
       setMessage(models.length ? `Found ${models.length} models` : 'No models returned');
     } finally {
       setBusy(false);
     }
+  }
+
+  function renderModelsSection(row: ProviderRowInfo) {
+    const profile = row.profile;
+    const enabledModels = new Set(profile?.models ?? []);
+    const modelOptions = Array.from(new Set([
+      ...(profile?.models ?? []),
+      ...(profile?.available_models ?? []),
+      ...availableModels,
+    ]))
+      .filter((model) => !normalizedModelFilter || model.toLowerCase().includes(normalizedModelFilter))
+      .sort((a, b) => a.localeCompare(b));
+    const baseUrl = profile?.base_url ?? row.preset?.value.base_url ?? '';
+
+    return (
+      <div className="modelsSection">
+        <div className="modelsHead">
+          <span>Models <em>{profile?.models.length ?? 0} enabled</em></span>
+          <button type="button" className="secondaryAction compactAction" onClick={() => void fetchModels(row)} disabled={busy || !baseUrl.trim()}>
+            <ListChecks size={14} />Refresh models
+          </button>
+        </div>
+        {(profile?.available_models?.length || availableModels.length || profile?.models.length) ? (
+          <div className="modelManagerSearch">
+            <Search size={14} />
+            <input value={modelFilter} onChange={(event) => setModelFilter(event.target.value)} placeholder="Search models" />
+          </div>
+        ) : null}
+        {modelOptions.length ? (
+          <div className="modelChecklist">
+            {modelOptions.map((model) => (
+              <label className="modelCheck" key={model}>
+                <input
+                  type="checkbox"
+                  checked={enabledModels.has(model)}
+                  onChange={() => {
+                    const next = enabledModels.has(model)
+                      ? (profile?.models ?? []).filter((value) => value !== model)
+                      : [...(profile?.models ?? []), model];
+                    patchProfile(row, { models: next });
+                  }}
+                />
+                <span>{model}</span>
+              </label>
+            ))}
+          </div>
+        ) : (
+          <p className="mutedText">
+            {normalizedModelFilter
+              ? 'No matching models.'
+              : 'No models found yet. Refresh the provider or add a model ID.'}
+          </p>
+        )}
+        <div className="modelAddRow">
+          <input
+            value={modelInput}
+            onChange={(event) => setModelInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                const model = modelInput.trim();
+                if (!model) return;
+                if (!(profile?.models ?? []).includes(model)) {
+                  patchProfile(row, { models: [...(profile?.models ?? []), model] });
+                }
+                setModelInput('');
+                setMessage(`Added model ${model}`);
+              }
+            }}
+            placeholder="Add model id manually (e.g. gpt-4o-mini)"
+          />
+          <button
+            type="button"
+            className="secondaryAction compactAction"
+            onClick={() => {
+              const model = modelInput.trim();
+              if (!model) return;
+              if (!(profile?.models ?? []).includes(model)) {
+                patchProfile(row, { models: [...(profile?.models ?? []), model] });
+              }
+              setModelInput('');
+              setMessage(`Added model ${model}`);
+            }}
+            disabled={!modelInput.trim()}
+          >
+            <Plus size={14} />Add
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  function renderExpandedBody(row: ProviderRowInfo) {
+    const profile = row.profile;
+    const preset = row.preset;
+    const hasKey = Boolean(profile?.has_api_key);
+
+    return (
+      <div className="providerItemBody">
+        <p className="providerItemDescription">{row.description}</p>
+
+        {row.kind === 'local' ? (
+          <label className="field">
+            <span>Server URL</span>
+            <input
+              value={profile?.base_url ?? preset?.value.base_url ?? ''}
+              onChange={(event) => patchProfile(row, { base_url: event.target.value })}
+              placeholder={preset?.value.base_url}
+            />
+          </label>
+        ) : null}
+
+        {row.kind === 'hosted' ? (
+          <label className="field">
+            <span>Base URL override</span>
+            <input
+              value={profile?.base_url ?? preset?.value.base_url ?? ''}
+              onChange={(event) => patchProfile(row, { base_url: event.target.value })}
+              placeholder={preset?.value.base_url}
+            />
+          </label>
+        ) : null}
+
+        {row.kind === 'custom' && profile ? (
+          <div className="editorGrid">
+            <label className="field">
+              <span>Display Name</span>
+              <input value={profile.label} onChange={(event) => patchProfile(row, { label: event.target.value })} placeholder="My Provider" />
+            </label>
+            <label className="field">
+              <span>Type</span>
+              <select value={profile.provider} onChange={(event) => patchProfile(row, { provider: event.target.value })}>
+                <option value="openai_compatible">OpenAI Compatible</option>
+                <option value="ollama">Ollama</option>
+                <option value="lmstudio">LM Studio</option>
+              </select>
+            </label>
+            <label className="field wideField">
+              <span>Base URL</span>
+              <input value={profile.base_url} onChange={(event) => patchProfile(row, { base_url: event.target.value })} placeholder="https://api.example.com/v1" />
+            </label>
+            <label className="field">
+              <span>Authentication</span>
+              <select value={profile.auth_type} onChange={(event) => patchProfile(row, { auth_type: event.target.value })}>
+                <option value="none">None</option>
+                <option value="api_key">API Key</option>
+                <option value="env">Environment variable</option>
+              </select>
+            </label>
+            <label className="field">
+              <span>API environment variable</span>
+              <input value={profile.api_key_env} onChange={(event) => patchProfile(row, { api_key_env: event.target.value })} placeholder="PROVIDER_API_KEY" />
+            </label>
+            <label className="field">
+              <span>Temperature</span>
+              <input className="numberInput" type="number" min={0} max={2} step={0.1} value={profile.temperature} onChange={(event) => patchProfile(row, { temperature: Number(event.target.value) })} />
+            </label>
+          </div>
+        ) : null}
+
+        {renderModelsSection(row)}
+
+        <div className="editorActions">
+          <button
+            className={profile && profile.id === activeId ? 'secondaryAction activeNow' : 'secondaryAction'}
+            onClick={() => setAsActive(row)}
+            disabled={busy || !profile || profile.models.length === 0}
+          >
+            <CheckCircle2 size={16} />{profile && profile.id === activeId ? 'Active provider' : 'Set as active'}
+          </button>
+          {hasKey ? (
+            <button className="secondaryAction" onClick={() => void clearKey(row)} disabled={busy}>
+              <Trash2 size={16} />Clear key
+            </button>
+          ) : null}
+          {profile ? (
+            <button className="secondaryAction danger" onClick={() => removeProfile(row)} disabled={busy}>
+              <Trash2 size={16} />Remove
+            </button>
+          ) : null}
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -307,180 +576,114 @@ export function ProviderManager({
           <button className="iconAction" onClick={onClose} aria-label="Close"><X size={18} /></button>
         </header>
 
-        <div className="providerLayout">
-          <aside className="providerList">
-            <div className="providerListHead">
-              <span>Providers</span>
-              <button className="secondaryAction compactAction" onClick={() => addProvider()} disabled={busy}><Plus size={14} />Custom</button>
-            </div>
-            {list.length === 0 ? <p className="mutedText">No providers configured yet.</p> : null}
-            {list.map((profile) => (
-              <button
-                key={profile.id}
-                type="button"
-                className={profile.id === selectedId ? 'providerRow selected' : 'providerRow'}
-                onClick={() => { setSelectedId(profile.id); setApiKeyInput(''); setModelInput(''); setModelFilter(''); setAvailableModels([]); }}
-              >
-                <span className="providerRowName">
-                  {providerDisplayName(profile)}
-                  {profile.id === activeId ? <em className="activeTag">Active</em> : null}
-                </span>
-                <small>{providerTypeLabel(profile.provider)} · {profile.models.length} model{profile.models.length === 1 ? '' : 's'}</small>
-              </button>
-            ))}
-            <div className="presetRow">
-              <span>Add provider</span>
-              <div className="presetButtons">
-                {PROVIDER_PRESETS.map((preset) => (
-                  <button key={preset.key} type="button" className="secondaryAction compactAction" onClick={() => addProvider(preset)} disabled={busy}>{preset.label}</button>
-                ))}
-              </div>
-            </div>
-          </aside>
-
-          <section className="providerEditor">
-            {selected ? (
-              <>
-                <div className="providerEditorIntro">
-                  <div>
-                    <h3>{providerDisplayName(selected)}</h3>
-                    <p>{selectedPreset?.description ?? 'Connect any service with an OpenAI-compatible API.'}</p>
+        <div className="providerStack">
+          {rows.map((row) => {
+            const profile = row.profile;
+            const expanded = expandedKey === row.key;
+            const authType = profile?.auth_type ?? row.preset?.value.auth_type ?? 'none';
+            const hasKey = Boolean(profile?.has_api_key);
+            const keyValue = keyInputs[row.key] ?? '';
+            const configured = Boolean(profile && (profile.models.length || hasKey));
+            return (
+              <section key={row.key} className={expanded ? 'providerItem expanded' : 'providerItem'}>
+                <div className="providerItemHead">
+                  <button type="button" className="providerItemToggle" onClick={() => toggleExpanded(row.key)}>
+                    <span className={configured ? 'providerDot configured' : 'providerDot'} />
+                    <span className="providerItemName">{row.label}</span>
+                    {profile && profile.id === activeId ? <em className="activeTag">Active</em> : null}
+                    {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                  </button>
+                  <div className="providerItemSide">
+                    {authType === 'api_key' ? (
+                      hasKey && !keyValue ? (
+                        <span className="connectedTag"><CheckCircle2 size={13} />Key saved</span>
+                      ) : (
+                        <div className="providerKeyInline">
+                          <input
+                            type="password"
+                            value={keyValue}
+                            onChange={(event) => setKeyInputs((prev) => ({ ...prev, [row.key]: event.target.value }))}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter') {
+                                event.preventDefault();
+                                void saveKey(row);
+                              }
+                            }}
+                            placeholder={`Paste ${row.label} key`}
+                            autoComplete="off"
+                            disabled={busy}
+                          />
+                          {keyValue.trim() ? (
+                            <button type="button" className="secondaryAction compactAction" onClick={() => void saveKey(row)} disabled={busy}>
+                              <KeyRound size={13} />Save
+                            </button>
+                          ) : null}
+                        </div>
+                      )
+                    ) : (
+                      <span className="providerItemHint">{profile?.base_url || row.preset?.value.base_url || ''}</span>
+                    )}
                   </div>
-                  {selected.has_api_key ? <span className="connectedTag"><CheckCircle2 size={13} />Key saved</span> : null}
                 </div>
+                {expanded ? renderExpandedBody(row) : null}
+              </section>
+            );
+          })}
 
-                {selected.auth_type === 'api_key' ? <div className="apiKeyRow">
-                  <label className="field apiKeyField">
-                    <span>API Key</span>
-                    <input type="password" value={apiKeyInput} onChange={(event) => setApiKeyInput(event.target.value)} placeholder={selected.has_api_key ? '•••••••• stored securely' : `Paste ${providerDisplayName(selected)} key`} />
-                  </label>
-                  <button className="secondaryAction" onClick={saveKey} disabled={busy || !apiKeyInput.trim()}><KeyRound size={16} />Save Key</button>
-                  <button className="secondaryAction" onClick={clearKey} disabled={busy || !selected.has_api_key}><Trash2 size={16} />Clear</button>
-                </div> : null}
+          <button type="button" className="providerAddCustom" onClick={addCustomProvider} disabled={busy}>
+            <Plus size={14} />Local / custom endpoint
+            <small>Point VERA at any OpenAI-compatible endpoint (vLLM, llama.cpp, etc.)</small>
+          </button>
 
-                {selectedPreset?.kind === 'local' ? (
-                  <label className="field">
-                    <span>Server URL</span>
-                    <input value={selected.base_url} onChange={(event) => updateSelected({ base_url: event.target.value })} placeholder={selectedPreset.value.base_url} />
-                  </label>
-                ) : null}
-
-                <div className="modelsSection">
-                  <div className="modelsHead">
-                    <span>Models <em>{selected.models.length} enabled</em></span>
-                    <button type="button" className="secondaryAction compactAction" onClick={fetchModels} disabled={busy || !selected.base_url.trim()}><ListChecks size={14} />Refresh models</button>
-                  </div>
-                  {(selected.available_models?.length || availableModels.length || selected.models.length) ? (
-                    <div className="modelManagerSearch">
-                      <Search size={14} />
-                      <input value={modelFilter} onChange={(event) => setModelFilter(event.target.value)} placeholder="Search models" />
-                    </div>
-                  ) : null}
-                  {modelOptions.length ? (
-                    <div className="modelChecklist">
-                      {modelOptions.map((model) => (
-                        <label className="modelCheck" key={model}>
-                          <input type="checkbox" checked={enabledModels.has(model)} onChange={() => toggleModel(model)} />
-                          <span>{model}</span>
-                        </label>
-                      ))}
-                    </div>
-                  ) : (
-                    <p className="mutedText">
-                      {normalizedModelFilter
-                        ? 'No matching models.'
-                        : 'No models found yet. Refresh the provider or add a model ID.'}
-                    </p>
-                  )}
-                  <div className="modelAddRow">
+          <section className={expandedKey === '__hf__' ? 'providerItem expanded' : 'providerItem'}>
+            <div className="providerItemHead">
+              <button type="button" className="providerItemToggle" onClick={() => toggleExpanded('__hf__')}>
+                <span className={hfTokenStored ? 'providerDot configured' : 'providerDot'} />
+                <span className="providerItemName">Hugging Face</span>
+                {expandedKey === '__hf__' ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+              </button>
+              <div className="providerItemSide">
+                {hfTokenStored && !hfTokenInput ? (
+                  <span className="connectedTag"><CheckCircle2 size={13} />Token saved</span>
+                ) : (
+                  <div className="providerKeyInline">
                     <input
-                      value={modelInput}
-                      onChange={(event) => setModelInput(event.target.value)}
+                      type="password"
+                      value={hfTokenInput}
+                      onChange={(event) => setHfTokenInput(event.target.value)}
                       onKeyDown={(event) => {
                         if (event.key === 'Enter') {
                           event.preventDefault();
-                          addManualModel();
+                          void saveHfToken();
                         }
                       }}
-                      placeholder="Add model id manually (e.g. gpt-4o-mini)"
+                      placeholder="Paste Hugging Face token"
+                      autoComplete="off"
+                      disabled={busy}
                     />
-                    <button type="button" className="secondaryAction compactAction" onClick={addManualModel} disabled={!modelInput.trim()}><Plus size={14} />Add</button>
-                  </div>
-                </div>
-
-                {selectedPreset ? (
-                  <details className="providerAdvanced">
-                    <summary>Advanced</summary>
-                    <div className="editorGrid">
-                      <label className="field">
-                        <span>Display Name</span>
-                        <input value={selected.label} onChange={(event) => updateSelected({ label: event.target.value })} />
-                      </label>
-                      {selectedPreset.kind === 'hosted' ? (
-                        <label className="field">
-                          <span>Base URL override</span>
-                          <input value={selected.base_url} onChange={(event) => updateSelected({ base_url: event.target.value })} placeholder={selectedPreset.value.base_url} />
-                        </label>
-                      ) : null}
-                      <label className="field">
-                        <span>Temperature</span>
-                        <input className="numberInput" type="number" min={0} max={2} step={0.1} value={selected.temperature} onChange={(event) => updateSelected({ temperature: Number(event.target.value) })} />
-                      </label>
-                    </div>
-                  </details>
-                ) : (
-                  <div className="customProviderFields">
-                    <div className="editorGrid">
-                      <label className="field">
-                        <span>Display Name</span>
-                        <input value={selected.label} onChange={(event) => updateSelected({ label: event.target.value })} placeholder="My Provider" />
-                      </label>
-                      <label className="field">
-                        <span>Type</span>
-                        <select value={selected.provider} onChange={(event) => updateSelected({ provider: event.target.value })}>
-                          <option value="openai_compatible">OpenAI Compatible</option>
-                          <option value="ollama">Ollama</option>
-                          <option value="lmstudio">LM Studio</option>
-                        </select>
-                      </label>
-                      <label className="field wideField">
-                        <span>Base URL</span>
-                        <input value={selected.base_url} onChange={(event) => updateSelected({ base_url: event.target.value })} placeholder="https://api.example.com/v1" />
-                      </label>
-                      <label className="field">
-                        <span>Authentication</span>
-                        <select value={selected.auth_type} onChange={(event) => updateSelected({ auth_type: event.target.value })}>
-                          <option value="none">None</option>
-                          <option value="api_key">API Key</option>
-                          <option value="env">Environment variable</option>
-                        </select>
-                      </label>
-                      <label className="field">
-                        <span>API environment variable</span>
-                        <input value={selected.api_key_env} onChange={(event) => updateSelected({ api_key_env: event.target.value })} placeholder="PROVIDER_API_KEY" />
-                      </label>
-                      <label className="field">
-                        <span>Temperature</span>
-                        <input className="numberInput" type="number" min={0} max={2} step={0.1} value={selected.temperature} onChange={(event) => updateSelected({ temperature: Number(event.target.value) })} />
-                      </label>
-                    </div>
+                    {hfTokenInput.trim() ? (
+                      <button type="button" className="secondaryAction compactAction" onClick={() => void saveHfToken()} disabled={busy}>
+                        <KeyRound size={13} />Save
+                      </button>
+                    ) : null}
                   </div>
                 )}
-
+              </div>
+            </div>
+            {expandedKey === '__hf__' ? (
+              <div className="providerItemBody">
+                <p className="providerItemDescription">
+                  Optional token for Docling layout models and other Hub downloads. Stored securely
+                  like provider API keys and passed to the sidecar as <code>HF_TOKEN</code>. Get one
+                  at huggingface.co/settings/tokens.
+                </p>
                 <div className="editorActions">
-                  <button
-                    className={selected.id === activeId ? 'secondaryAction activeNow' : 'secondaryAction'}
-                    onClick={() => setAsActive(selected)}
-                    disabled={busy || selected.models.length === 0}
-                  >
-                    <CheckCircle2 size={16} />{selected.id === activeId ? 'Active provider' : 'Set as active'}
+                  <button className="secondaryAction" onClick={() => void clearHfToken()} disabled={busy || !hfTokenStored}>
+                    <Trash2 size={16} />Clear token
                   </button>
-                  <button className="secondaryAction danger" onClick={() => deleteProvider(selected.id)} disabled={busy}><Trash2 size={16} />Delete</button>
                 </div>
-              </>
-            ) : (
-              <div className="emptyState"><Pencil size={20} />Select a provider to edit, or add a new one.</div>
-            )}
+              </div>
+            ) : null}
           </section>
         </div>
 

--- a/packages/vera-app/src/renderer/main.tsx
+++ b/packages/vera-app/src/renderer/main.tsx
@@ -183,6 +183,7 @@ function App() {
   const [activeModel, setActiveModel] = useState('');
   const [modes, setModes] = useState<Mode[]>([]);
   const [activeModeId, setActiveModeId] = useState('');
+  const [hasHfToken, setHasHfToken] = useState(false);
   const [modePickerOpen, setModePickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
@@ -1531,6 +1532,7 @@ function App() {
     setActiveProviderId(saved.active_provider_id);
     setActiveModel(saved.active_model || '');
     setActiveModeId(saved.active_mode_id || '');
+    setHasHfToken(Boolean(saved.has_hf_token));
     return saved;
   }
 
@@ -1540,6 +1542,7 @@ function App() {
     setActiveProviderId(saved.active_provider_id);
     setActiveModel(saved.active_model || '');
     setActiveModeId(saved.active_mode_id || '');
+    setHasHfToken(Boolean(saved.has_hf_token));
     return saved;
   }
 
@@ -2039,6 +2042,7 @@ function App() {
       setActiveProviderId(saved.active_provider_id);
       setActiveModel(saved.active_model || '');
       setActiveModeId(saved.active_mode_id || '');
+      setHasHfToken(Boolean(saved.has_hf_token));
     }
     async function loadSessions() {
       const saved = await window.vera.getSessions();
@@ -3663,6 +3667,7 @@ function App() {
           activeProviderId={activeProviderId}
           activeModel={activeModel}
           activeModeId={activeModeId}
+          hasHfToken={hasHfToken}
           onPersist={persistSettings}
           onRefresh={refreshSettings}
           onClose={() => setSettingsOpen(false)}

--- a/packages/vera-app/src/renderer/styles.css
+++ b/packages/vera-app/src/renderer/styles.css
@@ -3957,7 +3957,7 @@ input.viewerPageInput:focus {
 }
 
 .providerModal {
-  width: min(960px, 100%);
+  width: min(720px, 100%);
   max-height: min(700px, 92vh);
 }
 
@@ -4130,67 +4130,138 @@ input.viewerPageInput:focus {
   background: var(--bg-surface-3);
 }
 
-.providerLayout {
-  display: grid;
-  grid-template-columns: 252px 1fr;
-  min-height: 0;
+.providerStack {
   flex: 1;
-}
-
-.providerList {
+  min-height: 0;
+  overflow: auto;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 14px;
-  border-right: 1px solid var(--border);
-  overflow: auto;
+  padding: 6px 18px 14px;
 }
 
-.providerListHead {
+.providerItem {
+  border-bottom: 1px solid var(--border-faint);
+}
+
+.providerItem.expanded {
+  margin: 4px -6px;
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.providerItemHead {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 11.5px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+  gap: 16px;
+  min-height: 52px;
+  padding: 6px 6px;
 }
 
-.providerRow {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 3px;
-  padding: 9px 11px;
-  background: var(--bg-surface-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  text-align: left;
-  transition: border-color 0.12s, background 0.12s;
+.providerItem.expanded .providerItemHead {
+  padding: 6px 12px;
 }
 
-.providerRow:hover {
-  border-color: var(--border-strong);
-}
-
-.providerRow.selected {
-  background: var(--accent-soft);
-  border-color: var(--accent-soft-border);
-}
-
-.providerRowName {
+.providerItemToggle {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
-  font-size: 13px;
+  gap: 9px;
+  flex: 1;
+  min-width: 0;
+  padding: 6px 2px;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--text-faint);
+  text-align: left;
+}
+
+.providerItemName {
+  font-size: 13.5px;
   font-weight: 650;
   color: var(--text-strong);
 }
 
-.providerRow small {
-  font-size: 11.5px;
+.providerDot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--border-strong);
+}
+
+.providerDot.configured {
+  background: var(--good);
+}
+
+.providerItemSide {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: none;
+}
+
+.providerItemHint {
+  font-size: 12px;
+  color: var(--text-faint);
+}
+
+.providerKeyInline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.providerKeyInline input {
+  width: 230px;
+  height: 30px;
+  font-size: 12.5px;
+}
+
+.providerItemBody {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 2px 12px 14px;
+}
+
+.providerItemDescription {
+  margin: 0;
+  font-size: 12.5px;
   color: var(--text-muted);
+}
+
+.providerItemDescription code {
+  font-size: 11.5px;
+}
+
+.providerAddCustom {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 10px 0 6px;
+  padding: 10px 12px;
+  background: transparent;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius);
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+}
+
+.providerAddCustom:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.providerAddCustom small {
+  font-weight: 400;
+  font-size: 11.5px;
+  color: var(--text-faint);
 }
 
 .activeTag {
@@ -4203,56 +4274,6 @@ input.viewerPageInput:focus {
   background: var(--good-soft);
   padding: 1px 6px;
   border-radius: 999px;
-}
-
-.presetRow {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-top: 6px;
-  padding-top: 12px;
-  border-top: 1px solid var(--border);
-}
-
-.presetRow > span {
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-
-.presetButtons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.providerEditor {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 16px 18px;
-  overflow: auto;
-}
-
-.providerEditorIntro {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.providerEditorIntro h3 {
-  margin: 0 0 4px;
-  font-size: 17px;
-  color: var(--text-strong);
-}
-
-.providerEditorIntro p {
-  margin: 0;
-  font-size: 13px;
-  color: var(--text-muted);
 }
 
 .connectedTag {
@@ -4278,16 +4299,6 @@ input.viewerPageInput:focus {
   grid-column: 1 / -1;
 }
 
-.apiKeyRow {
-  display: flex;
-  align-items: end;
-  gap: 10px;
-}
-
-.apiKeyRow .apiKeyField {
-  flex: 1;
-}
-
 .modelsSection {
   display: flex;
   flex-direction: column;
@@ -4296,6 +4307,10 @@ input.viewerPageInput:focus {
   background: var(--bg-surface-2);
   border: 1px solid var(--border);
   border-radius: var(--radius);
+}
+
+.providerItem.expanded .modelsSection {
+  background: var(--bg-surface);
 }
 
 .modelsHead {
@@ -4365,27 +4380,6 @@ input.viewerPageInput:focus {
 .modelAddRow input {
   flex: 1;
   min-width: 0;
-}
-
-.providerAdvanced {
-  border-top: 1px solid var(--border);
-  padding-top: 12px;
-}
-
-.providerAdvanced summary {
-  width: fit-content;
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 650;
-  color: var(--text-muted);
-}
-
-.providerAdvanced[open] summary {
-  margin-bottom: 12px;
-}
-
-.customProviderFields {
-  padding-top: 2px;
 }
 
 .editorActions {

--- a/packages/vera-app/src/renderer/types.ts
+++ b/packages/vera-app/src/renderer/types.ts
@@ -45,6 +45,8 @@ export interface VeraApi {
   saveSettings(settings: AppSettings): Promise<AppSettings>;
   saveApiKey(providerId: string, apiKey: string): Promise<CredentialResult>;
   clearApiKey(providerId: string): Promise<CredentialResult>;
+  saveHfToken(token: string): Promise<CredentialResult>;
+  clearHfToken(): Promise<CredentialResult>;
   getSessions(): Promise<Session[]>;
   saveSession(session: Session): Promise<Session[]>;
   deleteSession(id: string): Promise<Session[]>;

--- a/packages/vera-app/src/shared/contracts.ts
+++ b/packages/vera-app/src/shared/contracts.ts
@@ -149,6 +149,12 @@ export interface AppSettings {
   active_provider_id: string;
   active_model: string;
   active_mode_id: string;
+  /**
+   * Runtime-only: true when a Hugging Face token is available from secure
+   * storage or the process environment (`HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN`).
+   * Not persisted in settings.json.
+   */
+  has_hf_token?: boolean;
 }
 
 export interface CredentialResult {

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -159,6 +159,9 @@ def test_hardening_json_contracts_are_documented():
     assert "Token-level `answer_delta`" in desktop_architecture
     assert "PyMuPDF parser" in desktop
     assert "local hashing embeddings" in desktop
+    assert "Hugging Face" in desktop
+    assert "HF_TOKEN" in desktop
+    assert "Hugging Face" in (DOCS / "packages" / "vera-app.md").read_text(encoding="utf-8")
     assert "`attachment_metadata()`" in python_api
     assert "do not contain a `data` field" in python_api
     assert "allow_empty=True" in libraries


### PR DESCRIPTION
﻿## Summary
- Redesign **File > LLM Providers** as a Hermes-style flat list with inline API key fields and accordion details for models/advanced options.
- Store an optional Hugging Face token in Electron secure storage and inject it into the sidecar as `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` (sidecar restarts on save/clear).
- Add `.env.example` for CLI/dev Hub auth and document the Settings + env paths.

## Test plan
- [ ] Open **File > LLM Providers** — presets appear as rows with inline key fields
- [ ] Paste/save an OpenAI (or other) key; confirm Key saved and Ask still works
- [ ] Expand a provider, refresh models, enable a model, set active
- [ ] Save an HF token; confirm sidecar restart and Hub downloads no longer warn about unauthenticated requests
- [ ] Clear HF token; confirm env fallback still reported if HF_TOKEN is set in the process environment
- [ ] `npm --prefix packages/vera-app run typecheck` and `test:unit`
- [ ] After merge to main, merge this into v0.3 so both branches share the UI
