### PR TITLE
Simplify embedding providers to match ingest Options + descriptors

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,20 +47,27 @@ schema or normative behavior.
   metadata and `vera.embedder_descriptors` (parallel to ingest pipelines).
 - [x] Accept `embedder_options` / `--embedder-option KEY=VALUE` and expose
   `describe_embedding_providers` for schema-driven Convert controls.
-- [ ] Add conversion-time provider and credential preflight checks.
-- [ ] Improve model selection with provider-specific model discovery.
+- [x] Advertise credential env vars via `capabilities.credential_env` (no
+  secrets in Options) and expose `preflight_embedder`.
+- [x] Advertise model presets via `vera.embedder_models` /
+  `list_embedding_models`.
+- [ ] Add conversion-time provider and credential preflight checks in the
+  Convert UI (sidecar `preflight_embedder` is ready).
+- [ ] Improve model selection UI with provider-specific model discovery
+  (sidecar `list_embedding_models` is ready).
 - [ ] Drive Convert UI embedding forms from descriptors (like
   `PipelineConfigForm`).
+- [ ] Store hosted embedding-provider credentials securely in the desktop app.
 
 ### Official embedding providers
 
 - [ ] Add a lightweight OpenAI-compatible embeddings provider.
 - [ ] Add Voyage AI embeddings for applications that use Claude for answers.
 - [ ] Add an Ollama embeddings provider for local models.
-- [ ] Store hosted embedding-provider credentials securely.
 - [x] Define supported configuration for endpoints, timeouts, and batch sizes
   via provider `Options` + descriptors (built-ins advertise dimension /
-  device / batch_size; hosted plugins follow the same pattern).
+  device / batch_size; hosted plugins follow the same pattern; secrets use
+  `credential_env`).
 - [ ] Document which providers are bundled with each desktop release.
 
 ### Packaging and local models

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,8 +43,14 @@ schema or normative behavior.
 - [x] Use the selected model for single-file and batch conversion.
 - [x] Show installed embedding providers as model-spec suggestions.
 - [x] Offer Convert-view presets for hashing and Sentence Transformers MiniLM.
+- [x] Advertise provider-owned options through `EmbedderOptions` dataclass
+  metadata and `vera.embedder_descriptors` (parallel to ingest pipelines).
+- [x] Accept `embedder_options` / `--embedder-option KEY=VALUE` and expose
+  `describe_embedding_providers` for schema-driven Convert controls.
 - [ ] Add conversion-time provider and credential preflight checks.
 - [ ] Improve model selection with provider-specific model discovery.
+- [ ] Drive Convert UI embedding forms from descriptors (like
+  `PipelineConfigForm`).
 
 ### Official embedding providers
 
@@ -52,7 +58,9 @@ schema or normative behavior.
 - [ ] Add Voyage AI embeddings for applications that use Claude for answers.
 - [ ] Add an Ollama embeddings provider for local models.
 - [ ] Store hosted embedding-provider credentials securely.
-- [ ] Define supported configuration for endpoints, timeouts, and batch sizes.
+- [x] Define supported configuration for endpoints, timeouts, and batch sizes
+  via provider `Options` + descriptors (built-ins advertise dimension /
+  device / batch_size; hosted plugins follow the same pattern).
 - [ ] Document which providers are bundled with each desktop release.
 
 ### Packaging and local models

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -48,6 +48,8 @@ Options:
   into a local cache instead of failing — see `vera ocr-languages`)
 - `--pipeline-option KEY=VALUE` (repeatable; provider-owned options that
   override compatibility aliases for the same key)
+- `--embedder-option KEY=VALUE` (repeatable; provider-owned embedding options
+  forwarded to the selected embedding provider)
 - `--recursive`
 - `--overwrite`
 - `--json`
@@ -62,7 +64,9 @@ auto-fetch curated language data, or a manually installed Tesseract
 archives beside PDFs, validates existing outputs before skipping them,
 reports malformed outputs separately, and does not accept `OUTPUT`.
 Pipeline-owned defaults and validation live in each ingest plugin; see
