### PR TITLE
Collapse Convert pipeline options under Advanced

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -257,7 +257,8 @@ First Docling conversion may download model artifacts. Set
 bundle Docling; source-run apps can select installed pipelines in the Convert
 view. The Convert UI is schema-driven: the sidecar
 `describe_ingest_pipelines` action supplies descriptors, and
-`PipelineConfigForm` renders only the fields each pipeline advertises.
+`PipelineConfigForm` renders only the fields each pipeline advertises under a
+collapsed **Advanced pipeline options** section.
 
 ## Storing the source PDF
 

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -216,7 +216,8 @@ message. Sidecar `convert` and `batch_convert` requests accept optional
 `ocr_language`, and `ocr_dpi` fields. Descriptor fields determine which legacy
 aliases are forwarded; explicit `pipeline_options` win. The Convert UI loads
 descriptors through `describe_ingest_pipelines` and renders them with
-`PipelineConfigForm`. `batch_convert` also accepts an explicit `paths` list of
+`PipelineConfigForm` inside a collapsed **Advanced pipeline options** section.
+`batch_convert` also accepts an explicit `paths` list of
 PDF files; when present, directory discovery is skipped. The sidecar continues
 after per-file failures and returns converted, skipped, malformed, and failed
 counts plus individual diagnostics. During multi-file conversion the UI shows

--- a/docs/desktop-app-getting-started.md
+++ b/docs/desktop-app-getting-started.md
@@ -57,8 +57,9 @@ offline `hashing` embedder. The Convert view exposes dropdowns for
 presets such as `sentence-transformers:all-MiniLM-L6-v2`, plus a custom
 `provider:model-id` field. Chunking and OCR controls are schema-driven: the
 sidecar `describe_ingest_pipelines` action supplies descriptors, and
-`PipelineConfigForm` renders only advertised fields (PyMuPDF includes overlap
-and OCR DPI; Docling does not). These settings are independent of the Chat
+`PipelineConfigForm` renders only advertised fields under a collapsed
+**Advanced pipeline options** section (PyMuPDF includes overlap and OCR DPI;
+Docling does not). These settings are independent of the Chat
 model and are persisted in app settings. `npm run app:dev` installs the `app`,
 `ml`, and `docling` extras into the workspace environment so both plugins are
 available for GUI testing. Packaged releases do not bundle optional ingest

--- a/docs/packages/vera-app.md
+++ b/docs/packages/vera-app.md
@@ -16,9 +16,9 @@ Download `VERA Setup <version>.exe` from the
 
 ## First workflow
 
-1. Open **Convert PDF** and convert selected PDFs or a directory. Pipeline
-   settings are schema-driven from `describe_ingest_pipelines` /
-   `PipelineConfigForm`.
+1. Open **Convert PDF** and convert selected PDFs or a directory. Expand
+   **Advanced pipeline options** for schema-driven settings from
+   `describe_ingest_pipelines` / `PipelineConfigForm`.
 2. Use **File > Open Folder** to activate a document library.
 3. Open **Search** for fully local hybrid retrieval.
 4. To use **Ask**, configure a provider under **File > LLM Providers**.

--- a/packages/vera-app/src/renderer/main.tsx
+++ b/packages/vera-app/src/renderer/main.tsx
@@ -2785,16 +2785,24 @@ function App() {
                       : <>Sentence Transformers is not installed. From the repo root run <code>uv sync --extra ml</code> and restart the app.</>}
                     {' '}Custom specs are saved when the field loses focus.
                   </p>
-                  <PipelineConfigForm
-                    descriptor={activePipelineDescriptor}
-                    values={pipelineOptions}
-                    disabled={conversionInProgress}
-                    onChange={(next) => { void savePipelineOptions(next); }}
-                  />
                   <label className="miniCheck">
                     <input type="checkbox" checked={storeOriginal} onChange={(event) => setStoreOriginal(event.target.checked)} />
                     <span>Store original PDF</span>
                   </label>
