### PR TITLE
Rewrite README around the .vera format, CLI, agents, blocks, plugins, and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,13 @@ documents. It is built on the same packages described above. Download it from
 [GitHub Releases](https://github.com/dkylewillis/vera/releases/latest) and see
 the [desktop app guide](docs/desktop-app-getting-started.md).
 
+<img src="docs/assets/readme/hero-grounded-answer.png" alt="VERA desktop app with a .vera library in the sidebar, an answer with inline citations in the center, and the source PDF open in the document viewer with the supporting passage highlighted" width="85%">
+
+The screenshot shows the three panes working together: the library of `.vera`
+archives on the left, an answer with inline citations in the center, and the
+source document on the right with the cited passage highlighted via stored
+region coordinates.
+
 ## Documentation
 
 Preview the documentation locally with `uv run --extra docs mkdocs serve`, or

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 [![PyPI - vera-doc](https://img.shields.io/pypi/v/vera-doc?label=vera-doc)](https://pypi.org/project/vera-doc/)
 [![License](https://img.shields.io/github/license/dkylewillis/vera)](LICENSE)
 
-**Convert once. Search anywhere.**
-
 A `.vera` file is a portable embedded vector database: one self-contained
 SQLite file holding ready-made text chunks, pre-computed embeddings, a keyword
-index, citation metadata, and the original source document. Copy it, share it,
-or hand it to an LLM agent — it stays semantically searchable with no vector
-database, no embedding service, and no retrieval server.
+index, citation metadata, and the original source document. The file can be
+copied, shared, or handed to an LLM agent and searched in place — no vector
+database, embedding service, or retrieval server is required.
 
 ```bash
 pip install vera-cli
@@ -20,32 +18,34 @@ vera search manual.vera "when is stormwater detention required?" --json
 
 ## The vision
 
-Every application that wants semantic search over documents rebuilds the same
-pipeline — and every copy of that pipeline needs infrastructure:
+Semantic search over a document normally requires a multi-stage pipeline —
+parsing, chunking, embedding, and indexing — plus a running vector database to
+hold the result. Every application that wants to search the same document
+repeats all of it:
 
 ```text
-Today                                   VERA
-─────                                   ────
+Typical retrieval pipeline              VERA
+──────────────────────────              ────
 Source document                         Source document
     ↓                                       ↓
-Parse ──┐                               Convert once
-Chunk   │  repeated per app,                ↓
-Embed   │  requires a running           .vera file
-Index   │  vector database                  ↓
-    ↓ ──┘                               Search anywhere —
-Search                                  any machine, any app, any agent
+Parse ──┐                               vera convert
+Chunk   │  repeated per                     ↓  (full pipeline, run once)
+Embed   │  application; results         .vera file
+Index   │  live in a separate               ↓
+    ↓ ──┘  vector database              local search from any
+Search                                  machine, application, or agent
 ```
 
-VERA moves the expensive work into the file. A PDF preserves how a document
-*looks*; a `.vera` preserves what it *means* — the document plus a complete
-retrieval layer. Conversion happens once, then any compatible application can
-open the archive and run semantic, keyword, or hybrid search locally, offline,
-with citation-ready results that point back to the exact page and heading.
+VERA moves the pipeline output into the file itself. A `.vera` archive stores
+the parsed document together with its retrieval layer: chunks, embeddings, a
+keyword index, and citation metadata. Conversion runs once; afterwards any
+compatible application can open the archive and run semantic, keyword, or
+hybrid search locally and offline, with results that reference the source
+page and heading.
 
-The core motivation is AI agents: an agent should be able to semantically
-search a document the moment it receives one — no parsing step, no chunking
-strategy decisions, no embedding API calls, no vector database to stand up.
-With VERA, "set up retrieval" collapses into "open the file."
+The primary use case is AI agents. An agent that receives a `.vera` file can
+search it immediately — no parsing step, no chunking decisions, no embedding
+API calls, and no vector database to provision.
 
 ## Getting started
 
@@ -56,28 +56,29 @@ and offline OCR data:
 python -m pip install "vera-cli>=0.2.4"
 ```
 
-Convert a PDF and start asking questions:
+Convert a PDF and search it:
 
 ```bash
-# Parse, OCR (if needed), chunk, embed, and index — one validated output file
+# Parse, OCR (if needed), chunk, embed, and index into one validated file
 vera convert manual.pdf manual.vera
 
-# Hybrid search (semantic + keyword), citation-ready results
+# Hybrid search (semantic + keyword) with page and heading citations
 vera search manual.vera "stormwater detention requirements" --top-k 5
 
-# What's inside?
+# Report pages, chunks, embedding model, parser, and metadata
 vera inspect manual.vera
 
-# Structurally sound?  exit 0 = valid
+# Check integrity (exit code 0 = valid)
 vera validate manual.vera
 
-# Get the original PDF back out
+# Recover the embedded original PDF
 vera export manual.vera exported.pdf
 ```
 
-The default embedding model is a deterministic local hashing embedder — no
-downloads, no API keys, fully offline. For stronger neural retrieval, install
-Sentence Transformers support and pick a model at convert time:
+The default embedding model is a deterministic local hashing embedder: no
+model downloads, no API keys, and no network access. For stronger retrieval
+quality, install Sentence Transformers support and select a model at convert
+time:
 
 ```bash
 python -m pip install "vera-doc[ml]"
@@ -87,10 +88,10 @@ vera convert manual.pdf --model sentence-transformers:all-MiniLM-L6-v2
 See the [getting started guide](docs/getting-started.md) for the full
 walkthrough and [CLI recipes](docs/examples.md) for more patterns.
 
-## What it can do (via CLI)
+## CLI functionality
 
-Every one-shot command accepts `--json` for machine-readable output, which
-makes the whole surface scriptable by agents and applications:
+Every one-shot command accepts `--json` for machine-readable output, so the
+full command surface is scriptable by agents and applications:
 
 | Command | What it does |
 |---------|--------------|
@@ -104,29 +105,29 @@ makes the whole surface scriptable by agents and applications:
 | `vera ocr-languages` | List or fetch Tesseract OCR language data |
 | `vera mcp` | Serve everything above to AI agents over MCP (stdio) |
 
-A few useful compositions:
+Common compositions:
 
 ```bash
 # Search a folder of .vera files as one corpus (results carry a "file" field)
 vera search ./library "landscape buffer requirements" --top-k 5 --json
 
-# Make large libraries fast with a persistent, rebuildable index
+# Build a persistent, rebuildable index for large libraries
 vera index build ./library --recursive
 vera index update ./library
 
-# Pull in neighboring prose, figure metadata, or page-coordinate highlights
+# Include neighboring chunks, figure metadata, or page-coordinate highlights
 vera search manual.vera "pipe sizing chart" --json --context-chunks 1 --figures --regions
 
-# Exact phrases and section numbers → keyword; paraphrased questions → semantic
+# Keyword mode for exact phrases and section numbers; semantic for paraphrases
 vera search manual.vera "section 4.2" --mode keyword
 vera search manual.vera "how big should the pond be" --mode semantic
 
-# Batch-convert a nested PDF library, then track retrieval quality
+# Batch-convert a nested PDF library, then measure retrieval quality
 vera convert ./proposals --recursive --json
 vera eval manual.vera queries.json --mode all --top-k 5 --json
 ```
 
-Every search result is citation-ready:
+Every search result includes citation fields:
 
 ```json
 {
@@ -141,12 +142,12 @@ Every search result is citation-ready:
 ```
 
 On a 1,038-page stormwater manual (2,442 chunks), hybrid search hits 9/10
-real-world regulatory queries at MRR 0.900 — tracked continuously with
+real-world regulatory queries at MRR 0.900, tracked with
 [`vera eval`](docs/evaluation.md).
 
-## Built for AI agents
+## Agent integration
 
-Three integration surfaces, one retrieval engine:
+Three integration surfaces share the same retrieval engine:
 
 - **CLI with `--json`** — any agent that can run shell commands can convert,
   search, inspect, and validate archives. This repository's own
@@ -161,14 +162,14 @@ Three integration surfaces, one retrieval engine:
   [Install the VERA Agent Skill](docs/agent-skills.md).
 
 The retrieval contract is the same everywhere: results always carry the source
-filename, page range, and heading path, so agents can quote *"(p. 117,
-Chapter 4 > 4.2 Detention Design)"* instead of hallucinating a citation.
-Optional `--regions` output adds page numbers and bounding boxes so a viewer
-can highlight exactly where an answer came from.
+filename, page range, and heading path, so an agent can construct a citation
+such as *"(p. 117, Chapter 4 > 4.2 Detention Design)"* directly from result
+fields. Optional `--regions` output adds page numbers and bounding boxes so a
+viewer can highlight the exact source location of a result.
 
 ## How it works
 
-**Conversion** runs the expensive pipeline exactly once, in five steps:
+**Conversion** runs the full ingestion pipeline once, in five steps:
 
 1. **Parse.** The ingest pipeline extracts text and layout from every page,
    selectively OCRing image-based pages that have little or no native text.
@@ -194,7 +195,7 @@ flowchart LR
     PDF -. "original stored too" .-> Vera
 ```
 
-**Search** never repeats any of that work. A query runs both retrieval paths
+**Search** repeats none of that work. A query runs both retrieval paths
 against the local file and fuses them:
 
 1. The query is embedded with the same model recorded in the archive and
@@ -202,8 +203,8 @@ against the local file and fuses them:
 2. The same query runs through the FTS5 keyword index, ranked with BM25.
 3. Both rankings are min-max normalized and combined with equal weight
    (`--mode semantic` or `--mode keyword` uses just one path).
-4. The top chunks come back with their score, text, source filename, page
-   range, and heading path — ready to cite.
+4. The top chunks are returned with their score, text, source filename, page
+   range, and heading path.
 
 ```mermaid
 flowchart LR
@@ -214,7 +215,8 @@ flowchart LR
     Fuse --> Results["Cited chunks<br/>(page, heading, score, text)"]
 ```
 
-Both paths read plain SQLite — a search is just opening a file.
+Both paths read the local SQLite file directly; no server process is
+involved.
 
 ## Inside a `.vera` file
 
@@ -233,10 +235,10 @@ any SQLite tool, though the CLI and Python API are the stable interface.
 | `attachments` | Opaque, SHA-256-hashed blobs: the original PDF, extracted figure images, and JSON viewer payloads for page and block geometry |
 | `chunk_attachments` | Links chunks to attachments with a semantic `role` (`"source"`, `"figure"`) |
 
-The archive is honest about its own provenance: it records which parser,
-chunking strategy, and embedding model were used, and whether stored vectors
-are L2-normalized. `vera validate` checks all of it — schema, hashes, vector
-dimensions, and index consistency.
+The archive records its own provenance: which parser, chunking strategy, and
+embedding model were used, and whether stored vectors are L2-normalized.
+`vera validate` checks schema, hashes, vector dimensions, and index
+consistency against these claims.
 
 ### Blocks: how VERA understands document structure
 
@@ -252,11 +254,12 @@ in page points (origin top-left), and one of five types:
 | `caption` | Text adjacent to a figure | Joined to figures so search can return captioned figure metadata |
 | `image` | Extracted figures, charts, and drawings | Stored as figure attachments with page and bbox — surfaced via `--figures`, never embedded as text |
 
-Chunks remember which blocks they came from. That provenance chain — chunk →
-blocks → page + bounding boxes — is what lets `--regions` return exact
-highlight rectangles and lets viewers draw an answer directly onto the source
-page. The full mapping of blocks, figures, and regions onto the storage schema
-is documented in [Figures and highlight regions](docs/figures-and-regions.md).
+Each chunk records the IDs of the blocks it was built from. That provenance
+chain — chunk to blocks to page and bounding boxes — is what allows
+`--regions` to return exact highlight rectangles for a search result, and
+allows a viewer to draw a result's location on the source page. The full
+mapping of blocks, figures, and regions onto the storage schema is documented
+in [Figures and highlight regions](docs/figures-and-regions.md).
 
 ### Libraries of archives
 
@@ -270,8 +273,8 @@ time. See [document libraries](docs/document-libraries.md) and the
 
 ## Plugins
 
-VERA avoids lock-in by design: the format does not depend on one parser or one
-embedding provider. Both are pluggable through standard Python entry points.
+The format does not depend on one parser or one embedding provider. Both are
+pluggable through standard Python entry points.
 
 ### Ingest pipelines (`vera.ingest_pipelines`)
 
@@ -285,7 +288,7 @@ vera convert manual.pdf --parser pymupdf --pipeline-option chunk_size=700
 vera convert manual.pdf --parser docling:hybrid   # requires vera-ingest-docling
 ```
 
-Two pipelines ship today:
+Two pipelines are currently available:
 
 - **`pymupdf`** (default, via `vera-ingest-pymupdf`) — PyMuPDF + pdfplumber
   parsing, table extraction, heading detection, and selective Tesseract OCR
@@ -293,7 +296,7 @@ Two pipelines ship today:
 - **`docling`** (optional, via `vera-ingest-docling`) — Docling layout models
   and HybridChunker with contextualized embedding text.
 
-Registering your own is a decorator away:
+A custom pipeline is registered with a decorator:
 
 ```python
 from vera_ingest import register_ingest_pipeline
@@ -305,9 +308,10 @@ def create_pipeline(variant: str = ""):
     return ingest
 ```
 
-Distribute it as a package with a `vera.ingest_pipelines` entry point and
-`vera convert --parser myformat` finds it automatically. Pipelines can also
-publish descriptors that advertise their options for schema-driven UIs. See
+A pipeline distributed as a package with a `vera.ingest_pipelines` entry
+point is discovered automatically by `vera convert --parser myformat`.
+Pipelines can also publish descriptors that advertise their options for
+schema-driven UIs. See
 [Creating an ingest pipeline](docs/creating-an-ingest-pipeline.md).
 
 ### Embedding providers (`vera.embedders`)
@@ -321,14 +325,15 @@ vera convert manual.pdf --model sentence-transformers:all-MiniLM-L6-v2     # loc
 vera convert manual.pdf --model hashing --embedder-option dimension=256    # provider-owned options
 ```
 
-Built-in providers are `hashing` (deterministic lexical hashing — portable,
-zero dependencies, no network) and `sentence-transformers` (local neural
+Built-in providers are `hashing` (deterministic lexical hashing; no extra
+dependencies or network access) and `sentence-transformers` (local neural
 embeddings via the `ml` extra). Third-party providers register through the
 `vera.embedders` entry-point group or `register_embedder()`, and can advertise
 option schemas, model presets, and required credential environment variables
-so hosts can preflight them without secrets in config. Unknown model names are
-rejected loudly — VERA never silently substitutes a different embedder,
-because the archive records exactly which model must answer queries. See
+so hosts can preflight them without storing secrets in configuration. Unknown
+model names are rejected with an error rather than silently substituted,
+because the archive records exactly which model must embed queries at search
+time. See
 [Creating an embedding provider](docs/creating-an-embedding-provider.md).
 
 ## The packages
@@ -346,18 +351,18 @@ vera-mcp ───────────────────────�
 
 | Package | Import / command | What it owns |
 |---------|------------------|--------------|
-| [`vera-doc`](https://pypi.org/project/vera-doc/) | `import vera` | The core: `.vera` schema and validation, transactional chunk/attachment CRUD, embedding storage, and keyword/semantic/hybrid/corpus search. Knows nothing about PDFs. |
+| [`vera-doc`](https://pypi.org/project/vera-doc/) | `import vera` | The core: `.vera` schema and validation, transactional chunk/attachment CRUD, embedding storage, and keyword/semantic/hybrid/corpus search. Has no knowledge of PDFs. |
 | [`vera-ingest`](https://pypi.org/project/vera-ingest/) | `import vera_ingest` | Provider-neutral conversion: the pipeline registry, shared block/chunk types, chunking helpers, atomic archive writing, and viewer helpers for pages, figures, and regions |
 | [`vera-ingest-pymupdf`](https://pypi.org/project/vera-ingest-pymupdf/) | plugin | Default PDF pipeline: PyMuPDF/pdfplumber parsing, table extraction, selective OCR |
 | [`vera-ingest-docling`](https://pypi.org/project/vera-ingest-docling/) | plugin | Optional Docling pipeline with layout models and hybrid chunking |
 | [`vera-cli`](https://pypi.org/project/vera-cli/) | `vera` | The command line: argument parsing, text/JSON output contracts, exit codes, and retrieval evaluation |
 | [`vera-mcp`](https://pypi.org/project/vera-mcp/) | `vera mcp` | Thin MCP adapter exposing search, inspection, figures, pages, and regions as agent tools |
-| `vera-app` | — | Electron/React desktop app with a Python sidecar — a full product built on the same stack |
+| `vera-app` | — | Electron/React desktop application with a Python sidecar, built on the same packages |
 
-The boundary that matters most: `vera-doc` never imports extraction, UI, MCP,
-or evaluation code. It is an embedded vector database that happens to be
-excellent at documents — attachments are opaque bytes and metadata is caller
-data. Everything else composes around it. Details in
+The central boundary rule: `vera-doc` never imports extraction, UI, MCP, or
+evaluation code. It is a general embedded vector database — attachments are
+opaque bytes and metadata is caller-owned JSON — and every other package
+composes around it. Details in
 [Contributing and architecture](docs/architecture.md) and the
 [package overview](packages/README.md).
 
@@ -389,7 +394,7 @@ with VeraDocument.open("knowledge.vera") as document:
     results = document.search(text="minimum pipe size", top_k=5)
 ```
 
-Full document conversion is one import away:
+PDF conversion is composed explicitly through `vera_ingest`:
 
 ```python
 from vera_ingest import convert
@@ -402,26 +407,26 @@ filters, corpus search, and embedding configuration.
 
 ## Design principles
 
-1. **Convert once, search anywhere.** The archive contains everything needed
-   to search it — the ingestion pipeline never has to run twice.
-2. **Preserve source truth.** The original document rides along inside the
+1. **Run ingestion once.** The archive contains everything needed to search
+   it; the ingestion pipeline does not run again after conversion.
+2. **Preserve source truth.** The original document is stored inside the
    archive, and every result points back to its page, heading, and region.
 3. **Be transparent.** The file declares its parser, chunking strategy,
-   embedding model, and normalization policy. `vera validate` holds it to that.
+   embedding model, and normalization policy, and `vera validate` verifies
+   those declarations.
 4. **Avoid lock-in.** SQLite container, documented schema, pluggable parsers
    and embedders — no dependence on any one vendor, model, or database.
-5. **Be useful before it is perfect.** A working local search file beats a
-   perfect design that never ships.
+5. **Be useful before it is perfect.** A working local search file is worth
+   more than a perfect design that never ships.
 
 ## Desktop app
 
-VERA also ships a desktop application for Windows — convert PDFs from the
-right-click menu, search libraries with highlighted citations, and connect an
-LLM provider for grounded Ask answers over your documents. Download it from
+VERA also includes a desktop application for Windows: PDF conversion from the
+Explorer context menu, library search with highlighted citations, and an
+optional LLM provider connection for grounded question answering over
+documents. It is built on the same packages described above. Download it from
 [GitHub Releases](https://github.com/dkylewillis/vera/releases/latest) and see
-the [desktop app guide](docs/desktop-app-getting-started.md). It is built
-entirely on the packages above — a demonstration that the archive, not the
-app, is the product.
+the [desktop app guide](docs/desktop-app-getting-started.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -168,36 +168,53 @@ can highlight exactly where an answer came from.
 
 ## How it works
 
-**Conversion** runs the ingestion pipeline once and writes a validated archive:
+**Conversion** runs the expensive pipeline exactly once, in five steps:
 
-```text
-PDF ──> parse pages & layout ──> detect headings, tables, figures
-            │                        │
-            ├─ selective OCR         ├─ heading-aware chunking
-            ▼                        ▼
-        page text              chunks + provenance
-                                     │
-                        embed each chunk (pluggable model)
-                                     │
-                                     ▼
-        ┌────────────────────── .vera file ──────────────────────┐
-        │ chunks · embeddings · FTS5 keyword index · metadata ·  │
-        │ figures · page/block geometry · original PDF           │
-        └─────────────────────────────────────────────────────────┘
+1. **Parse.** The ingest pipeline extracts text and layout from every page,
+   selectively OCRing image-based pages that have little or no native text.
+2. **Structure.** Each page is decomposed into typed layout blocks — headings,
+   paragraphs, tables, captions, and images — each with a page number and
+   bounding box.
+3. **Chunk.** Blocks are assembled into heading-aware chunks that keep their
+   provenance: source filename, page range, heading path, and the regions
+   they came from.
+4. **Embed and index.** Every chunk gets one vector from the chosen embedding
+   model and one row in the FTS5 keyword index.
+5. **Package.** Chunks, embeddings, the keyword index, figures, page geometry,
+   archive metadata, and the original PDF are written into a single SQLite
+   file, validated, and published atomically.
+
+```mermaid
+flowchart LR
+    PDF["PDF"] --> Parse["Parse + OCR"] --> Blocks["Layout blocks"] --> Chunks["Chunks with citations"]
+    Chunks --> Embed["Embeddings"]
+    Chunks --> FTS["Keyword index"]
+    Embed --> Vera[".vera file"]
+    FTS --> Vera
+    PDF -. "original stored too" .-> Vera
 ```
 
-**Search** never touches the source document again. Hybrid retrieval embeds
-the query with the same model recorded in the archive, scores it against the
-stored vectors (cosine similarity), runs the keyword query through FTS5
-(BM25), min-max normalizes both rankings, and fuses them with equal weight:
+**Search** never repeats any of that work. A query runs both retrieval paths
+against the local file and fuses them:
 
-```text
-query ──┬─> semantic ranking ──┐
-        │                      ├─> normalized fusion ─> cited chunks
-        └─> keyword ranking  ──┘        (page, heading, score, text)
+1. The query is embedded with the same model recorded in the archive and
+   scored against the stored vectors by cosine similarity.
+2. The same query runs through the FTS5 keyword index, ranked with BM25.
+3. Both rankings are min-max normalized and combined with equal weight
+   (`--mode semantic` or `--mode keyword` uses just one path).
+4. The top chunks come back with their score, text, source filename, page
+   range, and heading path — ready to cite.
+
+```mermaid
+flowchart LR
+    Query["Query"] --> Semantic["Semantic ranking<br/>(cosine over stored vectors)"]
+    Query --> Keyword["Keyword ranking<br/>(FTS5 + BM25)"]
+    Semantic --> Fuse["Score fusion"]
+    Keyword --> Fuse
+    Fuse --> Results["Cited chunks<br/>(page, heading, score, text)"]
 ```
 
-Both halves run against local SQLite — a search is just opening a file.
+Both paths read plain SQLite — a search is just opening a file.
 
 ## Inside a `.vera` file
 

--- a/README.md
+++ b/README.md
@@ -1,146 +1,360 @@
-# VERA - Vector-Embedded Retrieval Archive
+# VERA — Vector-Embedded Retrieval Archive
 
 [![Latest release](https://img.shields.io/github/v/release/dkylewillis/vera)](https://github.com/dkylewillis/vera/releases/latest)
 [![PyPI - vera-doc](https://img.shields.io/pypi/v/vera-doc?label=vera-doc)](https://pypi.org/project/vera-doc/)
 [![License](https://img.shields.io/github/license/dkylewillis/vera)](LICENSE)
 
+**Convert once. Search anywhere.**
 
-A `.vera` file is a portable embedded vector database: a self-contained SQLite file containing
-ready-made text chunks, embeddings, a keyword index, JSON metadata, and
-optional opaque attachments. Move it, share it, or search it locally without a
-retrieval service.
+A `.vera` file is a portable embedded vector database: one self-contained
+SQLite file holding ready-made text chunks, pre-computed embeddings, a keyword
+index, citation metadata, and the original source document. Copy it, share it,
+or hand it to an LLM agent — it stays semantically searchable with no vector
+database, no embedding service, and no retrieval server.
 
-The unique core is [`vera-doc`](https://pypi.org/project/vera-doc/) — an
-embeddable Python library that stores and searches `.vera` archives. The VERA
-desktop app is a polished product built on that same foundation. The CLI and
-MCP server give AI agents and applications the same citation-ready retrieval
-layer.
+```bash
+pip install vera-cli
+vera convert manual.pdf manual.vera
+vera search manual.vera "when is stormwater detention required?" --json
+```
 
-[Download VERA for Windows](https://github.com/dkylewillis/vera/releases/latest)
-· [`pip install vera-doc`](#build-on-vera) to embed it
-· [Read the documentation](https://dkylewillis.github.io/vera/)
+## The vision
 
-<img src="docs/assets/readme/hero-grounded-answer.png" alt="VERA desktop app showing an Ask answer beside the source PDF with a cited passage highlighted" width="85%">
+Every application that wants semantic search over documents rebuilds the same
+pipeline — and every copy of that pipeline needs infrastructure:
 
+```text
+Today                                   VERA
+─────                                   ────
+Source document                         Source document
+    ↓                                       ↓
+Parse ──┐                               Convert once
+Chunk   │  repeated per app,                ↓
+Embed   │  requires a running           .vera file
+Index   │  vector database                  ↓
+    ↓ ──┘                               Search anywhere —
+Search                                  any machine, any app, any agent
+```
 
-<!-- TODO(assets): 20–30s feature tour video — upload to a GitHub Release or
-external host, then add: [Watch the feature tour](https://github.com/dkylewillis/vera/releases/latest) -->
+VERA moves the expensive work into the file. A PDF preserves how a document
+*looks*; a `.vera` preserves what it *means* — the document plus a complete
+retrieval layer. Conversion happens once, then any compatible application can
+open the archive and run semantic, keyword, or hybrid search locally, offline,
+with citation-ready results that point back to the exact page and heading.
 
-## Try it in five minutes
+The core motivation is AI agents: an agent should be able to semantically
+search a document the moment it receives one — no parsing step, no chunking
+strategy decisions, no embedding API calls, no vector database to stand up.
+With VERA, "set up retrieval" collapses into "open the file."
 
-Converting and searching documents is fully local and needs no account or API
-key. You only connect a model provider when you want AI answers.
+## Getting started
 
-1. **Install VERA.** Download the `VERA Setup` installer from the
-   [latest Windows release](https://github.com/dkylewillis/vera/releases/latest)
-   and run it.
-2. **Convert your documents.**
-   - **One or more PDFs** — in **Convert PDF** → **Individual PDFs**, use
-     **Choose PDFs**, or select files in Explorer and right-click
-     **Convert PDF**. VERA writes a portable `.vera` archive beside
-     each file.
-   - **Entire library** — choose **PDF Directory** to batch-convert a folder
-     of PDFs, then use **File > Open Folder** to activate it. On your first
-     Search or Ask, VERA shows **Build library index?** — select
-     **Build index** to make the library fast. The footer reports completed
-     files, total files, the current archive, and indexed chunks as it runs.
-3. **Connect a model.** Go to **File > LLM Providers**, select a provider,
-   paste your **API Key**, select **Save Key**, then **Save & Close**. Keys
-   are stored encrypted on your machine. Local **Ollama** and **LM Studio**
-   servers work too — no key needed.
-4. **Search.** Open **Search** and query your documents. Hybrid retrieval
-   (semantic + keyword) works entirely offline.
-5. **Ask and verify.** Ask a question, then select a citation to see the
-   highlighted supporting text in the source document.
+Install the CLI (Python 3.10+). It bundles storage, the default PDF pipeline,
+and offline OCR data:
 
-The desktop app converts with local hashing embeddings; the model provider is
-only used for Ask responses. Use the CLI when you need a Sentence Transformers
-embedding model or explicit OCR control. For the complete walkthrough and
-troubleshooting, see [Run the desktop app](docs/desktop-app-getting-started.md).
-Long library inspections report per-archive progress in the same footer used
-for conversion and indexing.
+```bash
+python -m pip install "vera-cli>=0.2.4"
+```
 
-## How it works
+Convert a PDF and start asking questions:
 
-During conversion, the default `vera-ingest-pymupdf` pipeline extracts native
-PDF text, selectively OCRs image-based pages, and preserves headings, figures,
-and page coordinates. `vera-doc` then stores the chunks, embeddings, and
-keyword index in one validated `.vera` file. The desktop app, CLI, and MCP
-server all search that same archive:
+```bash
+# Parse, OCR (if needed), chunk, embed, and index — one validated output file
+vera convert manual.pdf manual.vera
 
-<img src="convert.png" alt="VERA conversion workflow from PDF parsing and OCR through chunking, embedding, and keyword indexing into a portable .vera archive" width="60%">
+# Hybrid search (semantic + keyword), citation-ready results
+vera search manual.vera "stormwater detention requirements" --top-k 5
 
-At search time, hybrid retrieval in `vera-doc` fuses semantic and keyword
-rankings and returns chunks with their source file, page range, and heading
-path — grounded context for a person or an LLM, with no retrieval service
-required:
+# What's inside?
+vera inspect manual.vera
 
-<img src="search.png" alt="VERA hybrid search workflow combining semantic and keyword search to provide cited context for an LLM response" width="60%">
+# Structurally sound?  exit 0 = valid
+vera validate manual.vera
+
+# Get the original PDF back out
+vera export manual.vera exported.pdf
+```
+
+The default embedding model is a deterministic local hashing embedder — no
+downloads, no API keys, fully offline. For stronger neural retrieval, install
+Sentence Transformers support and pick a model at convert time:
+
+```bash
+python -m pip install "vera-doc[ml]"
+vera convert manual.pdf --model sentence-transformers:all-MiniLM-L6-v2
+```
+
+See the [getting started guide](docs/getting-started.md) for the full
+walkthrough and [CLI recipes](docs/examples.md) for more patterns.
+
+## What it can do (via CLI)
+
+Every one-shot command accepts `--json` for machine-readable output, which
+makes the whole surface scriptable by agents and applications:
+
+| Command | What it does |
+|---------|--------------|
+| `vera convert` | Convert a PDF (or a whole directory) into `.vera` archives, with selective OCR |
+| `vera search` | Hybrid, semantic, or keyword search over a file or a folder-as-corpus |
+| `vera index` | Build, update, and check a persistent library index over many archives |
+| `vera inspect` | Report pages, chunks, embedding model, parser, and archive metadata |
+| `vera validate` | Verify schema, hashes, embeddings, and index integrity |
+| `vera export` | Recover the original source document from the archive |
+| `vera eval` | Score retrieval quality against a query set (hit rate, MRR) |
+| `vera ocr-languages` | List or fetch Tesseract OCR language data |
+| `vera mcp` | Serve everything above to AI agents over MCP (stdio) |
+
+A few useful compositions:
+
+```bash
+# Search a folder of .vera files as one corpus (results carry a "file" field)
+vera search ./library "landscape buffer requirements" --top-k 5 --json
+
+# Make large libraries fast with a persistent, rebuildable index
+vera index build ./library --recursive
+vera index update ./library
+
+# Pull in neighboring prose, figure metadata, or page-coordinate highlights
+vera search manual.vera "pipe sizing chart" --json --context-chunks 1 --figures --regions
+
+# Exact phrases and section numbers → keyword; paraphrased questions → semantic
+vera search manual.vera "section 4.2" --mode keyword
+vera search manual.vera "how big should the pond be" --mode semantic
+
+# Batch-convert a nested PDF library, then track retrieval quality
+vera convert ./proposals --recursive --json
+vera eval manual.vera queries.json --mode all --top-k 5 --json
+```
+
+Every search result is citation-ready:
+
+```json
+{
+  "chunk_id": "chunk_0042",
+  "score": 0.91,
+  "text": "Detention is required when the proposed development increases...",
+  "page_start": 117,
+  "page_end": 118,
+  "heading_path": "Chapter 4 > 4.2 Detention Design",
+  "source_filename": "manual.pdf"
+}
+```
 
 On a 1,038-page stormwater manual (2,442 chunks), hybrid search hits 9/10
 real-world regulatory queries at MRR 0.900 — tracked continuously with
 [`vera eval`](docs/evaluation.md).
 
-## What’s unique: how VERA is built
+## Built for AI agents
 
-The distinctive idea is the portable `.vera` archive and the `vera-doc`
-engine that reads and writes it. The desktop app is a flagship product built
-on that same stack — not the definition of VERA.
+Three integration surfaces, one retrieval engine:
 
-| Package | Role |
-|---------|------|
-| [`vera-doc`](https://pypi.org/project/vera-doc/) | Embeddable storage and search (`import vera`) |
-| [`vera-ingest`](https://pypi.org/project/vera-ingest/) | Conversion registry, shared types, and archive writer |
-| [`vera-ingest-pymupdf`](https://pypi.org/project/vera-ingest-pymupdf/) | Default PDF extraction / OCR pipeline (pulled in by CLI/app) |
-| [`vera-cli`](https://pypi.org/project/vera-cli/) / [`vera-mcp`](https://pypi.org/project/vera-mcp/) | Shell and agent frontends |
-| `vera-app` | Desktop product — a full implementation of the stack |
+- **CLI with `--json`** — any agent that can run shell commands can convert,
+  search, inspect, and validate archives. This repository's own
+  [AGENTS.md](AGENTS.md) teaches coding agents the workflow.
+- **MCP server** — `vera mcp` exposes `vera_search`, `vera_corpus_search`,
+  `vera_inspect`, `vera_validate`, `vera_figures`, `vera_get_page`, and
+  `vera_get_chunk_regions` as tools over stdio. Works with any MCP client;
+  see [Connect an MCP client](docs/mcp.md).
+- **Agent Skill** — a portable [SKILL.md](skills/vera/SKILL.md) package with a
+  complete [CLI reference](skills/vera/references/cli-reference.md) that drops
+  into Agent-Skills-compatible tools (Cursor and others). See
+  [Install the VERA Agent Skill](docs/agent-skills.md).
+
+The retrieval contract is the same everywhere: results always carry the source
+filename, page range, and heading path, so agents can quote *"(p. 117,
+Chapter 4 > 4.2 Detention Design)"* instead of hallucinating a citation.
+Optional `--regions` output adds page numbers and bounding boxes so a viewer
+can highlight exactly where an answer came from.
+
+## How it works
+
+**Conversion** runs the ingestion pipeline once and writes a validated archive:
 
 ```text
-vera-ingest-pymupdf ─┐
-vera-ingest ─────────┼──> vera-doc
-vera-cli ────────────┤
-vera-app ────────────┤
-vera-mcp ────────────┘
+PDF ──> parse pages & layout ──> detect headings, tables, figures
+            │                        │
+            ├─ selective OCR         ├─ heading-aware chunking
+            ▼                        ▼
+        page text              chunks + provenance
+                                     │
+                        embed each chunk (pluggable model)
+                                     │
+                                     ▼
+        ┌────────────────────── .vera file ──────────────────────┐
+        │ chunks · embeddings · FTS5 keyword index · metadata ·  │
+        │ figures · page/block geometry · original PDF           │
+        └─────────────────────────────────────────────────────────┘
 ```
+
+**Search** never touches the source document again. Hybrid retrieval embeds
+the query with the same model recorded in the archive, scores it against the
+stored vectors (cosine similarity), runs the keyword query through FTS5
+(BM25), min-max normalizes both rankings, and fuses them with equal weight:
+
+```text
+query ──┬─> semantic ranking ──┐
+        │                      ├─> normalized fusion ─> cited chunks
+        └─> keyword ranking  ──┘        (page, heading, score, text)
+```
+
+Both halves run against local SQLite — a search is just opening a file.
+
+## Inside a `.vera` file
+
+A `.vera` file is a plain SQLite 3 database with a standardized schema, fully
+specified in [the format spec](docs/vera-spec-v0.2.md). You can open one with
+any SQLite tool, though the CLI and Python API are the stable interface.
+
+### What each table stores
+
+| Table | Contents |
+|-------|----------|
+| `vera_metadata` | Format name/version, creator, embedding model, dimension, and normalization policy, plus a caller-owned `archive_metadata` JSON object (source filename and hash, parser identity, OCR diagnostics, page counts) |
+| `chunks` | The only searchable unit: final chunk text plus `metadata_json` carrying `source_filename`, `page_start`/`page_end`, `heading_path`, and highlight `regions` |
+| `embeddings` | Exactly one vector per chunk — little-endian float32, with the model name and dimension that produced it |
+| `chunks_fts` | SQLite FTS5 full-text index over chunk text, ranked with BM25 |
+| `attachments` | Opaque, SHA-256-hashed blobs: the original PDF, extracted figure images, and JSON viewer payloads for page and block geometry |
+| `chunk_attachments` | Links chunks to attachments with a semantic `role` (`"source"`, `"figure"`) |
+
+The archive is honest about its own provenance: it records which parser,
+chunking strategy, and embedding model were used, and whether stored vectors
+are L2-normalized. `vera validate` checks all of it — schema, hashes, vector
+dimensions, and index consistency.
+
+### Blocks: how VERA understands document structure
+
+During conversion, ingest pipelines decompose each page into normalized
+**layout blocks**. Every block has a stable ID, a page number, a bounding box
+in page points (origin top-left), and one of five types:
+
+| `block_type` | What it is | How VERA uses it |
+|--------------|------------|------------------|
+| `heading` | Section titles, with detected heading level | Starts new chunks and builds the `heading_path` breadcrumb every citation carries |
+| `paragraph` | Body text | The main content of chunks; its bbox becomes a highlight region |
+| `table` | Detected tables, exported as markdown | Searchable as chunk text, so table contents show up in results |
+| `caption` | Text adjacent to a figure | Joined to figures so search can return captioned figure metadata |
+| `image` | Extracted figures, charts, and drawings | Stored as figure attachments with page and bbox — surfaced via `--figures`, never embedded as text |
+
+Chunks remember which blocks they came from. That provenance chain — chunk →
+blocks → page + bounding boxes — is what lets `--regions` return exact
+highlight rectangles and lets viewers draw an answer directly onto the source
+page. The full mapping of blocks, figures, and regions onto the storage schema
+is documented in [Figures and highlight regions](docs/figures-and-regions.md).
+
+### Libraries of archives
+
+A folder of `.vera` files is already a corpus — `vera search ./library ...`
+searches them together and attributes each result to its file. For large
+collections, `vera index build` creates a persistent `.vera-index/` beside the
+archives. The index is derived and rebuildable: individual `.vera` files
+remain the source of truth, and the index can be discarded and rebuilt at any
+time. See [document libraries](docs/document-libraries.md) and the
+[index structure](docs/library-index-structure.md).
+
+## Plugins
+
+VERA avoids lock-in by design: the format does not depend on one parser or one
+embedding provider. Both are pluggable through standard Python entry points.
+
+### Ingest pipelines (`vera.ingest_pipelines`)
+
+A pipeline is any callable `(source_path, IngestRequest) -> IngestResult` that
+turns a source document into normalized pages, blocks, and chunks. Pipelines
+are selected by `provider[:variant]` spec and configured with provider-owned
+options:
+
+```bash
+vera convert manual.pdf --parser pymupdf --pipeline-option chunk_size=700
+vera convert manual.pdf --parser docling:hybrid   # requires vera-ingest-docling
+```
+
+Two pipelines ship today:
+
+- **`pymupdf`** (default, via `vera-ingest-pymupdf`) — PyMuPDF + pdfplumber
+  parsing, table extraction, heading detection, and selective Tesseract OCR
+  with bundled English data. Installed automatically with the CLI and app.
+- **`docling`** (optional, via `vera-ingest-docling`) — Docling layout models
+  and HybridChunker with contextualized embedding text.
+
+Registering your own is a decorator away:
+
+```python
+from vera_ingest import register_ingest_pipeline
+
+@register_ingest_pipeline("myformat")
+def create_pipeline(variant: str = ""):
+    def ingest(source_path, request):
+        ...  # return an IngestResult with pages, blocks, and chunks
+    return ingest
+```
+
+Distribute it as a package with a `vera.ingest_pipelines` entry point and
+`vera convert --parser myformat` finds it automatically. Pipelines can also
+publish descriptors that advertise their options for schema-driven UIs. See
+[Creating an ingest pipeline](docs/creating-an-ingest-pipeline.md).
+
+### Embedding providers (`vera.embedders`)
+
+Embedding models are resolved from `provider:model-id` specs through the same
+registry pattern:
+
+```bash
+vera convert manual.pdf --model hashing                                     # default: offline, deterministic
+vera convert manual.pdf --model sentence-transformers:all-MiniLM-L6-v2     # local neural model
+vera convert manual.pdf --model hashing --embedder-option dimension=256    # provider-owned options
+```
+
+Built-in providers are `hashing` (deterministic lexical hashing — portable,
+zero dependencies, no network) and `sentence-transformers` (local neural
+embeddings via the `ml` extra). Third-party providers register through the
+`vera.embedders` entry-point group or `register_embedder()`, and can advertise
+option schemas, model presets, and required credential environment variables
+so hosts can preflight them without secrets in config. Unknown model names are
+rejected loudly — VERA never silently substitutes a different embedder,
+because the archive records exactly which model must answer queries. See
+[Creating an embedding provider](docs/creating-an-embedding-provider.md).
+
+## The packages
+
+VERA is a mono-repo of independently installable packages with strict one-way
+dependencies pointing at the storage engine:
+
+```text
+vera-ingest-pymupdf ──> vera-ingest ─┐
+vera-ingest-docling ──> vera-ingest ─┤
+vera-cli ────────────────────────────┼──> vera-doc
+vera-app ────────────────────────────┤
+vera-mcp ────────────────────────────┘
+```
+
+| Package | Import / command | What it owns |
+|---------|------------------|--------------|
+| [`vera-doc`](https://pypi.org/project/vera-doc/) | `import vera` | The core: `.vera` schema and validation, transactional chunk/attachment CRUD, embedding storage, and keyword/semantic/hybrid/corpus search. Knows nothing about PDFs. |
+| [`vera-ingest`](https://pypi.org/project/vera-ingest/) | `import vera_ingest` | Provider-neutral conversion: the pipeline registry, shared block/chunk types, chunking helpers, atomic archive writing, and viewer helpers for pages, figures, and regions |
+| [`vera-ingest-pymupdf`](https://pypi.org/project/vera-ingest-pymupdf/) | plugin | Default PDF pipeline: PyMuPDF/pdfplumber parsing, table extraction, selective OCR |
+| [`vera-ingest-docling`](https://pypi.org/project/vera-ingest-docling/) | plugin | Optional Docling pipeline with layout models and hybrid chunking |
+| [`vera-cli`](https://pypi.org/project/vera-cli/) | `vera` | The command line: argument parsing, text/JSON output contracts, exit codes, and retrieval evaluation |
+| [`vera-mcp`](https://pypi.org/project/vera-mcp/) | `vera mcp` | Thin MCP adapter exposing search, inspection, figures, pages, and regions as agent tools |
+| `vera-app` | — | Electron/React desktop app with a Python sidecar — a full product built on the same stack |
+
+The boundary that matters most: `vera-doc` never imports extraction, UI, MCP,
+or evaluation code. It is an embedded vector database that happens to be
+excellent at documents — attachments are opaque bytes and metadata is caller
+data. Everything else composes around it. Details in
+[Contributing and architecture](docs/architecture.md) and the
+[package overview](packages/README.md).
 
 **Who installs what**
 
-- End users → the [desktop app](https://github.com/dkylewillis/vera/releases/latest)
-- Other apps with ready-made chunks → `vera-doc` only
-- PDF pipelines → `vera-doc` + `vera-ingest` + `vera-ingest-pymupdf`
-- Agents and scripts → CLI / MCP
+- Agents and scripts → `vera-cli` (optionally `vera-cli[mcp]`)
+- Apps with ready-made chunks → `vera-doc` only
+- PDF conversion in your own app → `vera-doc` + `vera-ingest` + `vera-ingest-pymupdf`
+- End users who want a GUI → the [desktop app](https://github.com/dkylewillis/vera/releases/latest)
 
-See [Contributing and architecture](docs/architecture.md) and the
-[package overview](packages/README.md) for boundaries and dependency rules.
+## Use VERA as a Python library
 
-## What VERA gives you
-
-- **Portable document archives** — each `.vera` file is self-contained;
-  copy it anywhere and it stays searchable.
-- **Grounded answers** — follow citations to the page, heading, and
-  highlighted source text.
-- **Libraries that stay fast** — a persistent local index makes searching
-  hundreds or even thousands of documents possible; update it as documents
-  change.
-- **Source-first review** — inspect pages and figures, validate archives, and
-  export the original PDF back out at any time. The desktop app keeps figure
-  search results lightweight and loads image previews only for the selected
-  result.
-
-<!-- TODO(assets): uncomment when captured — see docs/assets/readme/README.md
-<img src="docs/assets/readme/convert-single-pdf.png" alt="Convert PDF view converting a single PDF into a .vera archive" width="45%">
-<img src="docs/assets/readme/provider-setup.png" alt="LLM Providers dialog with a provider, API key field, and enabled models" width="45%"> -->
-
-## Build on VERA
-
-### Use VERA as a library
-
-Applications with ready-made chunks can use `vera-doc` directly without
-installing PDF/OCR dependencies:
-
-```bash
-python -m pip install "vera-doc>=0.2.4"
-```
+Applications that already have chunks need only `vera-doc` — no PDF or ML
+dependencies:
 
 ```python
 from vera import ChunkRecord, VeraDocument
@@ -158,73 +372,58 @@ with VeraDocument.open("knowledge.vera") as document:
     results = document.search(text="minimum pipe size", top_k=5)
 ```
 
-Archives record whether stored embeddings are L2-normalized, unnormalized, or
-unknown. Custom vector pipelines can set `embedding_normalization` at creation;
-`vera-doc` validates vectors when the archive declares L2 normalization.
+Full document conversion is one import away:
 
-### Convert sources
+```python
+from vera_ingest import convert
 
-PDF extraction lives in `vera-ingest-pymupdf` (pulled in by `vera-cli`) and is
-composed through the `vera-ingest` registry by `vera convert`:
-
-```bash
-python -m pip install "vera-cli>=0.2.4"
+convert("manual.pdf", "manual.vera")
 ```
 
-```bash
-# Convert a PDF to a portable retrieval archive.
-vera convert input.pdf output.vera
+See the [Python API guide](docs/python-api.md) for attachments, metadata
+filters, corpus search, and embedding configuration.
 
-# Provider-owned ingest options (repeatable; overrides legacy aliases).
-vera convert input.pdf --pipeline-option chunk_size=700 --pipeline-option ocr_mode=auto
+## Design principles
 
-# Build a persistent local index for a document library.
-vera index build ./library --recursive
+1. **Convert once, search anywhere.** The archive contains everything needed
+   to search it — the ingestion pipeline never has to run twice.
+2. **Preserve source truth.** The original document rides along inside the
+   archive, and every result points back to its page, heading, and region.
+3. **Be transparent.** The file declares its parser, chunking strategy,
+   embedding model, and normalization policy. `vera validate` holds it to that.
+4. **Avoid lock-in.** SQLite container, documented schema, pluggable parsers
+   and embedders — no dependence on any one vendor, model, or database.
+5. **Be useful before it is perfect.** A working local search file beats a
+   perfect design that never ships.
 
-# Return grounded results for an application or agent.
-vera search ./library "What are the detention requirements?" --top-k 5 --json
-```
+## Desktop app
 
-### CLI, MCP, and Agent Skill
-
-The default hybrid search combines semantic and keyword retrieval. Every result
-includes its source filename, page range, and heading path. Add
-`--context-chunks`, `--figures`, or `--regions` when the agent needs nearby
-text, figure metadata, or page coordinates.
-
-- [CLI quick start and recipes](docs/getting-started.md)
-- [CLI reference](docs/cli-reference.md)
-- [Connect an MCP client](docs/mcp.md)
-- [Install the VERA Agent Skill](docs/agent-skills.md)
-- [Use the Python API](docs/python-api.md)
-- [Agent quick reference](AGENTS.md)
-- [VERA Agent Skill package (SKILL.md)](skills/vera/SKILL.md)
-- [VERA Agent Skill CLI reference](skills/vera/references/cli-reference.md)
+VERA also ships a desktop application for Windows — convert PDFs from the
+right-click menu, search libraries with highlighted citations, and connect an
+LLM provider for grounded Ask answers over your documents. Download it from
+[GitHub Releases](https://github.com/dkylewillis/vera/releases/latest) and see
+the [desktop app guide](docs/desktop-app-getting-started.md). It is built
+entirely on the packages above — a demonstration that the archive, not the
+app, is the product.
 
 ## Documentation
 
-Preview the documentation locally with:
+Preview the documentation locally with `uv run --extra docs mkdocs serve`, or
+browse the [published docs](https://dkylewillis.github.io/vera/).
 
-```bash
-uv run --extra docs mkdocs serve
-```
-
-- [Desktop app guide](docs/desktop-app-getting-started.md)
-- [Convert documents](docs/conversion.md)
-- [Search documents](docs/searching.md)
-- [Search and index document libraries](docs/document-libraries.md)
-- [Work with figures and highlight regions](docs/figures-and-regions.md)
-- [Troubleshooting](docs/troubleshooting.md)
-- [Current VERA 0.2 format specification](docs/vera-spec-v0.2.md)
-- [Legacy VERA 0.1 format specification](docs/vera-spec-v0.1.md)
-- [Contributing and architecture](docs/architecture.md)
-- [Project roadmap](ROADMAP.md)
+- [Getting started (CLI)](docs/getting-started.md) · [CLI reference](docs/cli-reference.md) · [CLI recipes](docs/examples.md)
+- [Convert documents](docs/conversion.md) · [Search documents](docs/searching.md) · [Document libraries](docs/document-libraries.md)
+- [Figures and highlight regions](docs/figures-and-regions.md) · [Validation and export](docs/validation-and-export.md) · [Evaluation](docs/evaluation.md)
+- [Python API](docs/python-api.md) · [MCP integration](docs/mcp.md) · [Agent skills](docs/agent-skills.md) · [Agent quick reference](AGENTS.md)
+- [Creating an ingest pipeline](docs/creating-an-ingest-pipeline.md) · [Creating an embedding provider](docs/creating-an-embedding-provider.md)
+- [Format spec 0.2 (current)](docs/vera-spec-v0.2.md) · [Format spec 0.1 (legacy)](docs/vera-spec-v0.1.md)
+- [Architecture and contributing](docs/architecture.md) · [Roadmap](ROADMAP.md) · [Troubleshooting](docs/troubleshooting.md)
 
 ## Status and support
 
-VERA is an experimental pre-1.0 project. The desktop installer is available from
-[GitHub Releases](https://github.com/dkylewillis/vera/releases) and currently
-targets Windows. The `.vera` schema and format may change before a stable
-release.
+VERA is an experimental pre-1.0 project. The `.vera` schema and format may
+change before a stable release — see the [roadmap](ROADMAP.md) for what's
+planned. The desktop installer currently targets Windows and is available from
+[GitHub Releases](https://github.com/dkylewillis/vera/releases).
 
 VERA is licensed under [Apache-2.0](LICENSE).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rewrites `README.md` around the project vision: a portable vector-embedded retrieval archive that lets LLM agents semantically search documents without setting up a vector database. The tone is deliberately technical rather than promotional — no tagline, no slogans; each section states what the library does and how.
- Pivots from the desktop-app-first presentation to a CLI-first one: a runnable quick start, a command table covering all nine `vera` subcommands, composition recipes (corpus search, library indexing, `--context-chunks` / `--figures` / `--regions`, keyword vs. semantic modes, batch convert, `vera eval`), and a JSON result sample with citation fields.
- Adds an "Agent integration" section covering the `--json` contract, the MCP server tools, the portable Agent Skill (`skills/vera/SKILL.md`), and `AGENTS.md`.
- Explains "How it works" with numbered conversion and search steps plus GitHub-rendered Mermaid flowcharts.
- Documents the `.vera` architecture in depth: what each table stores (`vera_metadata`, `chunks`, `embeddings`, `chunks_fts`, `attachments`, `chunk_attachments`) and a table of the five normalized layout block types (`heading`, `paragraph`, `table`, `caption`, `image`) with how each is used for chunking, citations, regions, and figures.
- Adds a "Plugins" section for both extension points: ingest pipelines (`vera.ingest_pipelines`, `provider[:variant]`, `--pipeline-option`, `register_ingest_pipeline` example) and embedding providers (`vera.embedders`, `provider:model-id`, `--embedder-option`, error-on-unknown-model policy).
- Expands the package table with what each of the seven packages owns, the dependency diagram, and the `vera-doc` boundary rule; keeps the Python API examples, adds explicit design principles from the project brief, and reduces the desktop app to a short section illustrated with the existing `hero-grounded-answer.png` screenshot.
- Drops the standalone `convert.png` / `search.png` workflow images in favor of numbered steps and Mermaid diagrams. The image files remain in the repo.

## Test plan

- [x] Relevant automated tests pass — full suite `uv run --extra dev python -m pytest -q` (348 passed), including `tests/test_documentation.py` link-resolution and doc-contract checks.
- [x] Retrieval baselines were checked when search behavior changed — not applicable, docs-only change; existing eval numbers (9/10 hit rate, MRR 0.900) carried over unchanged.
- [x] Every CLI example in the new README was executed against a generated sample PDF: `convert` (incl. `--parser`, `--pipeline-option`, `--model`, `--embedder-option`), `search` (hybrid/keyword/semantic, `--json --context-chunks --figures --regions`, folder-as-corpus), `index build`/`update`, `inspect`, `validate`, `export`.

## Documentation

- [x] User-visible behavior is documented in the README or relevant `docs/` guide.
- [ ] CLI/API/MCP references and examples reflect public contract changes — no contract changes.
- [ ] `skills/vera/` reflects agent-facing behavior changes — no behavior changes.
- [ ] Documentation-contract tests were updated when commands, options, JSON, exit codes, links, or documented workflows changed — none changed; existing tests pass unmodified.
- [ ] Not applicable: this change has no user-visible or agent-facing behavior.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c67800d-6513-4c4a-8b45-43b1fa3dcf76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c67800d-6513-4c4a-8b45-43b1fa3dcf76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