-[Convert documents](conversion.md#pipeline-options).
+[Convert documents](conversion.md#pipeline-options). Embedding-provider
+options follow the same Options + descriptor pattern; see
+[Creating an embedding provider](creating-an-embedding-provider.md).
 
 ## `vera inspect FILE`
 

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -151,6 +151,10 @@ to `vera_ingest.convert`, call `vera.register_embedder`, or pass
 `embedder_options={...}` / CLI `--embedder-option KEY=VALUE` for
 provider-owned settings advertised by the provider's Options dataclass. See
 [Creating an embedding provider plugin](creating-an-embedding-provider.md).
+Prefer environment variables for API keys (`capabilities.credential_env` /
+`preflight_embedder`); do not put secrets in Options. Convert-time knobs such
+as `batch_size` use `scope: convert` so search can resolve
+`get_embedder(stored_model_name)` with defaults.
 
 ### Hosted provider plugins
 

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -144,8 +144,13 @@ that search an archive created with a Sentence Transformers model.
 Prefer `provider:model-id` specs. An unrecognized provider or model raises an
 error at convert time instead of silently falling back to hashing. Third-party
 plugins can register providers under the Python entry-point group
-`vera.embedders`. From Python, pass a custom `embedding_function` to
-`vera_ingest.convert` or call `vera.register_embedder`.
+`vera.embedders`, with optional `vera.embedder_descriptors` metadata for
+schema-driven Convert controls (`describe_embedding_providers` in the
+sidecar). From Python, pass a custom `embedding_function`
+to `vera_ingest.convert`, call `vera.register_embedder`, or pass
+`embedder_options={...}` / CLI `--embedder-option KEY=VALUE` for
+provider-owned settings advertised by the provider's Options dataclass. See
+[Creating an embedding provider plugin](creating-an-embedding-provider.md).
 
 ### Hosted provider plugins
 
@@ -154,14 +159,17 @@ registers the desired provider, then use its `provider:model-id` spec:
 
 ```bash
 set OPENAI_API_KEY=...
-vera convert "input.pdf" --model openai:text-embedding-3-small
+vera convert "input.pdf" --model openai:text-embedding-3-small \
+  --embedder-option batch_size=64
 ```
 
 The plugin's embedder must record the full spec (for example,
 `openai:text-embedding-3-small`) as `model_name`, so later semantic searches
-load the matching provider. See the
+load the matching provider. See
+[Creating an embedding provider plugin](creating-an-embedding-provider.md)
+for the Options + descriptor authoring model and the
 [OpenAI plugin example](../packages/vera-doc/README.md#openai-embedding-plugin-example)
-for a complete entry-point implementation.
+for a complete entry-point sketch.
 
 Claude is an LLM rather than an embedding provider: Anthropic's Claude API has
 no embeddings endpoint. A Claude application can use a separate provider such

--- a/docs/creating-an-embedding-provider.md
+++ b/docs/creating-an-embedding-provider.md
@@ -1,0 +1,225 @@
+# Creating an embedding provider plugin
+
+An embedding provider turns text into vectors for `.vera` archives. Built-in
+providers (`hashing`, `sentence-transformers`) and third-party plugins share
+the same contract — nothing in `vera-doc`, `vera-cli`, or `vera-app`
+special-cases a hosted OpenAI or Voyage package. Write your own to add a new
+API, a local runtime, or an experimental embedder.
+
+This guide mirrors [Creating an ingest pipeline plugin](creating-an-ingest-pipeline.md):
+a plain factory, one Options dataclass whose field `metadata` drives both
+validation and GUI/CLI descriptors, and entry points for discovery.
+
+## The contract
+
+A provider factory is any callable matching this shape:
+
+```python
+def factory(model_id: str, **config) -> EmbeddingFunction:
+    ...
+```
+
+The returned object must satisfy the structural `EmbeddingFunction` protocol:
+
+- `model_name: str` — stored in archive metadata; prefer the full
+  `provider:model-id` spec so later searches resolve the same provider
+- `dimension: int` — vector length
+- `embed(texts: list[str]) -> np.ndarray | list[np.ndarray]`
+- optional `normalization` — `"l2"`, `"none"`, or omit (`"unknown"`)
+
+There is no base class to inherit from for the embedder itself. For
+configuration, subclass `EmbedderOptions` so `from_mapping` and descriptors
+stay in sync.
+
+## Minimal example
+
+```text
+vera-openai-embeddings/
+  pyproject.toml
+  src/vera_openai_embeddings/
+    __init__.py
+    options.py
+    provider.py
+```
+
+`provider.py`:
+
+```python
+from __future__ import annotations
+
+import os
+
+import numpy as np
+from openai import OpenAI
+
+from .options import OpenAIOptions
+
+
+class OpenAIEmbedder:
+    normalization = "l2"
+
+    def __init__(self, model_id: str, *, api_key: str, batch_size: int):
+        self.model_name = f"openai:{model_id}"
+        self._client = OpenAI(api_key=api_key or os.environ["OPENAI_API_KEY"])
+        self._model = model_id
+        self._batch_size = batch_size
+        self.dimension = len(self.embed(["dimension probe"])[0])
+
+    def embed(self, texts: list[str]) -> list[np.ndarray]:
+        vectors = []
+        for start in range(0, len(texts), self._batch_size):
+            response = self._client.embeddings.create(
+                model=self._model,
+                input=texts[start : start + self._batch_size],
+            )
+            vectors.extend(item.embedding for item in response.data)
+        normalized = []
+        for vector in vectors:
+            array = np.asarray(vector, dtype=np.float32)
+            norm = np.linalg.norm(array)
+            normalized.append(array / norm if norm else array)
+        return normalized
+
+
+def create_embedder(model_id: str, **config):
+    options = OpenAIOptions.from_mapping(config)
+    return OpenAIEmbedder(
+        model_id,
+        api_key=options.api_key,
+        batch_size=options.batch_size,
+    )
+```
+
+`options.py` has two jobs: validate a raw options dict into a typed config
+(`from_mapping`), and describe that same config for CLI/GUI discovery
+(`describe_provider`). Doing both from *one* dataclass is what
+`dataclasses.field(metadata=...)` buys you:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from vera import (
+    EmbedderCapabilities,
+    EmbedderDescriptor,
+    EmbedderOptions,
+)
+from vera.core.embedder_descriptors import fields_from_dataclass
+
+
+@dataclass(frozen=True)
+class OpenAIOptions(EmbedderOptions):
+    api_key: str = field(
+        default="",
+        metadata={
+            "label": "API key",
+            "description": "Optional override; otherwise uses OPENAI_API_KEY.",
+            "allow_empty": True,
+        },
+    )
+    batch_size: int = field(
+        default=128,
+        metadata={
+            "label": "Batch size",
+            "description": "Texts embedded per OpenAI request.",
+            "minimum": 1,
+            "maximum": 2048,
+        },
+    )
+
+
+def describe_provider() -> EmbedderDescriptor:
+    return EmbedderDescriptor(
+        provider="openai",
+        label="openai — hosted embeddings",
+        description="OpenAI embeddings API (text-embedding-3-* and similar).",
+        default_model_id="text-embedding-3-small",
+        example_specs=(
+            "openai:text-embedding-3-small",
+            "openai:text-embedding-3-large",
+        ),
+        capabilities=EmbedderCapabilities(
+            requires_network=True,
+            requires_api_key=True,
+            local_model=False,
+            configurable_dimension=False,
+        ),
+        fields=fields_from_dataclass(OpenAIOptions),
+    )
+```
+
+`__init__.py` exposes the entry-point factories:
+
+```python
+from .options import describe_provider
+from .provider import create_embedder
+
+__all__ = ["create_descriptor", "create_embedder", "describe_provider"]
+
+
+def create_descriptor():
+    return describe_provider()
+```
+
+## Entry points
+
+```toml
+[project.entry-points."vera.embedders"]
+openai = "vera_openai_embeddings:create_embedder"
+
+[project.entry-points."vera.embedder_descriptors"]
+openai = "vera_openai_embeddings:create_descriptor"
+```
+
+After `pip install`, resolve and convert:
+
+```bash
+set OPENAI_API_KEY=...
+vera convert manual.pdf --model openai:text-embedding-3-small \
+  --embedder-option batch_size=64
+```
+
+```python
+from vera import describe_embedder, get_embedder, register_embedder
+from vera_ingest import convert
+
+embedder = get_embedder(
+    "openai:text-embedding-3-large",
+    embedder_options={"batch_size": 64},
+)
+convert("manual.pdf", "manual.vera", embedding_function=embedder)
+
+# Local experiments can skip packaging:
+@register_embedder("myexperiment")
+def create_embedder(model_id: str, **config):
+    ...
+```
+
+## Descriptors without packaging
+
+`describe_embedder("hashing")` and `list_embedding_provider_descriptors()`
+power Convert UI discovery (`describe_embedding_providers` in the sidecar),
+the same way ingest pipelines use `describe_ingest_pipelines`. A plugin that
+omits the descriptor entry point still works for embedding; clients fall back
+to a generic descriptor with no schema-driven fields.
+
+## When *not* to inherit `EmbedderOptions`
+
+`EmbedderOptions.from_mapping` only knows how to validate four field shapes:
+a `bool`, an `int` (positive if `metadata["minimum"]` is a positive number,
+otherwise non-negative), a `str` restricted to `metadata["choices"]` (unless
+`allow_custom` is set), or free-text `str` (`allow_empty` permits blanks).
+Override `from_mapping` when you need type conversion beyond those shapes,
+cross-field checks, or normalizing values. Use
+`vera.core.option_parsing` helpers directly in that override.
+
+## Reference implementations
+
+- Built-in hashing and Sentence Transformers providers in
+  `packages/vera-doc/src/vera/core/embeddings.py` — Options + descriptors live
+  beside the factories.
+- This guide's OpenAI sketch — hosted API with `api_key` / `batch_size`.
+
+See also [Convert documents](conversion.md#embedding-models) and the
+[vera-doc package overview](packages/vera-doc.md).

--- a/docs/creating-an-embedding-provider.md
+++ b/docs/creating-an-embedding-provider.md
@@ -22,7 +22,8 @@ def factory(model_id: str, **config) -> EmbeddingFunction:
 The returned object must satisfy the structural `EmbeddingFunction` protocol:
 
 - `model_name: str` — stored in archive metadata; prefer the full
-  `provider:model-id` spec so later searches resolve the same provider
+  `provider:model-id` spec (or an identity-encoding name such as
+  `vera-hashing-128`) so later searches resolve the same provider
 - `dimension: int` — vector length
 - `embed(texts: list[str]) -> np.ndarray | list[np.ndarray]`
 - optional `normalization` — `"l2"`, `"none"`, or omit (`"unknown"`)
@@ -30,6 +31,24 @@ The returned object must satisfy the structural `EmbeddingFunction` protocol:
 There is no base class to inherit from for the embedder itself. For
 configuration, subclass `EmbedderOptions` so `from_mapping` and descriptors
 stay in sync.
+
+### Convert-time vs search-time
+
+Archives store `model_name`, dimension, and normalization — not your
+`--embedder-option` bag. At search time VERA typically calls
+`get_embedder(stored_model_name)` with **defaults**.
+
+- Mark throughput/hardware settings with `metadata={"scope": "convert"}`
+  (device, batch size, timeouts). Search may ignore them and use defaults.
+- Mark identity-affecting settings with `metadata={"scope": "always"}` and
+  encode them in `model_name` (hashing does this as `vera-hashing-<N>`).
+- **Do not put API keys in Options.** Advertise
+  `capabilities.credential_env` (for example `OPENAI_API_KEY`) and read the
+  environment inside the factory. The desktop app will store secrets
+  separately; Options fields must stay non-secret.
+
+Use `preflight_embedder("openai:text-embedding-3-small")` to check that a
+required credential env var is present without loading model weights.
 
 ## Minimal example
 
@@ -58,9 +77,9 @@ from .options import OpenAIOptions
 class OpenAIEmbedder:
     normalization = "l2"
 
-    def __init__(self, model_id: str, *, api_key: str, batch_size: int):
+    def __init__(self, model_id: str, *, batch_size: int):
         self.model_name = f"openai:{model_id}"
-        self._client = OpenAI(api_key=api_key or os.environ["OPENAI_API_KEY"])
+        self._client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
         self._model = model_id
         self._batch_size = batch_size
         self.dimension = len(self.embed(["dimension probe"])[0])
@@ -83,17 +102,11 @@ class OpenAIEmbedder:
 
 def create_embedder(model_id: str, **config):
     options = OpenAIOptions.from_mapping(config)
-    return OpenAIEmbedder(
-        model_id,
-        api_key=options.api_key,
-        batch_size=options.batch_size,
-    )
+    return OpenAIEmbedder(model_id, batch_size=options.batch_size)
 ```
 
-`options.py` has two jobs: validate a raw options dict into a typed config
-(`from_mapping`), and describe that same config for CLI/GUI discovery
-(`describe_provider`). Doing both from *one* dataclass is what
-`dataclasses.field(metadata=...)` buys you:
+`options.py` validates convert-time knobs and describes them for CLI/GUI
+discovery. Credentials stay out of the dataclass:
 
 ```python
 from __future__ import annotations
@@ -104,27 +117,21 @@ from vera import (
     EmbedderCapabilities,
     EmbedderDescriptor,
     EmbedderOptions,
+    EmbeddingModelInfo,
 )
 from vera.core.embedder_descriptors import fields_from_dataclass
 
 
 @dataclass(frozen=True)
 class OpenAIOptions(EmbedderOptions):
-    api_key: str = field(
-        default="",
-        metadata={
-            "label": "API key",
-            "description": "Optional override; otherwise uses OPENAI_API_KEY.",
-            "allow_empty": True,
-        },
-    )
     batch_size: int = field(
         default=128,
         metadata={
             "label": "Batch size",
-            "description": "Texts embedded per OpenAI request.",
+            "description": "Texts embedded per OpenAI request (convert-time).",
             "minimum": 1,
             "maximum": 2048,
+            "scope": "convert",
         },
     )
 
@@ -142,20 +149,42 @@ def describe_provider() -> EmbedderDescriptor:
         capabilities=EmbedderCapabilities(
             requires_network=True,
             requires_api_key=True,
+            credential_env="OPENAI_API_KEY",
             local_model=False,
             configurable_dimension=False,
+            supports_model_listing=True,
         ),
         fields=fields_from_dataclass(OpenAIOptions),
+    )
+
+
+def list_models() -> tuple[EmbeddingModelInfo, ...]:
+    return (
+        EmbeddingModelInfo(
+            model_id="text-embedding-3-small",
+            label="text-embedding-3-small",
+            spec="openai:text-embedding-3-small",
+        ),
+        EmbeddingModelInfo(
+            model_id="text-embedding-3-large",
+            label="text-embedding-3-large",
+            spec="openai:text-embedding-3-large",
+        ),
     )
 ```
 
 `__init__.py` exposes the entry-point factories:
 
 ```python
-from .options import describe_provider
+from .options import describe_provider, list_models
 from .provider import create_embedder
 
-__all__ = ["create_descriptor", "create_embedder", "describe_provider"]
+__all__ = [
+    "create_descriptor",
+    "create_embedder",
+    "describe_provider",
+    "list_models",
+]
 
 
 def create_descriptor():
@@ -170,6 +199,9 @@ openai = "vera_openai_embeddings:create_embedder"
 
 [project.entry-points."vera.embedder_descriptors"]
 openai = "vera_openai_embeddings:create_descriptor"
+
+[project.entry-points."vera.embedder_models"]
+openai = "vera_openai_embeddings:list_models"
 ```
 
 After `pip install`, resolve and convert:
@@ -181,14 +213,24 @@ vera convert manual.pdf --model openai:text-embedding-3-small \
 ```
 
 ```python
-from vera import describe_embedder, get_embedder, register_embedder
+from vera import (
+    describe_embedder,
+    get_embedder,
+    list_embedding_models,
+    preflight_embedder,
+    register_embedder,
+)
 from vera_ingest import convert
 
+assert preflight_embedder("openai:text-embedding-3-small").ok
 embedder = get_embedder(
     "openai:text-embedding-3-large",
     embedder_options={"batch_size": 64},
 )
 convert("manual.pdf", "manual.vera", embedding_function=embedder)
+
+# Later searches only need the stored model_name (+ env credentials):
+# get_embedder("openai:text-embedding-3-large")
 
 # Local experiments can skip packaging:
 @register_embedder("myexperiment")
@@ -196,13 +238,14 @@ def create_embedder(model_id: str, **config):
     ...
 ```
 
-## Descriptors without packaging
+## Descriptors and model listing
 
 `describe_embedder("hashing")` and `list_embedding_provider_descriptors()`
-power Convert UI discovery (`describe_embedding_providers` in the sidecar),
-the same way ingest pipelines use `describe_ingest_pipelines`. A plugin that
-omits the descriptor entry point still works for embedding; clients fall back
-to a generic descriptor with no schema-driven fields.
+power Convert UI discovery (`describe_embedding_providers` in the sidecar).
+`list_embedding_models(provider)` / sidecar `list_embedding_models` advertise
+preset or live model ids when `supports_model_listing` is true. A plugin that
+omits descriptor or model entry points still works for embedding; clients fall
+back to a generic descriptor and the provider's `default_model_id`.
 
 ## When *not* to inherit `EmbedderOptions`
 
@@ -212,14 +255,16 @@ otherwise non-negative), a `str` restricted to `metadata["choices"]` (unless
 `allow_custom` is set), or free-text `str` (`allow_empty` permits blanks).
 Override `from_mapping` when you need type conversion beyond those shapes,
 cross-field checks, or normalizing values. Use
-`vera.core.option_parsing` helpers directly in that override.
+`vera.core.option_parsing` helpers directly in that override (`vera-ingest`
+re-exports the same helpers).
 
 ## Reference implementations
 
 - Built-in hashing and Sentence Transformers providers in
-  `packages/vera-doc/src/vera/core/embeddings.py` — Options + descriptors live
-  beside the factories.
-- This guide's OpenAI sketch — hosted API with `api_key` / `batch_size`.
+  `packages/vera-doc/src/vera/core/embeddings.py` — Options + descriptors +
+  model lists live beside the factories.
+- This guide's OpenAI sketch — hosted API with env credentials and
+  convert-time `batch_size`.
 
 See also [Convert documents](conversion.md#embedding-models) and the
 [vera-doc package overview](packages/vera-doc.md).

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -64,6 +64,7 @@ Initial actions:
 - `index_update`
 - `list_models`
 - `list_embedding_providers`
+- `describe_embedding_providers`
 - `list_ingest_pipelines`
 - `describe_ingest_pipelines`
 - `list_modes`
@@ -213,11 +214,14 @@ sidecar. It publishes a validated
 temporary sibling atomically, preserves an existing destination after failure,
 and rejects PDFs with no searchable text after OCR with an OCR-specific
 message. Sidecar `convert` and `batch_convert` requests accept optional
-`pipeline_options` plus legacy `chunk_size`, `overlap`, `ocr_mode`,
-`ocr_language`, and `ocr_dpi` fields. Descriptor fields determine which legacy
-aliases are forwarded; explicit `pipeline_options` win. The Convert UI loads
-descriptors through `describe_ingest_pipelines` and renders them with
-`PipelineConfigForm` inside a collapsed **Advanced pipeline options** section.
+`pipeline_options` and `embedder_options` plus legacy `chunk_size`, `overlap`,
+`ocr_mode`, `ocr_language`, and `ocr_dpi` fields. Descriptor fields determine
+which legacy ingest aliases are forwarded; explicit `pipeline_options` win.
+The Convert UI loads ingest descriptors through `describe_ingest_pipelines`
+and renders them with `PipelineConfigForm` inside a collapsed
+**Advanced pipeline options** section. Embedding providers are listed via
+`list_embedding_providers`; `describe_embedding_providers` returns the same
+Options-derived field metadata for schema-driven embedder controls.
 `batch_convert` also accepts an explicit `paths` list of
 PDF files; when present, directory discovery is skipped. The sidecar continues
 after per-file failures and returns converted, skipped, malformed, and failed

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -65,6 +65,8 @@ Initial actions:
 - `list_models`
 - `list_embedding_providers`
 - `describe_embedding_providers`
+- `list_embedding_models`
+- `preflight_embedder`
 - `list_ingest_pipelines`
 - `describe_ingest_pipelines`
 - `list_modes`
@@ -222,6 +224,10 @@ and renders them with `PipelineConfigForm` inside a collapsed
 **Advanced pipeline options** section. Embedding providers are listed via
 `list_embedding_providers`; `describe_embedding_providers` returns the same
 Options-derived field metadata for schema-driven embedder controls.
+`list_embedding_models` returns provider-advertised model presets, and
+`preflight_embedder` checks credential env readiness without loading
+runtimes. Secrets stay in the environment (`capabilities.credential_env`),
+not in Options fields.
 `batch_convert` also accepts an explicit `paths` list of
 PDF files; when present, directory discovery is skipped. The sidecar continues
 after per-file failures and returns converted, skipped, malformed, and failed

--- a/docs/packages/vera-doc.md
+++ b/docs/packages/vera-doc.md
@@ -25,7 +25,9 @@ Python 3.10 or newer is required. The default hashing embedder works locally
 without a model download or API key. Neural embeddings are available through
 the optional `ml` extra. Additional providers can be registered with
 `register_embedder` or discovered through the `vera.embedders` entry-point
-group; unknown model specs raise `UnknownEmbeddingModelError`.
+group (optional `vera.embedder_descriptors` for schema-driven options);
+unknown model specs raise `UnknownEmbeddingModelError`. See
+[Creating an embedding provider plugin](../creating-an-embedding-provider.md).
 
 ## Start here
 
@@ -47,6 +49,8 @@ with VeraDocument.open("knowledge.vera") as document:
 
 ## Documentation
 
+- [Creating an embedding provider plugin](../creating-an-embedding-provider.md) —
+  write and register a `vera.embedders` plugin.
 - [Concepts](../concepts/overview.md) — archives, records, search modes, and indexes.
 - [Basic usage](../guides/basic-usage.md) — convert, inspect, and search workflows.
 - [Search documents](../searching.md) — semantic, keyword, and hybrid retrieval.

--- a/docs/reference/vera.md
+++ b/docs/reference/vera.md
@@ -17,13 +17,18 @@ queries, and library indexes for `.vera` archives.
         - EmbeddingFunction
         - EmbedderOptions
         - EmbedderDescriptor
+        - EmbeddingModelInfo
+        - EmbedderPreflightResult
         - UnknownEmbeddingModelError
         - get_embedder
         - register_embedder
         - register_embedder_descriptor
+        - register_embedder_models
         - describe_embedder
         - list_embedding_providers
         - list_embedding_provider_descriptors
+        - list_embedding_models
+        - preflight_embedder
         - build_library_index
         - update_library_index
         - library_index_status

--- a/docs/reference/vera.md
+++ b/docs/reference/vera.md
@@ -15,10 +15,15 @@ queries, and library indexes for `.vera` archives.
         - QueryResult
         - CorpusSearchResult
         - EmbeddingFunction
+        - EmbedderOptions
+        - EmbedderDescriptor
         - UnknownEmbeddingModelError
         - get_embedder
         - register_embedder
+        - register_embedder_descriptor
+        - describe_embedder
         - list_embedding_providers
+        - list_embedding_provider_descriptors
         - build_library_index
         - update_library_index
         - library_index_status

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
           - Getting started: guides/basic-usage.md
           - Concepts: concepts/overview.md
       - Guides:
+          - Creating an embedding provider: creating-an-embedding-provider.md
           - Search: searching.md
           - Document libraries: document-libraries.md
           - Figures and regions: figures-and-regions.md

--- a/packages/vera-app/src/vera_app/sidecar.py
+++ b/packages/vera-app/src/vera_app/sidecar.py
@@ -18,6 +18,7 @@ from vera import (
     VeraDocument,
     build_library_index,
     library_index_status,
+    list_embedding_provider_descriptors,
     list_embedding_providers,
     update_library_index,
 )
@@ -1122,6 +1123,12 @@ def _convert(
         if isinstance(raw_pipeline_options, dict)
         else None
     )
+    raw_embedder_options = request.get("embedder_options")
+    embedder_options = (
+        dict(raw_embedder_options)
+        if isinstance(raw_embedder_options, dict)
+        else None
+    )
     output = convert(
         input_path,
         str(request["output"]),
@@ -1135,6 +1142,7 @@ def _convert(
         ocr_dpi=int(request.get("ocr_dpi", 300)),
         ocr_download=bool(request.get("ocr_download", False)),
         pipeline_options=pipeline_options,
+        embedder_options=embedder_options,
         cancel=cancel,
     )
     if write_event:
@@ -1210,6 +1218,11 @@ def _batch_convert(
         pipeline_options=(
             dict(request["pipeline_options"])
             if isinstance(request.get("pipeline_options"), dict)
+            else None
+        ),
+        embedder_options=(
+            dict(request["embedder_options"])
+            if isinstance(request.get("embedder_options"), dict)
             else None
         ),
         progress=report_progress,
@@ -1355,6 +1368,15 @@ def _list_embedding_providers(request: Request) -> dict[str, Any]:
     return {"providers": list_embedding_providers()}
 
 
+def _describe_embedding_providers(request: Request) -> dict[str, Any]:
+    """Return installed embedding-provider descriptors for schema-driven controls."""
+    return {
+        "providers": [
+            descriptor.as_dict() for descriptor in list_embedding_provider_descriptors()
+        ],
+    }
+
+
 def _list_ingest_pipelines(request: Request) -> dict[str, Any]:
     """List installed ingest pipeline providers for the Convert view."""
     return {"pipelines": list_ingest_pipelines()}
@@ -1418,6 +1440,7 @@ HANDLERS: dict[str, Handler] = {
     "page": _page,
     "list_models": _list_models,
     "list_embedding_providers": _list_embedding_providers,
+    "describe_embedding_providers": _describe_embedding_providers,
     "list_ingest_pipelines": _list_ingest_pipelines,
     "describe_ingest_pipelines": _describe_ingest_pipelines,
     "ocr_languages_list": _ocr_languages_list,

--- a/packages/vera-app/src/vera_app/sidecar.py
+++ b/packages/vera-app/src/vera_app/sidecar.py
@@ -18,8 +18,10 @@ from vera import (
     VeraDocument,
     build_library_index,
     library_index_status,
+    list_embedding_models,
     list_embedding_provider_descriptors,
     list_embedding_providers,
+    preflight_embedder,
     update_library_index,
 )
 from vera.corpus import VeraCorpus
@@ -1377,6 +1379,23 @@ def _describe_embedding_providers(request: Request) -> dict[str, Any]:
     }
 
 
+def _list_embedding_models(request: Request) -> dict[str, Any]:
+    """Return model ids advertised by one embedding provider."""
+    provider = str(request.get("provider") or "").strip()
+    if not provider:
+        raise ValueError("provider is required")
+    return {
+        "provider": provider,
+        "models": [item.as_dict() for item in list_embedding_models(provider)],
+    }
+
+
+def _preflight_embedder(request: Request) -> dict[str, Any]:
+    """Check credential/env readiness for a model spec without loading runtimes."""
+    model = str(request.get("model") or "hashing")
+    return preflight_embedder(model).as_dict()
+
+
 def _list_ingest_pipelines(request: Request) -> dict[str, Any]:
     """List installed ingest pipeline providers for the Convert view."""
     return {"pipelines": list_ingest_pipelines()}
@@ -1441,6 +1460,8 @@ HANDLERS: dict[str, Handler] = {
     "list_models": _list_models,
     "list_embedding_providers": _list_embedding_providers,
     "describe_embedding_providers": _describe_embedding_providers,
+    "list_embedding_models": _list_embedding_models,
+    "preflight_embedder": _preflight_embedder,
     "list_ingest_pipelines": _list_ingest_pipelines,
     "describe_ingest_pipelines": _describe_ingest_pipelines,
     "ocr_languages_list": _ocr_languages_list,

--- a/packages/vera-cli/src/vera_cli/commands.py
+++ b/packages/vera-cli/src/vera_cli/commands.py
@@ -51,8 +51,16 @@ def _result_payload(result) -> dict:
 
 
 def _pipeline_options_from_args(args) -> dict[str, object]:
+    return _key_value_options_from_args(getattr(args, "pipeline_options", []) or [])
+
+
+def _embedder_options_from_args(args) -> dict[str, object]:
+    return _key_value_options_from_args(getattr(args, "embedder_options", []) or [])
+
+
+def _key_value_options_from_args(pairs) -> dict[str, object]:
     options: dict[str, object] = {}
-    for key, raw in getattr(args, "pipeline_options", []) or []:
+    for key, raw in pairs:
         text = str(raw).strip()
         lowered = text.lower()
         if lowered in {"true", "false"}:
@@ -72,6 +80,7 @@ def _pipeline_options_from_args(args) -> dict[str, object]:
 def cmd_convert(args) -> int:
     input_path = Path(args.input)
     pipeline_options = _pipeline_options_from_args(args)
+    embedder_options = _embedder_options_from_args(args)
     try:
         if input_path.is_dir():
             if args.output:
@@ -95,6 +104,7 @@ def cmd_convert(args) -> int:
                 ocr_dpi=args.ocr_dpi,
                 ocr_download=args.ocr_allow_download,
                 pipeline_options=pipeline_options or None,
+                embedder_options=embedder_options or None,
             )
             unsuccessful = report["failed"] + report["malformed"]
             if args.json:
@@ -126,6 +136,7 @@ def cmd_convert(args) -> int:
             ocr_dpi=args.ocr_dpi,
             ocr_download=args.ocr_allow_download,
             pipeline_options=pipeline_options or None,
+            embedder_options=embedder_options or None,
         )
     except (UnknownIngestPipelineError, UnknownEmbeddingModelError) as exc:
         if args.json:

--- a/packages/vera-cli/src/vera_cli/main.py
+++ b/packages/vera-cli/src/vera_cli/main.py
@@ -33,7 +33,7 @@ def positive_int(value: str) -> int:
 
 
 def pipeline_option(value: str) -> tuple[str, str]:
-    """Parse ``KEY=VALUE`` pairs for ``--pipeline-option``."""
+    """Parse ``KEY=VALUE`` pairs for ``--pipeline-option`` / ``--embedder-option``."""
     if "=" not in value:
         raise argparse.ArgumentTypeError("must be KEY=VALUE")
     key, raw = value.split("=", 1)
@@ -41,6 +41,9 @@ def pipeline_option(value: str) -> tuple[str, str]:
     if not key:
         raise argparse.ArgumentTypeError("option key must be non-empty")
     return key, raw
+
+
+embedder_option = pipeline_option
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -101,6 +104,19 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Provider-owned ingest option (repeatable). Overrides compatibility "
             "aliases for the same key when the selected pipeline accepts it."
+        ),
+    )
+    convert_p.add_argument(
+        "--embedder-option",
+        dest="embedder_options",
+        action="append",
+        type=embedder_option,
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Provider-owned embedding option (repeatable). Forwarded to the "
+            "selected embedding provider (for example --embedder-option "
+            "batch_size=64 or --embedder-option dimension=256)."
         ),
     )
     convert_p.add_argument("--recursive", action="store_true", help="Discover PDFs recursively when input is a directory")

--- a/packages/vera-doc/README.md
+++ b/packages/vera-doc/README.md
@@ -470,6 +470,7 @@ them as `embedder_options={...}`, `get_embedder(..., batch_size=64)`, or CLI
 VERA does not bundle hosted providers. Prefer the Options + descriptor
 authoring model in
 [Creating an embedding provider plugin](../../docs/creating-an-embedding-provider.md).
+Keep secrets in the environment (`OPENAI_API_KEY`), not in Options fields.
 This minimal sketch shows the factory + entry points:
 
 ```toml
@@ -483,42 +484,47 @@ openai = "vera_openai_embeddings:create_embedder"
 
 [project.entry-points."vera.embedder_descriptors"]
 openai = "vera_openai_embeddings:create_descriptor"
+
+[project.entry-points."vera.embedder_models"]
+openai = "vera_openai_embeddings:list_models"
 ```
 
 ```python
 # vera_openai_embeddings.py
 import os
+from dataclasses import dataclass, field
 
 import numpy as np
 from openai import OpenAI
 
-from vera import EmbedderCapabilities, EmbedderDescriptor, EmbedderOptions
+from vera import (
+    EmbedderCapabilities,
+    EmbedderDescriptor,
+    EmbedderOptions,
+    EmbeddingModelInfo,
+)
 from vera.core.embedder_descriptors import fields_from_dataclass
-from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
 class OpenAIOptions(EmbedderOptions):
-    api_key: str = field(
-        default="",
-        metadata={
-            "label": "API key",
-            "allow_empty": True,
-            "description": "Optional override; otherwise uses OPENAI_API_KEY.",
-        },
-    )
     batch_size: int = field(
         default=128,
-        metadata={"label": "Batch size", "minimum": 1, "maximum": 2048},
+        metadata={
+            "label": "Batch size",
+            "minimum": 1,
+            "maximum": 2048,
+            "scope": "convert",
+        },
     )
 
 
 class OpenAIEmbedder:
     normalization = "l2"
 
-    def __init__(self, model_id: str, *, api_key: str, batch_size: int):
+    def __init__(self, model_id: str, *, batch_size: int):
         self.model_name = f"openai:{model_id}"
-        self._client = OpenAI(api_key=api_key or os.environ["OPENAI_API_KEY"])
+        self._client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
         self._model = model_id
         self._batch_size = batch_size
         self.dimension = len(self.embed(["dimension probe"])[0])
@@ -541,11 +547,7 @@ class OpenAIEmbedder:
 
 def create_embedder(model_id: str, **config):
     options = OpenAIOptions.from_mapping(config)
-    return OpenAIEmbedder(
-        model_id,
-        api_key=options.api_key,
-        batch_size=options.batch_size,
-    )
+    return OpenAIEmbedder(model_id, batch_size=options.batch_size)
 
 
 def create_descriptor() -> EmbedderDescriptor:
@@ -558,9 +560,21 @@ def create_descriptor() -> EmbedderDescriptor:
         capabilities=EmbedderCapabilities(
             requires_network=True,
             requires_api_key=True,
+            credential_env="OPENAI_API_KEY",
             local_model=False,
+            supports_model_listing=True,
         ),
         fields=fields_from_dataclass(OpenAIOptions),
+    )
+
+
+def list_models():
+    return (
+        EmbeddingModelInfo(
+            model_id="text-embedding-3-small",
+            label="text-embedding-3-small",
+            spec="openai:text-embedding-3-small",
+        ),
     )
 ```
 
@@ -574,9 +588,10 @@ vera convert "manual.pdf" --model openai:text-embedding-3-small \
 Or pass provider-specific settings from Python:
 
 ```python
-from vera import get_embedder
+from vera import get_embedder, preflight_embedder
 from vera_ingest import convert
 
+assert preflight_embedder("openai:text-embedding-3-large").ok
 embedder = get_embedder(
     "openai:text-embedding-3-large",
     embedder_options={"batch_size": 64},

--- a/packages/vera-doc/README.md
+++ b/packages/vera-doc/README.md
@@ -439,37 +439,50 @@ Register additional providers in-process:
 from vera import get_embedder, register_embedder
 
 
+@register_embedder("example")
 def factory(model_id: str, **config):
     return MyEmbedder()  # model_name / dimension / embed(...)
 
 
-register_embedder("example", factory)
 embedder = get_embedder("example:my-embedder")
 ```
 
-Or ship a plugin that advertises an entry point in the `vera.embedders` group:
+Or ship a plugin that advertises entry points in the `vera.embedders` and
+optional `vera.embedder_descriptors` groups:
 
 ```toml
 [project.entry-points."vera.embedders"]
 example = "my_package.embeddings:factory"
+
+[project.entry-points."vera.embedder_descriptors"]
+example = "my_package.embeddings:create_descriptor"
 ```
 
 After `pip install`, `get_embedder("example:my-embedder")` resolves the factory
-with no changes to `vera-doc`.
+with no changes to `vera-doc`. Provider-owned settings use an
+`EmbedderOptions` dataclass (same metadata pattern as ingest pipelines); pass
+them as `embedder_options={...}`, `get_embedder(..., batch_size=64)`, or CLI
+`--embedder-option KEY=VALUE`. See
+[Creating an embedding provider plugin](../../docs/creating-an-embedding-provider.md).
 
 ### OpenAI embedding plugin example
 
-VERA does not bundle hosted providers. This minimal third-party package adds an
-OpenAI provider:
+VERA does not bundle hosted providers. Prefer the Options + descriptor
+authoring model in
+[Creating an embedding provider plugin](../../docs/creating-an-embedding-provider.md).
+This minimal sketch shows the factory + entry points:
 
 ```toml
 # pyproject.toml
 [project]
 name = "vera-openai-embeddings"
-dependencies = ["openai>=1"]
+dependencies = ["openai>=1", "vera-doc"]
 
 [project.entry-points."vera.embedders"]
-openai = "vera_openai_embeddings:factory"
+openai = "vera_openai_embeddings:create_embedder"
+
+[project.entry-points."vera.embedder_descriptors"]
+openai = "vera_openai_embeddings:create_descriptor"
 ```
 
 ```python
@@ -479,17 +492,35 @@ import os
 import numpy as np
 from openai import OpenAI
 
+from vera import EmbedderCapabilities, EmbedderDescriptor, EmbedderOptions
+from vera.core.embedder_descriptors import fields_from_dataclass
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class OpenAIOptions(EmbedderOptions):
+    api_key: str = field(
+        default="",
+        metadata={
+            "label": "API key",
+            "allow_empty": True,
+            "description": "Optional override; otherwise uses OPENAI_API_KEY.",
+        },
+    )
+    batch_size: int = field(
+        default=128,
+        metadata={"label": "Batch size", "minimum": 1, "maximum": 2048},
+    )
+
 
 class OpenAIEmbedder:
     normalization = "l2"
 
-    def __init__(self, model_id: str, **config):
+    def __init__(self, model_id: str, *, api_key: str, batch_size: int):
         self.model_name = f"openai:{model_id}"
-        self._client = OpenAI(
-            api_key=config.get("api_key") or os.environ["OPENAI_API_KEY"]
-        )
+        self._client = OpenAI(api_key=api_key or os.environ["OPENAI_API_KEY"])
         self._model = model_id
-        self._batch_size = int(config.get("batch_size", 128))
+        self._batch_size = batch_size
         self.dimension = len(self.embed(["dimension probe"])[0])
 
     def embed(self, texts: list[str]) -> list[np.ndarray]:
@@ -508,14 +539,36 @@ class OpenAIEmbedder:
         return normalized
 
 
-def factory(model_id: str, **config):
-    return OpenAIEmbedder(model_id, **config)
+def create_embedder(model_id: str, **config):
+    options = OpenAIOptions.from_mapping(config)
+    return OpenAIEmbedder(
+        model_id,
+        api_key=options.api_key,
+        batch_size=options.batch_size,
+    )
+
+
+def create_descriptor() -> EmbedderDescriptor:
+    return EmbedderDescriptor(
+        provider="openai",
+        label="openai — hosted embeddings",
+        description="OpenAI embeddings API.",
+        default_model_id="text-embedding-3-small",
+        example_specs=("openai:text-embedding-3-small",),
+        capabilities=EmbedderCapabilities(
+            requires_network=True,
+            requires_api_key=True,
+            local_model=False,
+        ),
+        fields=fields_from_dataclass(OpenAIOptions),
+    )
 ```
 
 After installing the plugin and setting `OPENAI_API_KEY`, use it from the CLI:
 
 ```bash
-vera convert "manual.pdf" --model openai:text-embedding-3-small
+vera convert "manual.pdf" --model openai:text-embedding-3-small \
+  --embedder-option batch_size=64
 ```
 
 Or pass provider-specific settings from Python:
@@ -526,7 +579,7 @@ from vera_ingest import convert
 
 embedder = get_embedder(
     "openai:text-embedding-3-large",
-    batch_size=64,
+    embedder_options={"batch_size": 64},
 )
 convert("manual.pdf", "manual.vera", embedding_function=embedder)
 ```

--- a/packages/vera-doc/src/vera/__init__.py
+++ b/packages/vera-doc/src/vera/__init__.py
@@ -7,13 +7,23 @@ from .collection import (
     update_library_index,
 )
 from .corpus import CorpusSearchResult, VeraCorpus
+from .core.embedder_descriptors import (
+    EmbedderCapabilities,
+    EmbedderDescriptor,
+    EmbedderField,
+    EmbedderFieldChoice,
+)
+from .core.embedder_options import EmbedderOptions
 from .core.embeddings import (
     EmbeddingFunction,
     UnknownEmbeddingModelError,
     clear_embedder_cache,
+    describe_embedder,
     get_embedder,
+    list_embedding_provider_descriptors,
     list_embedding_providers,
     register_embedder,
+    register_embedder_descriptor,
 )
 from .document import (
     DuplicateRecordError,
@@ -33,11 +43,19 @@ __all__ = [
     "update_library_index",
     "library_index_status",
     "EmbeddingFunction",
+    "EmbedderOptions",
+    "EmbedderDescriptor",
+    "EmbedderField",
+    "EmbedderFieldChoice",
+    "EmbedderCapabilities",
     "EmbeddingNormalization",
     "UnknownEmbeddingModelError",
     "get_embedder",
     "register_embedder",
+    "register_embedder_descriptor",
+    "describe_embedder",
     "list_embedding_providers",
+    "list_embedding_provider_descriptors",
     "clear_embedder_cache",
     "ChunkRecord",
     "AttachmentRecord",

--- a/packages/vera-doc/src/vera/__init__.py
+++ b/packages/vera-doc/src/vera/__init__.py
@@ -12,6 +12,8 @@ from .core.embedder_descriptors import (
     EmbedderDescriptor,
     EmbedderField,
     EmbedderFieldChoice,
+    EmbedderPreflightResult,
+    EmbeddingModelInfo,
 )
 from .core.embedder_options import EmbedderOptions
 from .core.embeddings import (
@@ -20,10 +22,13 @@ from .core.embeddings import (
     clear_embedder_cache,
     describe_embedder,
     get_embedder,
+    list_embedding_models,
     list_embedding_provider_descriptors,
     list_embedding_providers,
+    preflight_embedder,
     register_embedder,
     register_embedder_descriptor,
+    register_embedder_models,
 )
 from .document import (
     DuplicateRecordError,
@@ -48,14 +53,19 @@ __all__ = [
     "EmbedderField",
     "EmbedderFieldChoice",
     "EmbedderCapabilities",
+    "EmbeddingModelInfo",
+    "EmbedderPreflightResult",
     "EmbeddingNormalization",
     "UnknownEmbeddingModelError",
     "get_embedder",
     "register_embedder",
     "register_embedder_descriptor",
+    "register_embedder_models",
     "describe_embedder",
     "list_embedding_providers",
     "list_embedding_provider_descriptors",
+    "list_embedding_models",
+    "preflight_embedder",
     "clear_embedder_cache",
     "ChunkRecord",
     "AttachmentRecord",

--- a/packages/vera-doc/src/vera/core/embedder_descriptors.py
+++ b/packages/vera-doc/src/vera/core/embedder_descriptors.py
@@ -1,0 +1,139 @@
+"""Plugin-neutral embedding-provider descriptors for discovery and GUI forms."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, fields
+from typing import Any, Literal
+
+
+FieldType = Literal["string", "enum", "integer", "number", "boolean"]
+
+
+@dataclass(frozen=True)
+class EmbedderFieldChoice:
+    """One selectable value for an enum descriptor field."""
+
+    value: str
+    label: str
+
+
+@dataclass(frozen=True)
+class EmbedderField:
+    """Constrained configuration field advertised by an embedding provider."""
+
+    key: str
+    label: str
+    type: FieldType
+    default: Any = None
+    description: str = ""
+    unit: str | None = None
+    choices: tuple[EmbedderFieldChoice, ...] = ()
+    minimum: int | float | None = None
+    maximum: int | float | None = None
+    step: int | float | None = None
+    placeholder: str | None = None
+    # When True on an enum field, GUIs may offer a free-text "Custom" value
+    # outside the advertised choices.
+    allow_custom: bool = False
+    # When True on a string field, blank values are valid (for example an
+    # optional device string that means "auto").
+    allow_empty: bool = False
+
+
+@dataclass(frozen=True)
+class EmbedderCapabilities:
+    """Capability flags that help clients hide irrelevant controls."""
+
+    requires_network: bool = False
+    requires_api_key: bool = False
+    local_model: bool = True
+    configurable_dimension: bool = False
+
+
+@dataclass(frozen=True)
+class EmbedderDescriptor:
+    """Metadata describing an installed embedding provider."""
+
+    provider: str
+    label: str
+    description: str = ""
+    installed: bool = True
+    default_model_id: str = ""
+    example_specs: tuple[str, ...] = ()
+    capabilities: EmbedderCapabilities = field(default_factory=EmbedderCapabilities)
+    fields: tuple[EmbedderField, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def field_keys(self) -> set[str]:
+        return {item.key for item in self.fields}
+
+    def defaults(self) -> dict[str, Any]:
+        return {item.key: item.default for item in self.fields}
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize for sidecar/CLI JSON clients."""
+        return asdict(self)
+
+
+_FIELD_TYPE_BY_ANNOTATION = {
+    "bool": "boolean",
+    "int": "integer",
+    "float": "number",
+    "str": "string",
+}
+
+
+def fields_from_dataclass(cls: type) -> tuple[EmbedderField, ...]:
+    """Derive descriptor fields from a dataclass's fields and per-field ``metadata``.
+
+    A provider's ``Options`` dataclass stays the single source of truth for a
+    setting's key and default: this reads them straight off each
+    :func:`dataclasses.field`, and reads presentation data (``label``,
+    ``description``, bounds, ``choices``, ...) from that field's ``metadata``
+    mapping instead of a hand-maintained, parallel list of ``EmbedderField``
+    entries. A field with no ``metadata`` is treated as internal and omitted.
+    """
+    result: list[EmbedderField] = []
+    for item in fields(cls):
+        meta = item.metadata
+        if not meta:
+            continue
+        annotation = item.type
+        type_name = annotation if isinstance(annotation, str) else getattr(
+            annotation, "__name__", str(annotation)
+        )
+        field_type = meta.get("type") or _FIELD_TYPE_BY_ANNOTATION.get(type_name, "string")
+        choices = tuple(
+            EmbedderFieldChoice(value, label) for value, label in meta.get("choices", ())
+        )
+        result.append(
+            EmbedderField(
+                key=item.name,
+                label=meta.get("label", item.name),
+                type=field_type,
+                default=item.default,
+                description=meta.get("description", ""),
+                unit=meta.get("unit"),
+                choices=choices,
+                minimum=meta.get("minimum"),
+                maximum=meta.get("maximum"),
+                step=meta.get("step"),
+                placeholder=meta.get("placeholder"),
+                allow_custom=meta.get("allow_custom", False),
+                allow_empty=meta.get("allow_empty", False),
+            )
+        )
+    return tuple(result)
+
+
+def generic_embedder_descriptor(provider: str) -> EmbedderDescriptor:
+    """Minimal fallback when a plugin does not register a descriptor."""
+    return EmbedderDescriptor(
+        provider=provider,
+        label=provider,
+        description=f"Installed embedding provider '{provider}'.",
+        notes=(
+            "This plugin did not publish a configuration descriptor; "
+            "use provider-documented embedder options.",
+        ),
+    )

--- a/packages/vera-doc/src/vera/core/embedder_descriptors.py
+++ b/packages/vera-doc/src/vera/core/embedder_descriptors.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 
 FieldType = Literal["string", "enum", "integer", "number", "boolean"]
+FieldScope = Literal["convert", "always"]
 
 
 @dataclass(frozen=True)
@@ -38,6 +39,11 @@ class EmbedderField:
     # When True on a string field, blank values are valid (for example an
     # optional device string that means "auto").
     allow_empty: bool = False
+    # ``convert`` options affect embedding throughput/hardware only and may use
+    # defaults at search time. ``always`` options participate in archive
+    # identity (for example hashing dimension) and must round-trip via
+    # ``model_name`` or explicit search-time config.
+    scope: FieldScope = "convert"
 
 
 @dataclass(frozen=True)
@@ -46,8 +52,41 @@ class EmbedderCapabilities:
 
     requires_network: bool = False
     requires_api_key: bool = False
+    # Environment variable the provider reads for credentials (never put secrets
+    # in Options fields or descriptors). Empty when no API key is required.
+    credential_env: str = ""
     local_model: bool = True
     configurable_dimension: bool = False
+    # When True, ``list_embedding_models(provider)`` is expected to return
+    # useful model ids (static presets and/or a live provider listing).
+    supports_model_listing: bool = False
+
+
+@dataclass(frozen=True)
+class EmbeddingModelInfo:
+    """One selectable model id advertised by an embedding provider."""
+
+    model_id: str
+    label: str = ""
+    spec: str = ""
+    description: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class EmbedderPreflightResult:
+    """Lightweight readiness check for an embedding provider or model spec."""
+
+    ok: bool
+    provider: str
+    model_id: str = ""
+    missing_credential_env: str = ""
+    detail: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -69,6 +108,14 @@ class EmbedderDescriptor:
 
     def defaults(self) -> dict[str, Any]:
         return {item.key: item.default for item in self.fields}
+
+    def convert_fields(self) -> tuple[EmbedderField, ...]:
+        """Fields that are convert-time only (safe to default at search)."""
+        return tuple(item for item in self.fields if item.scope == "convert")
+
+    def always_fields(self) -> tuple[EmbedderField, ...]:
+        """Fields that participate in archive identity / search resolve."""
+        return tuple(item for item in self.fields if item.scope == "always")
 
     def as_dict(self) -> dict[str, Any]:
         """Serialize for sidecar/CLI JSON clients."""
@@ -106,6 +153,12 @@ def fields_from_dataclass(cls: type) -> tuple[EmbedderField, ...]:
         choices = tuple(
             EmbedderFieldChoice(value, label) for value, label in meta.get("choices", ())
         )
+        scope = meta.get("scope", "convert")
+        if scope not in {"convert", "always"}:
+            raise ValueError(
+                f"Unsupported EmbedderField scope {scope!r} for {item.name}; "
+                "use 'convert' or 'always'"
+            )
         result.append(
             EmbedderField(
                 key=item.name,
@@ -121,6 +174,7 @@ def fields_from_dataclass(cls: type) -> tuple[EmbedderField, ...]:
                 placeholder=meta.get("placeholder"),
                 allow_custom=meta.get("allow_custom", False),
                 allow_empty=meta.get("allow_empty", False),
+                scope=scope,
             )
         )
     return tuple(result)

--- a/packages/vera-doc/src/vera/core/embedder_options.py
+++ b/packages/vera-doc/src/vera/core/embedder_options.py
@@ -1,0 +1,99 @@
+"""Base class for embedding-provider ``Options`` dataclasses.
+
+Most embedder settings are one of a handful of shapes: a boolean flag, an
+integer with a floor, a string restricted to a fixed set of choices, or free
+text. :class:`EmbedderOptions` validates a raw options mapping against exactly
+those shapes, inferred from each dataclass field's default value and
+``metadata`` — the same ``metadata`` already used by
+:func:`vera.core.embedder_descriptors.fields_from_dataclass` to build the
+CLI/GUI descriptor — so a plugin whose settings all fit those shapes needs no
+validation code at all.
+
+A provider needing something beyond bool/int/choice/string validation can
+still subclass :class:`EmbedderOptions` and override ``from_mapping``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Any, ClassVar, Mapping
+
+from .option_parsing import (
+    allowed_keys_from_dataclass,
+    reject_unknown_keys,
+    require_bool,
+    require_choice,
+    require_mapping,
+    require_non_negative_int,
+    require_positive_int,
+    require_string,
+)
+
+
+class EmbedderOptions:
+    """Base for an embedding provider's typed, validated settings.
+
+    Subclass alongside ``@dataclass(frozen=True)``::
+
+        @dataclass(frozen=True)
+        class MyOptions(EmbedderOptions):
+            batch_size: int = field(default=64, metadata={"label": "Batch size"})
+
+    ``MyOptions.from_mapping(raw)`` validates a raw options dict field by
+    field. For each field, its own default value's type picks the validator:
+
+    - a ``bool`` default uses :func:`~vera.core.option_parsing.require_bool`;
+    - an ``int`` default uses :func:`~vera.core.option_parsing.require_positive_int`
+      when ``metadata["minimum"]`` is a positive number, otherwise
+      :func:`~vera.core.option_parsing.require_non_negative_int`;
+    - a ``str`` default with ``metadata["choices"]`` and no
+      ``metadata["allow_custom"]`` uses
+      :func:`~vera.core.option_parsing.require_choice`;
+    - any other ``str`` default uses :func:`~vera.core.option_parsing.require_string`
+      (``metadata["allow_empty"]`` permits blank values).
+
+    Two class attributes customize behavior without an override:
+
+    - ``options_label`` sets the name used in error messages (default: the
+      class name with a trailing ``Options`` dropped).
+    - ``ignored_keys`` names legacy option keys to silently accept and drop.
+    """
+
+    options_label: ClassVar[str] = ""
+    ignored_keys: ClassVar[frozenset[str]] = frozenset()
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None = None) -> Any:
+        label = cls.options_label or cls.__name__.removesuffix("Options") or cls.__name__
+        data = reject_unknown_keys(
+            require_mapping(raw, label=f"{label} embedder_options"),
+            allowed=allowed_keys_from_dataclass(cls),
+            ignored=cls.ignored_keys or None,
+            label=label,
+        )
+        values: dict[str, Any] = {}
+        for item in fields(cls):
+            name = item.name
+            default = getattr(cls, name)
+            value = data.get(name, default)
+            if isinstance(default, bool):
+                values[name] = require_bool(value, name=name)
+            elif isinstance(default, int):
+                minimum = item.metadata.get("minimum")
+                if isinstance(minimum, (int, float)) and minimum > 0:
+                    values[name] = require_positive_int(value, name=name)
+                else:
+                    values[name] = require_non_negative_int(value, name=name)
+            else:
+                choices = item.metadata.get("choices")
+                if choices and not item.metadata.get("allow_custom"):
+                    values[name] = require_choice(
+                        value, name=name, choices={choice[0] for choice in choices}
+                    )
+                else:
+                    values[name] = require_string(
+                        value,
+                        name=name,
+                        allow_empty=bool(item.metadata.get("allow_empty")),
+                    )
+        return cls(**values)

--- a/packages/vera-doc/src/vera/core/embeddings.py
+++ b/packages/vera-doc/src/vera/core/embeddings.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import re
 import threading
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from importlib.metadata import entry_points
 from typing import Any, Callable, Iterable, Protocol
@@ -13,17 +14,22 @@ import numpy as np
 from .embedder_descriptors import (
     EmbedderCapabilities,
     EmbedderDescriptor,
+    EmbedderPreflightResult,
+    EmbeddingModelInfo,
     fields_from_dataclass,
     generic_embedder_descriptor,
 )
 from .embedder_options import EmbedderOptions
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
+_HASHING_NAME_RE = re.compile(r"^vera-hashing-(\d+)$")
 _ENTRY_POINT_GROUP = "vera.embedders"
 _DESCRIPTOR_ENTRY_POINT_GROUP = "vera.embedder_descriptors"
+_MODELS_ENTRY_POINT_GROUP = "vera.embedder_models"
 _REGISTRY_LOCK = threading.RLock()
 _PROVIDERS: dict[str, Callable[..., EmbeddingFunction]] = {}
 _DESCRIPTOR_FACTORIES: dict[str, Callable[[], EmbedderDescriptor]] = {}
+_MODEL_LISTERS: dict[str, Callable[[], Sequence[EmbeddingModelInfo]]] = {}
 _ENTRY_POINTS_LOADED = False
 _INSTANCE_CACHE: dict[tuple[Any, ...], EmbeddingFunction] = {}
 
@@ -79,10 +85,14 @@ class HashingOptions(EmbedderOptions):
         default=384,
         metadata={
             "label": "Dimension",
-            "description": "Output vector length for the hashing embedder.",
+            "description": (
+                "Output vector length. Encoded into model_name as "
+                "vera-hashing-<N> so search resolves the same size."
+            ),
             "minimum": 8,
             "maximum": 4096,
             "step": 8,
+            "scope": "always",
         },
     )
 
@@ -97,20 +107,26 @@ class SentenceTransformersOptions(EmbedderOptions):
             "label": "Device",
             "description": (
                 "Optional torch device (for example cpu or cuda). "
-                "Leave blank to let Sentence Transformers choose."
+                "Leave blank to let Sentence Transformers choose. "
+                "Convert-time only — search may use the default device."
             ),
             "allow_empty": True,
             "placeholder": "cpu",
+            "scope": "convert",
         },
     )
     batch_size: int = field(
         default=32,
         metadata={
             "label": "Batch size",
-            "description": "Texts encoded per Sentence Transformers batch.",
+            "description": (
+                "Texts encoded per Sentence Transformers batch. "
+                "Convert-time only — search may use the default batch size."
+            ),
             "minimum": 1,
             "maximum": 2048,
             "step": 1,
+            "scope": "convert",
         },
     )
 
@@ -161,10 +177,15 @@ class SentenceTransformerEmbedder:
 
 
 def _hashing_factory(model_id: str = "vera-hashing-384", **config: Any) -> HashingEmbedder:
-    options = HashingOptions.from_mapping(config)
+    raw = dict(config)
     name = (model_id or "").strip() or "vera-hashing-384"
-    if name in {"hashing", "vera-hashing-384"}:
-        name = "vera-hashing-384"
+    match = _HASHING_NAME_RE.match(name)
+    if match and "dimension" not in raw:
+        raw["dimension"] = int(match.group(1))
+    options = HashingOptions.from_mapping(raw)
+    if name in {"hashing", "vera-hashing-384"} or match is not None:
+        # Keep archive identity and search resolve aligned with dimension.
+        name = f"vera-hashing-{options.dimension}"
     return HashingEmbedder(dimension=options.dimension, model_name=name)
 
 
@@ -202,6 +223,7 @@ def _hashing_descriptor() -> EmbedderDescriptor:
             requires_api_key=False,
             local_model=True,
             configurable_dimension=True,
+            supports_model_listing=True,
         ),
         fields=fields_from_dataclass(HashingOptions),
     )
@@ -226,11 +248,41 @@ def _sentence_transformers_descriptor() -> EmbedderDescriptor:
             requires_api_key=False,
             local_model=True,
             configurable_dimension=False,
+            supports_model_listing=True,
         ),
         fields=fields_from_dataclass(SentenceTransformersOptions),
         notes=(
             "Install vera-doc[ml] (or sentence-transformers) before first use. "
-            "The first resolve may download model weights.",
+            "The first resolve may download model weights. "
+            "device and batch_size are convert-time options; search uses defaults.",
+        ),
+    )
+
+
+def _hashing_models() -> tuple[EmbeddingModelInfo, ...]:
+    return (
+        EmbeddingModelInfo(
+            model_id="vera-hashing-384",
+            label="Hashing 384-d",
+            spec="hashing:vera-hashing-384",
+            description="Default deterministic offline hashing embedder.",
+        ),
+    )
+
+
+def _sentence_transformers_models() -> tuple[EmbeddingModelInfo, ...]:
+    return (
+        EmbeddingModelInfo(
+            model_id="all-MiniLM-L6-v2",
+            label="all-MiniLM-L6-v2",
+            spec="sentence-transformers:all-MiniLM-L6-v2",
+            description="Compact general-purpose Sentence Transformers model.",
+        ),
+        EmbeddingModelInfo(
+            model_id="all-MiniLM-L12-v2",
+            label="all-MiniLM-L12-v2",
+            spec="sentence-transformers:all-MiniLM-L12-v2",
+            description="Larger MiniLM variant for slightly stronger retrieval.",
         ),
     )
 
@@ -313,12 +365,55 @@ def register_embedder_descriptor(
     return None
 
 
+def register_embedder_models(
+    provider: str,
+    factory: Callable[[], Sequence[EmbeddingModelInfo]] | None = None,
+    *,
+    replace: bool = False,
+) -> (
+    Callable[
+        [Callable[[], Sequence[EmbeddingModelInfo]]],
+        Callable[[], Sequence[EmbeddingModelInfo]],
+    ]
+    | None
+):
+    """Register a model-listing callback for an embedding provider.
+
+    Also usable as a decorator when ``factory`` is omitted — see
+    :func:`register_embedder`.
+    """
+    if factory is None:
+        def decorator(
+            actual_factory: Callable[[], Sequence[EmbeddingModelInfo]],
+        ) -> Callable[[], Sequence[EmbeddingModelInfo]]:
+            register_embedder_models(provider, actual_factory, replace=replace)
+            return actual_factory
+
+        return decorator
+
+    key = provider.strip().lower()
+    if not key:
+        raise ValueError("provider name must be non-empty")
+    if ":" in key:
+        raise ValueError("embedding provider name must not contain ':'")
+    if not callable(factory):
+        raise TypeError("embedding provider model lister must be callable")
+    with _REGISTRY_LOCK:
+        if key in _MODEL_LISTERS and not replace:
+            raise ValueError(
+                f"embedding provider model lister for {provider!r} is already registered"
+            )
+        _MODEL_LISTERS[key] = factory
+    return None
+
+
 def unregister_embedder(provider: str) -> None:
     """Remove a provider registration (primarily for tests)."""
     key = provider.strip().lower()
     with _REGISTRY_LOCK:
         _PROVIDERS.pop(key, None)
         _DESCRIPTOR_FACTORIES.pop(key, None)
+        _MODEL_LISTERS.pop(key, None)
         _INSTANCE_CACHE.clear()
 
 
@@ -366,6 +461,90 @@ def list_embedding_provider_descriptors() -> list[EmbedderDescriptor]:
     return [describe_embedder(provider) for provider in list_embedding_providers()]
 
 
+def list_embedding_models(provider: str) -> list[EmbeddingModelInfo]:
+    """Return model ids advertised by ``provider`` (presets and/or live listing)."""
+    key = provider.strip().lower()
+    if not key:
+        raise ValueError("provider name must be non-empty")
+    _ensure_entry_points_loaded()
+    with _REGISTRY_LOCK:
+        if key not in _PROVIDERS:
+            available = ", ".join(sorted(_PROVIDERS)) or "(none)"
+            raise UnknownEmbeddingModelError(
+                f"Unknown embedding provider {provider!r}. "
+                f"Registered providers: {available}."
+            )
+        lister = _MODEL_LISTERS.get(key)
+    if lister is None:
+        descriptor = describe_embedder(key)
+        default_id = descriptor.default_model_id.strip()
+        if not default_id:
+            return []
+        return [
+            EmbeddingModelInfo(
+                model_id=default_id,
+                label=default_id,
+                spec=f"{key}:{default_id}",
+            )
+        ]
+    models = list(lister())
+    for item in models:
+        if not isinstance(item, EmbeddingModelInfo):
+            raise TypeError(
+                f"Embedding model lister for {provider!r} must return EmbeddingModelInfo values."
+            )
+    return models
+
+
+def preflight_embedder(model: str = "hashing") -> EmbedderPreflightResult:
+    """Check whether ``model`` can be resolved without instantiating heavy runtimes.
+
+    Validates the provider exists and, when the descriptor requires an API key,
+    that ``capabilities.credential_env`` is set in the environment. Does not
+    download models or call remote APIs.
+    """
+    try:
+        provider, model_id = parse_model_spec(model)
+    except UnknownEmbeddingModelError as exc:
+        return EmbedderPreflightResult(
+            ok=False,
+            provider="",
+            model_id="",
+            detail=str(exc),
+        )
+    try:
+        descriptor = describe_embedder(provider)
+    except UnknownEmbeddingModelError as exc:
+        return EmbedderPreflightResult(
+            ok=False,
+            provider=provider,
+            model_id=model_id,
+            detail=str(exc),
+        )
+    caps = descriptor.capabilities
+    if caps.requires_api_key:
+        env_name = (caps.credential_env or "").strip()
+        if not env_name:
+            return EmbedderPreflightResult(
+                ok=False,
+                provider=provider,
+                model_id=model_id,
+                detail=(
+                    f"Provider {provider!r} requires an API key but did not "
+                    "advertise capabilities.credential_env."
+                ),
+            )
+        if not os.environ.get(env_name, "").strip():
+            return EmbedderPreflightResult(
+                ok=False,
+                provider=provider,
+                model_id=model_id,
+                missing_credential_env=env_name,
+                detail=f"Set the {env_name} environment variable before converting or searching.",
+            )
+    return EmbedderPreflightResult(ok=True, provider=provider, model_id=model_id)
+
+
 def _register_builtins() -> None:
     with _REGISTRY_LOCK:
         _PROVIDERS.setdefault("hashing", _hashing_factory)
@@ -374,6 +553,8 @@ def _register_builtins() -> None:
         _DESCRIPTOR_FACTORIES.setdefault(
             "sentence-transformers", _sentence_transformers_descriptor
         )
+        _MODEL_LISTERS.setdefault("hashing", _hashing_models)
+        _MODEL_LISTERS.setdefault("sentence-transformers", _sentence_transformers_models)
 
 
 def _load_entry_point_group(group: str) -> list[Any]:
@@ -410,6 +591,16 @@ def _ensure_entry_points_loaded() -> None:
                 continue
             if callable(factory):
                 _DESCRIPTOR_FACTORIES[name] = factory
+        for entry in _load_entry_point_group(_MODELS_ENTRY_POINT_GROUP):
+            name = entry.name.strip().lower()
+            if not name or name in _MODEL_LISTERS:
+                continue
+            try:
+                factory = entry.load()
+            except Exception:  # noqa: BLE001, S112
+                continue
+            if callable(factory):
+                _MODEL_LISTERS[name] = factory
         _ENTRY_POINTS_LOADED = True
 
 
@@ -419,6 +610,7 @@ def reset_embedding_registry(*, builtins: bool = True) -> None:
     with _REGISTRY_LOCK:
         _PROVIDERS.clear()
         _DESCRIPTOR_FACTORIES.clear()
+        _MODEL_LISTERS.clear()
         _INSTANCE_CACHE.clear()
         _ENTRY_POINTS_LOADED = False
         if builtins:
@@ -431,15 +623,17 @@ def parse_model_spec(model: str | None) -> tuple[str, str]:
     Accepted forms:
 
     - ``provider:model-id`` (preferred)
-    - Legacy aliases: ``hashing``, ``vera-hashing-384``, ``all-MiniLM-L6-v2``,
-      and ``sentence-transformers/<id>``
+    - Legacy aliases: ``hashing``, ``vera-hashing-384``, ``vera-hashing-<N>``,
+      ``all-MiniLM-L6-v2``, and ``sentence-transformers/<id>``
     """
     normalized = (model or "hashing").strip()
     if not normalized:
         normalized = "hashing"
 
-    if normalized in {"hashing", "vera-hashing-384"}:
+    if normalized == "hashing":
         return "hashing", "vera-hashing-384"
+    if _HASHING_NAME_RE.match(normalized):
+        return "hashing", normalized
     if normalized == "all-MiniLM-L6-v2":
         return "sentence-transformers", "all-MiniLM-L6-v2"
     if normalized.startswith("sentence-transformers/"):

--- a/packages/vera-doc/src/vera/core/embeddings.py
+++ b/packages/vera-doc/src/vera/core/embeddings.py
@@ -3,16 +3,27 @@ from __future__ import annotations
 import hashlib
 import re
 import threading
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from importlib.metadata import entry_points
 from typing import Any, Callable, Iterable, Protocol
 
 import numpy as np
 
+from .embedder_descriptors import (
+    EmbedderCapabilities,
+    EmbedderDescriptor,
+    fields_from_dataclass,
+    generic_embedder_descriptor,
+)
+from .embedder_options import EmbedderOptions
+
 _TOKEN_RE = re.compile(r"[A-Za-z0-9_]+")
 _ENTRY_POINT_GROUP = "vera.embedders"
+_DESCRIPTOR_ENTRY_POINT_GROUP = "vera.embedder_descriptors"
 _REGISTRY_LOCK = threading.RLock()
 _PROVIDERS: dict[str, Callable[..., EmbeddingFunction]] = {}
+_DESCRIPTOR_FACTORIES: dict[str, Callable[[], EmbedderDescriptor]] = {}
 _ENTRY_POINTS_LOADED = False
 _INSTANCE_CACHE: dict[tuple[Any, ...], EmbeddingFunction] = {}
 
@@ -60,6 +71,50 @@ class UnknownEmbeddingModelError(ValueError):
     """Raised when a model spec cannot be resolved to a registered provider."""
 
 
+@dataclass(frozen=True)
+class HashingOptions(EmbedderOptions):
+    """Settings for the built-in hashing embedder."""
+
+    dimension: int = field(
+        default=384,
+        metadata={
+            "label": "Dimension",
+            "description": "Output vector length for the hashing embedder.",
+            "minimum": 8,
+            "maximum": 4096,
+            "step": 8,
+        },
+    )
+
+
+@dataclass(frozen=True)
+class SentenceTransformersOptions(EmbedderOptions):
+    """Settings for the Sentence Transformers provider."""
+
+    device: str = field(
+        default="",
+        metadata={
+            "label": "Device",
+            "description": (
+                "Optional torch device (for example cpu or cuda). "
+                "Leave blank to let Sentence Transformers choose."
+            ),
+            "allow_empty": True,
+            "placeholder": "cpu",
+        },
+    )
+    batch_size: int = field(
+        default=32,
+        metadata={
+            "label": "Batch size",
+            "description": "Texts encoded per Sentence Transformers batch.",
+            "minimum": 1,
+            "maximum": 2048,
+            "step": 1,
+        },
+    )
+
+
 @dataclass
 class HashingEmbedder:
     """Deterministic offline lexical embedder for portable tests and no-network use."""
@@ -86,19 +141,16 @@ class HashingEmbedder:
 
 
 class SentenceTransformerEmbedder:
-    def __init__(self, model_name: str, **config: Any):
+    def __init__(self, model_name: str, *, device: str = "", batch_size: int = 32):
         from sentence_transformers import SentenceTransformer
 
         self.model_name = model_name
         self.normalization = "l2"
-        encode_kwargs = {}
-        if "device" in config and config["device"] is not None:
-            self._model = SentenceTransformer(model_name, device=config["device"])
+        if device:
+            self._model = SentenceTransformer(model_name, device=device)
         else:
             self._model = SentenceTransformer(model_name)
-        if "batch_size" in config and config["batch_size"] is not None:
-            encode_kwargs["batch_size"] = int(config["batch_size"])
-        self._encode_kwargs = encode_kwargs
+        self._encode_kwargs = {"batch_size": int(batch_size)}
         get_dim = getattr(self._model, "get_embedding_dimension", None) or self._model.get_sentence_embedding_dimension
         dim = get_dim()
         self.dimension = int(dim or len(self.embed(["dimension probe"])[0]))
@@ -109,11 +161,11 @@ class SentenceTransformerEmbedder:
 
 
 def _hashing_factory(model_id: str = "vera-hashing-384", **config: Any) -> HashingEmbedder:
-    dimension = int(config.get("dimension", 384))
-    name = model_id.strip() or "vera-hashing-384"
+    options = HashingOptions.from_mapping(config)
+    name = (model_id or "").strip() or "vera-hashing-384"
     if name in {"hashing", "vera-hashing-384"}:
         name = "vera-hashing-384"
-    return HashingEmbedder(dimension=dimension, model_name=name)
+    return HashingEmbedder(dimension=options.dimension, model_name=name)
 
 
 def _sentence_transformers_factory(model_id: str, **config: Any) -> SentenceTransformerEmbedder:
@@ -127,28 +179,138 @@ def _sentence_transformers_factory(model_id: str, **config: Any) -> SentenceTran
         model_name = model_id
     else:
         model_name = f"sentence-transformers/{model_id}"
-    return SentenceTransformerEmbedder(model_name, **config)
+    options = SentenceTransformersOptions.from_mapping(config)
+    return SentenceTransformerEmbedder(
+        model_name,
+        device=options.device,
+        batch_size=options.batch_size,
+    )
+
+
+def _hashing_descriptor() -> EmbedderDescriptor:
+    return EmbedderDescriptor(
+        provider="hashing",
+        label="hashing — deterministic offline embedder",
+        description=(
+            "Local lexical hashing embedder for portable tests and no-network use. "
+            "Does not require model downloads or API keys."
+        ),
+        default_model_id="vera-hashing-384",
+        example_specs=("hashing", "hashing:vera-hashing-384", "vera-hashing-384"),
+        capabilities=EmbedderCapabilities(
+            requires_network=False,
+            requires_api_key=False,
+            local_model=True,
+            configurable_dimension=True,
+        ),
+        fields=fields_from_dataclass(HashingOptions),
+    )
+
+
+def _sentence_transformers_descriptor() -> EmbedderDescriptor:
+    return EmbedderDescriptor(
+        provider="sentence-transformers",
+        label="sentence-transformers — local neural embeddings",
+        description=(
+            "Sentence Transformers models via the optional ml extra "
+            "(for example all-MiniLM-L6-v2)."
+        ),
+        default_model_id="all-MiniLM-L6-v2",
+        example_specs=(
+            "sentence-transformers:all-MiniLM-L6-v2",
+            "sentence-transformers/all-MiniLM-L6-v2",
+            "all-MiniLM-L6-v2",
+        ),
+        capabilities=EmbedderCapabilities(
+            requires_network=True,
+            requires_api_key=False,
+            local_model=True,
+            configurable_dimension=False,
+        ),
+        fields=fields_from_dataclass(SentenceTransformersOptions),
+        notes=(
+            "Install vera-doc[ml] (or sentence-transformers) before first use. "
+            "The first resolve may download model weights.",
+        ),
+    )
 
 
 def register_embedder(
     provider: str,
-    factory: Callable[..., EmbeddingFunction],
+    factory: Callable[..., EmbeddingFunction] | None = None,
     *,
     replace: bool = False,
-) -> None:
+) -> Callable[[Callable[..., EmbeddingFunction]], Callable[..., EmbeddingFunction]] | None:
     """Register an embedding provider factory under ``provider``.
 
     Factories are called as ``factory(model_id, **config)`` and must return an
     object satisfying :class:`EmbeddingFunction`.
+
+    Called with both arguments, this registers ``factory`` immediately and
+    returns ``None``. Omit ``factory`` to use it as a decorator::
+
+        @register_embedder("myexperiment")
+        def create_embedder(model_id: str, **config):
+            return MyEmbedder(model_id, **config)
     """
+    if factory is None:
+        def decorator(
+            actual_factory: Callable[..., EmbeddingFunction],
+        ) -> Callable[..., EmbeddingFunction]:
+            register_embedder(provider, actual_factory, replace=replace)
+            return actual_factory
+
+        return decorator
+
     key = provider.strip().lower()
     if not key:
         raise ValueError("provider name must be non-empty")
+    if ":" in key:
+        raise ValueError("embedding provider name must not contain ':'")
+    if not callable(factory):
+        raise TypeError("embedding provider factory must be callable")
     with _REGISTRY_LOCK:
         if key in _PROVIDERS and not replace:
             raise ValueError(f"embedding provider {provider!r} is already registered")
         _PROVIDERS[key] = factory
         _INSTANCE_CACHE.clear()
+    return None
+
+
+def register_embedder_descriptor(
+    provider: str,
+    factory: Callable[[], EmbedderDescriptor] | None = None,
+    *,
+    replace: bool = False,
+) -> Callable[[Callable[[], EmbedderDescriptor]], Callable[[], EmbedderDescriptor]] | None:
+    """Register a descriptor factory for an embedding provider.
+
+    Also usable as a decorator when ``factory`` is omitted — see
+    :func:`register_embedder`.
+    """
+    if factory is None:
+        def decorator(
+            actual_factory: Callable[[], EmbedderDescriptor],
+        ) -> Callable[[], EmbedderDescriptor]:
+            register_embedder_descriptor(provider, actual_factory, replace=replace)
+            return actual_factory
+
+        return decorator
+
+    key = provider.strip().lower()
+    if not key:
+        raise ValueError("provider name must be non-empty")
+    if ":" in key:
+        raise ValueError("embedding provider name must not contain ':'")
+    if not callable(factory):
+        raise TypeError("embedding provider descriptor factory must be callable")
+    with _REGISTRY_LOCK:
+        if key in _DESCRIPTOR_FACTORIES and not replace:
+            raise ValueError(
+                f"embedding provider descriptor for {provider!r} is already registered"
+            )
+        _DESCRIPTOR_FACTORIES[key] = factory
+    return None
 
 
 def unregister_embedder(provider: str) -> None:
@@ -156,6 +318,7 @@ def unregister_embedder(provider: str) -> None:
     key = provider.strip().lower()
     with _REGISTRY_LOCK:
         _PROVIDERS.pop(key, None)
+        _DESCRIPTOR_FACTORIES.pop(key, None)
         _INSTANCE_CACHE.clear()
 
 
@@ -172,10 +335,53 @@ def list_embedding_providers() -> list[str]:
         return sorted(_PROVIDERS)
 
 
+def describe_embedder(provider: str) -> EmbedderDescriptor:
+    """Return metadata for an installed provider without instantiating it."""
+    key = provider.strip().lower()
+    if not key:
+        raise ValueError("provider name must be non-empty")
+    _ensure_entry_points_loaded()
+    with _REGISTRY_LOCK:
+        if key not in _PROVIDERS:
+            available = ", ".join(sorted(_PROVIDERS)) or "(none)"
+            raise UnknownEmbeddingModelError(
+                f"Unknown embedding provider {provider!r}. "
+                f"Registered providers: {available}. "
+                "Install a plugin that registers under the 'vera.embedders' "
+                "entry-point group, or call register_embedder()."
+            )
+        factory = _DESCRIPTOR_FACTORIES.get(key)
+        if factory is None:
+            return generic_embedder_descriptor(key)
+        descriptor = factory()
+        if not isinstance(descriptor, EmbedderDescriptor):
+            raise TypeError(
+                f"Embedding provider descriptor for {provider!r} must return EmbedderDescriptor."
+            )
+        return descriptor
+
+
+def list_embedding_provider_descriptors() -> list[EmbedderDescriptor]:
+    """Return descriptors for each installed embedding provider."""
+    return [describe_embedder(provider) for provider in list_embedding_providers()]
+
+
 def _register_builtins() -> None:
     with _REGISTRY_LOCK:
         _PROVIDERS.setdefault("hashing", _hashing_factory)
         _PROVIDERS.setdefault("sentence-transformers", _sentence_transformers_factory)
+        _DESCRIPTOR_FACTORIES.setdefault("hashing", _hashing_descriptor)
+        _DESCRIPTOR_FACTORIES.setdefault(
+            "sentence-transformers", _sentence_transformers_descriptor
+        )
+
+
+def _load_entry_point_group(group: str) -> list[Any]:
+    try:
+        selected = entry_points(group=group)
+    except TypeError:  # pragma: no cover - Python <3.10 compatibility path
+        selected = entry_points().get(group, [])  # type: ignore[index]
+    return list(selected)
 
 
 def _ensure_entry_points_loaded() -> None:
@@ -184,19 +390,26 @@ def _ensure_entry_points_loaded() -> None:
         if _ENTRY_POINTS_LOADED:
             return
         _register_builtins()
-        try:
-            selected = entry_points(group=_ENTRY_POINT_GROUP)
-        except TypeError:  # pragma: no cover - Python <3.10 compatibility path
-            selected = entry_points().get(_ENTRY_POINT_GROUP, [])  # type: ignore[index]
-        for entry in selected:
+        for entry in _load_entry_point_group(_ENTRY_POINT_GROUP):
             name = entry.name.strip().lower()
             if not name or name in _PROVIDERS:
                 continue
             try:
                 factory = entry.load()
-            except Exception:
+            except Exception:  # noqa: BLE001, S112 - one broken plugin must not hide others
                 continue
-            _PROVIDERS[name] = factory
+            if callable(factory):
+                _PROVIDERS[name] = factory
+        for entry in _load_entry_point_group(_DESCRIPTOR_ENTRY_POINT_GROUP):
+            name = entry.name.strip().lower()
+            if not name or name in _DESCRIPTOR_FACTORIES:
+                continue
+            try:
+                factory = entry.load()
+            except Exception:  # noqa: BLE001, S112
+                continue
+            if callable(factory):
+                _DESCRIPTOR_FACTORIES[name] = factory
         _ENTRY_POINTS_LOADED = True
 
 
@@ -205,6 +418,7 @@ def reset_embedding_registry(*, builtins: bool = True) -> None:
     global _ENTRY_POINTS_LOADED
     with _REGISTRY_LOCK:
         _PROVIDERS.clear()
+        _DESCRIPTOR_FACTORIES.clear()
         _INSTANCE_CACHE.clear()
         _ENTRY_POINTS_LOADED = False
         if builtins:
@@ -251,19 +465,41 @@ def _cache_key(provider: str, model_id: str, config: dict[str, Any]) -> tuple[An
     return (provider, model_id, items)
 
 
-def get_embedder(model: str = "hashing", **config: Any) -> EmbeddingFunction:
+def _merge_embedder_config(
+    embedder_options: Mapping[str, Any] | None,
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    if embedder_options:
+        if not isinstance(embedder_options, Mapping):
+            raise TypeError("embedder_options must be a mapping of string keys")
+        merged.update({str(key): value for key, value in embedder_options.items()})
+    merged.update(config)
+    return merged
+
+
+def get_embedder(
+    model: str = "hashing",
+    *,
+    embedder_options: Mapping[str, Any] | None = None,
+    **config: Any,
+) -> EmbeddingFunction:
     """Resolve ``model`` to a registered embedder instance.
 
     Args:
         model: Model spec string (``provider:model-id`` or a legacy alias).
+        embedder_options: Provider-owned options mapping (same keys a plugin's
+            ``Options`` dataclass advertises). Keyword ``config`` values win
+            for the same key.
         **config: Provider-specific keyword arguments forwarded to the factory.
 
     Raises:
         UnknownEmbeddingModelError: When the provider is not registered.
     """
     provider, model_id = parse_model_spec(model)
+    resolved = _merge_embedder_config(embedder_options, config)
     _ensure_entry_points_loaded()
-    key = _cache_key(provider, model_id, config)
+    key = _cache_key(provider, model_id, resolved)
     with _REGISTRY_LOCK:
         cached = _INSTANCE_CACHE.get(key)
         if cached is not None:
@@ -277,7 +513,7 @@ def get_embedder(model: str = "hashing", **config: Any) -> EmbeddingFunction:
                 "Install a plugin that registers under the 'vera.embedders' "
                 "entry-point group, or call register_embedder()."
             )
-        embedder = factory(model_id, **config)
+        embedder = factory(model_id, **resolved)
         _INSTANCE_CACHE[key] = embedder
         return embedder
 

--- a/packages/vera-doc/src/vera/core/option_parsing.py
+++ b/packages/vera-doc/src/vera/core/option_parsing.py
@@ -1,0 +1,91 @@
+"""Helpers for strict plugin-owned option parsing."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import fields
+from typing import Any
+
+
+def allowed_keys_from_dataclass(cls: type) -> set[str]:
+    """Return a dataclass's field names as the allowed option keys.
+
+    Keeps an Options dataclass the single source of truth for which keys
+    ``from_mapping`` accepts, instead of a hand-maintained set kept in sync
+    with the field list by hand.
+    """
+    return {item.name for item in fields(cls)}
+
+
+def require_mapping(raw: Mapping[str, Any] | None, *, label: str) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise TypeError(f"{label} must be a mapping of string keys")
+    return {str(key): value for key, value in raw.items()}
+
+
+def reject_unknown_keys(
+    raw: Mapping[str, Any],
+    *,
+    allowed: set[str],
+    ignored: set[str] | None = None,
+    label: str,
+) -> dict[str, Any]:
+    """Return only allowed keys; reject unknown non-ignored keys."""
+    ignored_keys = ignored or set()
+    unknown = sorted(key for key in raw if key not in allowed and key not in ignored_keys)
+    if unknown:
+        names = ", ".join(repr(key) for key in unknown)
+        raise ValueError(f"Unknown {label} option(s): {names}")
+    return {key: raw[key] for key in allowed if key in raw}
+
+
+def require_positive_int(value: Any, *, name: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if parsed <= 0:
+        raise ValueError(f"{name} must be positive")
+    return parsed
+
+
+def require_non_negative_int(value: Any, *, name: str) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if parsed < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return parsed
+
+
+def require_string(value: Any, *, name: str, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    text = value.strip()
+    if not allow_empty and not text:
+        raise ValueError(f"{name} must not be empty")
+    return text
+
+
+def require_bool(value: Any, *, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "off", ""}:
+            return False
+    raise ValueError(f"{name} must be a boolean")
+
+
+def require_choice(value: Any, *, name: str, choices: set[str]) -> str:
+    text = require_string(value, name=name)
+    normalized = text.lower()
+    if normalized not in choices:
+        allowed = ", ".join(sorted(choices))
+        raise ValueError(f"Unsupported {name} {value!r}; use one of: {allowed}")
+    return normalized

--- a/packages/vera-ingest/src/vera_ingest/convert.py
+++ b/packages/vera-ingest/src/vera_ingest/convert.py
@@ -112,6 +112,7 @@ def convert(
     ocr_dpi: int = 300,
     ocr_download: bool = False,
     pipeline_options: dict[str, Any] | None = None,
+    embedder_options: dict[str, Any] | None = None,
     cancel: Any | None = None,
 ) -> str:
     """Convert a PDF into a validated ``.vera`` archive.
@@ -142,6 +143,8 @@ def convert(
             checksum-verified download of missing Tesseract language data.
         pipeline_options: Explicit provider-owned options. These override
             compatibility aliases for the same keys.
+        embedder_options: Explicit provider-owned embedding options forwarded
+            to :func:`~vera.get_embedder` when ``embedding_function`` is omitted.
         cancel: Optional cancellation token with ``raise_if_cancelled()``.
 
     Returns:
@@ -160,7 +163,11 @@ def convert(
 
     _, pipeline_variant = parse_ingest_pipeline_spec(parser)
     pipeline = get_ingest_pipeline(parser)
-    embedder = embedding_function if embedding_function is not None else get_embedder(model)
+    embedder = (
+        embedding_function
+        if embedding_function is not None
+        else get_embedder(model, embedder_options=embedder_options)
+    )
     resolved_options = prepare_pipeline_options(
         spec=parser,
         pipeline_options=pipeline_options,
@@ -472,6 +479,7 @@ def batch_convert(
     ocr_dpi: int = 300,
     ocr_download: bool = False,
     pipeline_options: dict[str, Any] | None = None,
+    embedder_options: dict[str, Any] | None = None,
     progress: Callable[[int, int, str], None] | None = None,
     cancel: Any | None = None,
 ) -> dict[str, Any]:
@@ -494,6 +502,8 @@ def batch_convert(
         ocr_dpi: OCR DPI passed to :func:`convert`.
         ocr_download: OCR language auto-download flag passed to :func:`convert`.
         pipeline_options: Explicit provider-owned options passed to :func:`convert`.
+        embedder_options: Explicit provider-owned embedding options passed to
+            :func:`convert`.
         progress: Optional ``(current, total, filename)`` callback.
         cancel: Optional cancellation token.
 
@@ -510,7 +520,11 @@ def batch_convert(
     """
     # Resolve once up front so bad providers fail before discovery or PDF work.
     get_ingest_pipeline(parser)
-    embedder = embedding_function if embedding_function is not None else get_embedder(model)
+    embedder = (
+        embedding_function
+        if embedding_function is not None
+        else get_embedder(model, embedder_options=embedder_options)
+    )
 
     root, pdfs = _resolve_batch_pdfs(
         directory,

--- a/packages/vera-ingest/src/vera_ingest/option_parsing.py
+++ b/packages/vera-ingest/src/vera_ingest/option_parsing.py
@@ -1,91 +1,30 @@
-"""Helpers for strict plugin-owned option parsing."""
+"""Helpers for strict plugin-owned option parsing.
+
+Canonical implementation lives in :mod:`vera.core.option_parsing`. This module
+re-exports those helpers so ingest pipelines and older imports keep working
+without duplicating validators.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from dataclasses import fields
-from typing import Any
+from vera.core.option_parsing import (
+    allowed_keys_from_dataclass,
+    reject_unknown_keys,
+    require_bool,
+    require_choice,
+    require_mapping,
+    require_non_negative_int,
+    require_positive_int,
+    require_string,
+)
 
-
-def allowed_keys_from_dataclass(cls: type) -> set[str]:
-    """Return a dataclass's field names as the allowed ``pipeline_options`` keys.
-
-    Keeps an Options dataclass the single source of truth for which keys
-    ``from_mapping`` accepts, instead of a hand-maintained set kept in sync
-    with the field list by hand.
-    """
-    return {item.name for item in fields(cls)}
-
-
-def require_mapping(raw: Mapping[str, Any] | None, *, label: str) -> dict[str, Any]:
-    if raw is None:
-        return {}
-    if not isinstance(raw, Mapping):
-        raise TypeError(f"{label} must be a mapping of string keys")
-    return {str(key): value for key, value in raw.items()}
-
-
-def reject_unknown_keys(
-    raw: Mapping[str, Any],
-    *,
-    allowed: set[str],
-    ignored: set[str] | None = None,
-    label: str,
-) -> dict[str, Any]:
-    """Return only allowed keys; reject unknown non-ignored keys."""
-    ignored_keys = ignored or set()
-    unknown = sorted(key for key in raw if key not in allowed and key not in ignored_keys)
-    if unknown:
-        names = ", ".join(repr(key) for key in unknown)
-        raise ValueError(f"Unknown {label} option(s): {names}")
-    return {key: raw[key] for key in allowed if key in raw}
-
-
-def require_positive_int(value: Any, *, name: str) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be an integer") from exc
-    if parsed <= 0:
-        raise ValueError(f"{name} must be positive")
-    return parsed
-
-
-def require_non_negative_int(value: Any, *, name: str) -> int:
-    try:
-        parsed = int(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be an integer") from exc
-    if parsed < 0:
-        raise ValueError(f"{name} must be non-negative")
-    return parsed
-
-
-def require_string(value: Any, *, name: str, allow_empty: bool = False) -> str:
-    if not isinstance(value, str):
-        raise ValueError(f"{name} must be a string")
-    text = value.strip()
-    if not allow_empty and not text:
-        raise ValueError(f"{name} must not be empty")
-    return text
-
-
-def require_bool(value: Any, *, name: str) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        lowered = value.strip().lower()
-        if lowered in {"true", "1", "yes", "y", "on"}:
-            return True
-        if lowered in {"false", "0", "no", "n", "off", ""}:
-            return False
-    raise ValueError(f"{name} must be a boolean")
-
-
-def require_choice(value: Any, *, name: str, choices: set[str]) -> str:
-    text = require_string(value, name=name)
-    normalized = text.lower()
-    if normalized not in choices:
-        allowed = ", ".join(sorted(choices))
-        raise ValueError(f"Unsupported {name} {value!r}; use one of: {allowed}")
-    return normalized
+__all__ = [
+    "allowed_keys_from_dataclass",
+    "reject_unknown_keys",
+    "require_bool",
+    "require_choice",
+    "require_mapping",
+    "require_non_negative_int",
+    "require_positive_int",
+    "require_string",
+]

--- a/skills/vera/references/cli-reference.md
+++ b/skills/vera/references/cli-reference.md
@@ -63,6 +63,10 @@ Options:
   Values coerce to bool (`true`/`false`), int, or float when unambiguous;
   otherwise they remain strings. Explicit `--pipeline-option` values always
   override compatibility aliases for the same key.
+- `--embedder-option KEY=VALUE` is repeatable. Sets provider-owned
+  `embedder_options` entries (for example `--embedder-option batch_size=64`
+  or `--embedder-option dimension=256`). Values coerce the same way as
+  `--pipeline-option`.
 - `--recursive` recursively discovers PDFs in directory mode.
 - `--overwrite` replaces existing outputs in directory mode.
 - `--json` emits one JSON object.

--- a/tests/test_app_sidecar.py
+++ b/tests/test_app_sidecar.py
@@ -696,6 +696,9 @@ def test_sidecar_forwards_embedding_model_and_lists_providers(monkeypatch):
         }
     )
     providers = handle({"id": "embedding-providers", "action": "list_embedding_providers"})
+    described = handle(
+        {"id": "embedding-providers-describe", "action": "describe_embedding_providers"}
+    )
 
     assert converted["ok"] is True
     assert captured["model"] == "openai:text-embedding-3-small"
@@ -704,6 +707,9 @@ def test_sidecar_forwards_embedding_model_and_lists_providers(monkeypatch):
         "ok": True,
         "result": {"providers": ["hashing", "openai"]},
     }
+    assert described["ok"] is True
+    assert "providers" in described["result"]
+    assert isinstance(described["result"]["providers"], list)
 
 
 def test_source_action_materializes_cache_file(tmp_path):

--- a/tests/test_app_sidecar.py
+++ b/tests/test_app_sidecar.py
@@ -699,6 +699,16 @@ def test_sidecar_forwards_embedding_model_and_lists_providers(monkeypatch):
     described = handle(
         {"id": "embedding-providers-describe", "action": "describe_embedding_providers"}
     )
+    models = handle(
+        {
+            "id": "embedding-models",
+            "action": "list_embedding_models",
+            "provider": "hashing",
+        }
+    )
+    preflight = handle(
+        {"id": "embedding-preflight", "action": "preflight_embedder", "model": "hashing"}
+    )
 
     assert converted["ok"] is True
     assert captured["model"] == "openai:text-embedding-3-small"
@@ -710,6 +720,12 @@ def test_sidecar_forwards_embedding_model_and_lists_providers(monkeypatch):
     assert described["ok"] is True
     assert "providers" in described["result"]
     assert isinstance(described["result"]["providers"], list)
+    assert models["ok"] is True
+    assert models["result"]["provider"] == "hashing"
+    assert models["result"]["models"][0]["model_id"] == "vera-hashing-384"
+    assert preflight["ok"] is True
+    assert preflight["result"]["ok"] is True
+    assert preflight["result"]["provider"] == "hashing"
 
 
 def test_source_action_materializes_cache_file(tmp_path):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -101,6 +101,16 @@ def test_documented_cli_examples_parse():
             "ocr_mode=auto",
             "--json",
         ],
+        [
+            "convert",
+            "input.pdf",
+            "output.vera",
+            "--model",
+            "hashing",
+            "--embedder-option",
+            "dimension=256",
+            "--json",
+        ],
         ["inspect", "output.vera", "--json"],
         [
             "search",
@@ -158,12 +168,22 @@ def test_hardening_json_contracts_are_documented():
     assert "compatibility alias" in conversion.lower() or "Compatibility aliases" in conversion
     assert "ocr_language=en" in conversion
     assert "overlap" in conversion and "ocr_dpi" in conversion
+    assert "--embedder-option" in conversion
+    assert "embedder_options" in conversion
+    assert "describe_embedding_providers" in conversion or "creating-an-embedding-provider.md" in conversion
     assert "`--pipeline-option KEY=VALUE`" in cli_reference
+    assert "`--embedder-option KEY=VALUE`" in cli_reference
     assert "compatibility alias" in cli_reference.lower() or "Compatibility alias" in cli_reference
     assert "pipeline-owned typed options" in roadmap
     assert "`vera convert --pipeline-option KEY=VALUE`" in roadmap
     assert "describe_ingest_pipelines" in roadmap
     assert "PipelineConfigForm" in roadmap
+    assert "EmbedderOptions" in roadmap
+    assert "describe_embedding_providers" in roadmap
+    assert "--embedder-option" in roadmap
+    assert (DOCS / "creating-an-embedding-provider.md").is_file()
+    assert "EmbedderOptions" in (DOCS / "creating-an-embedding-provider.md").read_text(encoding="utf-8")
+    assert "vera.embedder_descriptors" in (DOCS / "creating-an-embedding-provider.md").read_text(encoding="utf-8")
     assert "skipped_files" in libraries
     assert "skipped_semantic_model_groups" in libraries
     assert "does not reopen archives" in libraries
@@ -189,6 +209,8 @@ def test_hardening_json_contracts_are_documented():
     assert "only explicit `search_start` and `search_done`" in desktop_architecture
     assert "Token-level `answer_delta`" in desktop_architecture
     assert "describe_ingest_pipelines" in desktop_architecture
+    assert "describe_embedding_providers" in desktop_architecture
+    assert "embedder_options" in desktop_architecture
     assert "pipeline_options" in desktop_architecture
     assert "PipelineConfigForm" in desktop_architecture
     assert "Advanced pipeline options" in desktop_architecture

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -181,9 +181,22 @@ def test_hardening_json_contracts_are_documented():
     assert "EmbedderOptions" in roadmap
     assert "describe_embedding_providers" in roadmap
     assert "--embedder-option" in roadmap
+    assert "preflight_embedder" in roadmap
+    assert "list_embedding_models" in roadmap
+    assert "credential_env" in roadmap
     assert (DOCS / "creating-an-embedding-provider.md").is_file()
-    assert "EmbedderOptions" in (DOCS / "creating-an-embedding-provider.md").read_text(encoding="utf-8")
-    assert "vera.embedder_descriptors" in (DOCS / "creating-an-embedding-provider.md").read_text(encoding="utf-8")
+    guide = (DOCS / "creating-an-embedding-provider.md").read_text(encoding="utf-8")
+    assert "EmbedderOptions" in guide
+    assert "vera.embedder_descriptors" in guide
+    assert "credential_env" in guide
+    assert "Do not put API keys in Options" in guide or "do not put secrets" in guide.lower()
+    assert "scope\": \"convert\"" in guide or "scope: convert" in guide or '"scope": "convert"' in guide
+    assert "vera.embedder_models" in guide
+    assert "preflight_embedder" in conversion
+    assert "credential_env" in conversion
+    assert "list_embedding_models" in desktop_architecture
+    assert "preflight_embedder" in desktop_architecture
+    assert "credential_env" in desktop_architecture
     assert "skipped_files" in libraries
     assert "skipped_semantic_model_groups" in libraries
     assert "does not reopen archives" in libraries

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -11,9 +11,11 @@ from vera.core.embeddings import (
     describe_embedder,
     deserialize_vector,
     get_embedder,
+    list_embedding_models,
     list_embedding_provider_descriptors,
     list_embedding_providers,
     parse_model_spec,
+    preflight_embedder,
     register_embedder,
     reset_embedding_registry,
     serialize_vector,
@@ -242,6 +244,11 @@ class TestGetEmbedder:
     def test_hashing_options_from_mapping(self):
         embedder = get_embedder("hashing", embedder_options={"dimension": 128})
         assert embedder.dimension == 128
+        assert embedder.model_name == "vera-hashing-128"
+        # Search-time resolve from the stored model_name recovers dimension.
+        again = get_embedder("vera-hashing-128")
+        assert again.dimension == 128
+        assert again.model_name == "vera-hashing-128"
         with pytest.raises(ValueError, match="Unknown Hashing option"):
             get_embedder("hashing", embedder_options={"typo": 1})
 
@@ -250,10 +257,50 @@ class TestGetEmbedder:
         assert hashing.provider == "hashing"
         assert hashing.field_keys() == {"dimension"}
         assert hashing.defaults()["dimension"] == 384
+        assert hashing.always_fields()[0].key == "dimension"
+        st = describe_embedder("sentence-transformers")
+        assert {item.key for item in st.convert_fields()} == {"device", "batch_size"}
         descriptors = list_embedding_provider_descriptors()
         providers = {item.provider for item in descriptors}
         assert "hashing" in providers
         assert "sentence-transformers" in providers
+
+    def test_list_embedding_models_and_preflight(self, monkeypatch):
+        models = list_embedding_models("hashing")
+        assert models[0].model_id == "vera-hashing-384"
+        assert models[0].spec.startswith("hashing:")
+        st_models = list_embedding_models("sentence-transformers")
+        assert any(item.model_id == "all-MiniLM-L6-v2" for item in st_models)
+        assert preflight_embedder("hashing").ok is True
+
+        from vera import EmbedderCapabilities, EmbedderDescriptor, register_embedder_descriptor
+
+        @register_embedder("unit-test-creds", replace=True)
+        def factory(model_id: str, **config):
+            return HashingEmbedder(model_name=f"creds/{model_id}")
+
+        register_embedder_descriptor(
+            "unit-test-creds",
+            lambda: EmbedderDescriptor(
+                provider="unit-test-creds",
+                label="creds",
+                capabilities=EmbedderCapabilities(
+                    requires_api_key=True,
+                    credential_env="UNIT_TEST_EMBED_KEY",
+                ),
+            ),
+            replace=True,
+        )
+        try:
+            monkeypatch.delenv("UNIT_TEST_EMBED_KEY", raising=False)
+            failed = preflight_embedder("unit-test-creds:alpha")
+            assert failed.ok is False
+            assert failed.missing_credential_env == "UNIT_TEST_EMBED_KEY"
+            monkeypatch.setenv("UNIT_TEST_EMBED_KEY", "secret")
+            assert preflight_embedder("unit-test-creds:alpha").ok is True
+        finally:
+            unregister_embedder("unit-test-creds")
+            clear_embedder_cache()
 
     def test_config_keyed_cache(self):
         calls: list[tuple[str, dict]] = []
@@ -304,6 +351,8 @@ class TestGetEmbedder:
                 return [FakeEntry()]
             if group == "vera.embedder_descriptors":
                 return [FakeDescriptorEntry()]
+            if group == "vera.embedder_models":
+                return []
             return []
 
         reset_embedding_registry(builtins=True)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -8,8 +8,10 @@ from vera.core.embeddings import (
     UnknownEmbeddingModelError,
     clear_embedder_cache,
     cosine_similarity,
+    describe_embedder,
     deserialize_vector,
     get_embedder,
+    list_embedding_provider_descriptors,
     list_embedding_providers,
     parse_model_spec,
     register_embedder,
@@ -17,6 +19,7 @@ from vera.core.embeddings import (
     serialize_vector,
     unregister_embedder,
 )
+from vera.core.embedder_descriptors import EmbedderDescriptor
 from vera import ChunkRecord, QueryResult, VeraDocument
 from vera_cli import str_to_bool
 from vera_ingest.types import ParsedPage
@@ -224,6 +227,34 @@ class TestGetEmbedder:
             unregister_embedder("unit-test-custom")
             clear_embedder_cache()
 
+    def test_register_embedder_decorator(self):
+        @register_embedder("unit-test-decorator", replace=True)
+        def factory(model_id: str, **config):
+            return HashingEmbedder(model_name=f"decorated/{model_id}")
+
+        try:
+            embedder = get_embedder("unit-test-decorator:beta")
+            assert embedder.model_name == "decorated/beta"
+        finally:
+            unregister_embedder("unit-test-decorator")
+            clear_embedder_cache()
+
+    def test_hashing_options_from_mapping(self):
+        embedder = get_embedder("hashing", embedder_options={"dimension": 128})
+        assert embedder.dimension == 128
+        with pytest.raises(ValueError, match="Unknown Hashing option"):
+            get_embedder("hashing", embedder_options={"typo": 1})
+
+    def test_describe_builtin_providers(self):
+        hashing = describe_embedder("hashing")
+        assert hashing.provider == "hashing"
+        assert hashing.field_keys() == {"dimension"}
+        assert hashing.defaults()["dimension"] == 384
+        descriptors = list_embedding_provider_descriptors()
+        providers = {item.provider for item in descriptors}
+        assert "hashing" in providers
+        assert "sentence-transformers" in providers
+
     def test_config_keyed_cache(self):
         calls: list[tuple[str, dict]] = []
 
@@ -258,9 +289,22 @@ class TestGetEmbedder:
                     model_name=f"ep/{model_id or 'default'}"
                 )
 
+        class FakeDescriptorEntry:
+            name = "ep-test"
+
+            def load(self):
+                return lambda: EmbedderDescriptor(
+                    provider="ep-test",
+                    label="ep-test",
+                    description="entry-point descriptor",
+                )
+
         def fake_entry_points(*, group=None):
-            assert group == "vera.embedders"
-            return [FakeEntry()]
+            if group == "vera.embedders":
+                return [FakeEntry()]
+            if group == "vera.embedder_descriptors":
+                return [FakeDescriptorEntry()]
+            return []
 
         reset_embedding_registry(builtins=True)
         monkeypatch.setattr(
@@ -270,6 +314,8 @@ class TestGetEmbedder:
         try:
             embedder = get_embedder("ep-test:widget")
             assert embedder.model_name == "ep/widget"
+            descriptor = describe_embedder("ep-test")
+            assert descriptor.description == "entry-point descriptor"
         finally:
             reset_embedding_registry(builtins=True)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Embedding providers on v0.3 already had a registry + `vera.embedders` entry points. Authoring was thinner than the post-#12 ingest model. This PR brings embedders in line with that pattern, then hardens the design where embedders differ from ingest.

### Authoring (ingest parity)

- **`EmbedderOptions`** + dataclass field `metadata` as the single source of truth
- **`EmbedderDescriptor`** / `fields_from_dataclass`, with `vera.embedder_descriptors`
- Decorator form of **`register_embedder`** / **`register_embedder_descriptor`**
- Built-in **hashing** / **sentence-transformers** advertise Options + descriptors
- **`embedder_options`** on convert, CLI **`--embedder-option`**, sidecar **`describe_embedding_providers`**
- Guide: [`docs/creating-an-embedding-provider.md`](docs/creating-an-embedding-provider.md)

### Hardening (embedder-specific)

- **Shared `option_parsing`**: `vera-ingest` re-exports `vera.core.option_parsing` (no duplicated validators)
- **No secrets in Options**: `capabilities.credential_env` + **`preflight_embedder`** (sidecar action included)
- **Model listing**: `vera.embedder_models` / **`list_embedding_models`** (sidecar action included)
- **Field `scope`**: `convert` (batch/device) vs `always` (archive identity); hashing encodes dimension as `vera-hashing-<N>` so search resolves correctly
- Authoring guide updated accordingly

### Still follow-ups (intentionally not in this PR)

- Convert UI forms from embedder descriptors (`PipelineConfigForm` equivalent)
- Secure desktop credential storage UI
- Official OpenAI / Voyage / Ollama packages

## Test plan

- [x] `uv run --extra dev python -m pytest -q`
- [ ] Spot-check `vera convert … --embedder-option dimension=256` → archive model `vera-hashing-256`
- [ ] Sidecar `describe_embedding_providers` / `list_embedding_models` / `preflight_embedder`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-014d9034-b776-447c-86c0-782a82b22ab4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-014d9034-b776-447c-86c0-782a82b22ab4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