+                  <details className="convertAdvanced">
+                    <summary>Advanced pipeline options</summary>
+                    <p className="sideMuted">
+                      Controls advertised by the selected ingest pipeline descriptor
+                      {activePipelineDescriptor?.spec ? ` (${activePipelineDescriptor.spec})` : ''}.
+                      Defaults apply until you change them.
+                    </p>
+                    <PipelineConfigForm
+                      descriptor={activePipelineDescriptor}
+                      values={pipelineOptions}
+                      disabled={conversionInProgress}
+                      onChange={(next) => { void savePipelineOptions(next); }}
+                    />
+                  </details>
                   <div className="convertActions">
                     <button
                       className="sidePrimary"

--- a/packages/vera-app/src/renderer/styles.css
+++ b/packages/vera-app/src/renderer/styles.css
@@ -1162,6 +1162,44 @@ select option {
   gap: 10px;
 }
 
+.convertAdvanced {
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+  display: grid;
+  gap: 10px;
+}
+
+.convertAdvanced > summary {
+  width: fit-content;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--text-muted);
+  list-style: none;
+}
+
+.convertAdvanced > summary::-webkit-details-marker {
+  display: none;
+}
+
+.convertAdvanced > summary::after {
+  content: ' ▸';
+  font-size: 11px;
+}
+
+.convertAdvanced[open] > summary::after {
+  content: ' ▾';
+}
+
+.convertAdvanced[open] > summary {
+  margin-bottom: 2px;
+}
+
+.convertAdvanced .pipelineConfigForm {
+  display: grid;
+  gap: 10px;
+}
+
 .convertActions {
   display: flex;
   gap: 8px;

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -154,6 +154,7 @@ def test_hardening_json_contracts_are_documented():
     assert "IngestRequest" in conversion
     assert "describe_ingest_pipelines" in conversion
     assert "PipelineConfigForm" in conversion
+    assert "Advanced pipeline options" in conversion
     assert "compatibility alias" in conversion.lower() or "Compatibility aliases" in conversion
     assert "ocr_language=en" in conversion
     assert "overlap" in conversion and "ocr_dpi" in conversion
@@ -184,11 +185,13 @@ def test_hardening_json_contracts_are_documented():
     assert "loads image previews" in desktop
     assert "describe_ingest_pipelines" in desktop
     assert "PipelineConfigForm" in desktop
+    assert "Advanced pipeline options" in desktop
     assert "only explicit `search_start` and `search_done`" in desktop_architecture
     assert "Token-level `answer_delta`" in desktop_architecture
     assert "describe_ingest_pipelines" in desktop_architecture
     assert "pipeline_options" in desktop_architecture
     assert "PipelineConfigForm" in desktop_architecture
+    assert "Advanced pipeline options" in desktop_architecture
     assert "PyMuPDF ingest pipeline" in desktop
     assert "ingest_pipeline" in desktop
     assert "vera-ingest-docling" in conversion or "docling:hybrid" in conversion
@@ -196,6 +199,7 @@ def test_hardening_json_contracts_are_documented():
     assert "Hugging Face" in desktop
     assert "HF_TOKEN" in desktop
     assert "Hugging Face" in (DOCS / "packages" / "vera-app.md").read_text(encoding="utf-8")
+    assert "Advanced pipeline options" in (DOCS / "packages" / "vera-app.md").read_text(encoding="utf-8")
     assert "`attachment_metadata()`" in python_api
     assert "do not contain a `data` field" in python_api
     assert "pipeline_options" in python_api


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Move schema-driven convert pipeline settings behind a collapsed **Advanced pipeline options** section so the default Convert view stays focused on pipeline, embedding, and store-original.

## Details

- Fields still come from sidecar `describe_ingest_pipelines` descriptors via `PipelineConfigForm` (not hardcoded React).
- Expanded section shows only the selected pipeline’s advertised controls (e.g. PyMuPDF overlap/DPI; Docling token chunk size / RapidOCR).
- Docs and documentation-contract tests updated.

## Verification

- `npm run app:typecheck`
- `npm --prefix packages/vera-app run test:unit`
- `uv run --extra dev python -m pytest -q tests/test_documentation.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a802fbf1-d3f0-41fe-a276-67f7be09776b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a802fbf1-d3f0-41fe-a276-67f7be09776b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

