### PR TITLE
feat: expand only the active library in Explorer

### DIFF
--- a/packages/vera-app/src/renderer/lib/explorer.test.ts
+++ b/packages/vera-app/src/renderer/lib/explorer.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { collapsedFoldersForActiveLibrary } from './explorer';
+
+describe('collapsedFoldersForActiveLibrary', () => {
+  it('collapses every folder when none is active', () => {
+    expect(collapsedFoldersForActiveLibrary(['/a', '/b'], '')).toEqual(['/a', '/b']);
+  });
+
+  it('keeps the active library expanded and collapses the rest', () => {
+    expect(collapsedFoldersForActiveLibrary(['/a', '/b', '/c'], '/b')).toEqual(['/a', '/c']);
+  });
+
+  it('expands a lone active library', () => {
+    expect(collapsedFoldersForActiveLibrary(['/only'], '/only')).toEqual([]);
+  });
+});

--- a/packages/vera-app/src/renderer/lib/explorer.ts
+++ b/packages/vera-app/src/renderer/lib/explorer.ts
@@ -1,0 +1,8 @@
+/** Paths that should start collapsed so only the active library's files show. */
+export function collapsedFoldersForActiveLibrary(
+  folderPaths: string[],
+  activeLibraryPath: string,
+): string[] {
+  const active = activeLibraryPath.trim();
+  return folderPaths.filter((folderPath) => folderPath !== active);
+}

--- a/packages/vera-app/src/renderer/main.tsx
+++ b/packages/vera-app/src/renderer/main.tsx
@@ -57,6 +57,7 @@ import {
   type ExplorerSelection,
 } from './lib/formatting';
 import { figureCacheKey, mergeFigureData, sameSearchResult } from './lib/figures';
+import { collapsedFoldersForActiveLibrary } from './lib/explorer';
 import { defaultEnabledModels, filterDiscoveredModels, providerDisplayName, REASONING_EFFORTS, reasoningEffortLabel } from './lib/providers';
 import type { AppSettings, BatchConvertResult, ChatAnswerResult, ChatAttachment, ChatCitationResult, ExportResult, FigureResult, FolderEntry, InspectResult, LibraryIndexBuildReport, LibraryIndexStatus, Mode, PageResult, ProviderProfile, SearchResult, Session, SessionTurn, StreamEvent, SourceDocumentResult, ValidateResult, WorkspaceFolderResult } from './types';
 import './styles.css';
@@ -2023,6 +2024,13 @@ function App() {
     const folderPaths = folderPathsKey ? folderPathsKey.split('\n') : [];
     void window.vera.setWatchedFolders(folderPaths);
   }, [folderPathsKey]);
+
+  // Keep folder headers scannable: expand the active library, collapse the rest.
+  // Manual caret toggles still work until the active library or folder set changes.
+  useEffect(() => {
+    const folderPaths = folderPathsKey ? folderPathsKey.split('\n') : [];
+    setCollapsedFolders(collapsedFoldersForActiveLibrary(folderPaths, activeLibraryPath));
+  }, [folderPathsKey, activeLibraryPath]);
 
   useEffect(() => window.vera.onFolderChanged((folderPath) => {
     dismissedIndexStates.current.delete(folderPath);


### PR DESCRIPTION
﻿## Summary
- On launch and whenever the active library or folder list changes, expand only the active library and collapse the others so all folder headers stay visible.
- Manual caret toggles still work until the next active-library or folder-set change.
- Same change as #8 (opened against main); this PR targets v0.3 so the branch can pick it up.

## Test plan
- [ ] Launch with multiple libraries and a saved active library — only the active one is expanded
- [ ] Switch active library — previous collapses, new one expands
- [ ] Manually expand a second folder, then switch active library — inactive folders collapse again
- [ ] npm --prefix packages/vera-app run test:unit
