### PR TITLE
Rewrite README for main (0.2 line) with plugin system marked as planned for v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,320 @@
-# VERA - Vector-Embedded Retrieval Archive
+# VERA — Vector-Embedded Retrieval Archive
 
 [![Latest release](https://img.shields.io/github/v/release/dkylewillis/vera)](https://github.com/dkylewillis/vera/releases/latest)
 [![PyPI - vera-doc](https://img.shields.io/pypi/v/vera-doc?label=vera-doc)](https://pypi.org/project/vera-doc/)
 [![License](https://img.shields.io/github/license/dkylewillis/vera)](LICENSE)
 
+A `.vera` file is a portable embedded vector database: one self-contained
+SQLite file holding ready-made text chunks, pre-computed embeddings, a keyword
+index, citation metadata, and the original source document. The file can be
+copied, shared, or handed to an LLM agent and searched in place — no vector
+database, embedding service, or retrieval server is required.
 
-A `.vera` file is a portable embedded vector database: a self-contained SQLite file containing
-ready-made text chunks, embeddings, a keyword index, JSON metadata, and
-optional opaque attachments. Move it, share it, or search it locally without a
-retrieval service.
+```bash
+pip install vera-cli
+vera convert manual.pdf manual.vera
+vera search manual.vera "when is stormwater detention required?" --json
+```
 
-The unique core is [`vera-doc`](https://pypi.org/project/vera-doc/) — an
-embeddable Python library that stores and searches `.vera` archives. The VERA
-desktop app is a polished product built on that same foundation. The CLI and
-MCP server give AI agents and applications the same citation-ready retrieval
-layer.
+## The vision
 
-[Download VERA for Windows](https://github.com/dkylewillis/vera/releases/latest)
-· [`pip install vera-doc`](#build-on-vera) to embed it
-· [Read the documentation](https://dkylewillis.github.io/vera/)
+Semantic search over a document normally requires a multi-stage pipeline —
+parsing, chunking, embedding, and indexing — plus a running vector database to
+hold the result. Every application that wants to search the same document
+repeats all of it:
 
-<img src="docs/assets/readme/hero-grounded-answer.png" alt="VERA desktop app showing an Ask answer beside the source PDF with a cited passage highlighted" width="85%">
+```text
+Typical retrieval pipeline              VERA
+──────────────────────────              ────
+Source document                         Source document
+    ↓                                       ↓
+Parse ──┐                               vera convert
+Chunk   │  repeated per                     ↓  (full pipeline, run once)
+Embed   │  application; results         .vera file
+Index   │  live in a separate               ↓
+    ↓ ──┘  vector database              local search from any
+Search                                  machine, application, or agent
+```
 
+VERA moves the pipeline output into the file itself. A `.vera` archive stores
+the parsed document together with its retrieval layer: chunks, embeddings, a
+keyword index, and citation metadata. Conversion runs once; afterwards any
+compatible application can open the archive and run semantic, keyword, or
+hybrid search locally and offline, with results that reference the source
+page and heading.
 
-<!-- TODO(assets): 20–30s feature tour video — upload to a GitHub Release or
-external host, then add: [Watch the feature tour](https://github.com/dkylewillis/vera/releases/latest) -->
+The primary use case is AI agents. An agent that receives a `.vera` file can
+search it immediately — no parsing step, no chunking decisions, no embedding
+API calls, and no vector database to provision.
 
-## Try it in five minutes
+## Getting started
 
-Converting and searching documents is fully local and needs no account or API
-key. You only connect a model provider when you want AI answers.
+Install the CLI (Python 3.10+). It bundles storage, the default PDF pipeline,
+and offline OCR data:
 
-1. **Install VERA.** Download the `VERA Setup` installer from the
-   [latest Windows release](https://github.com/dkylewillis/vera/releases/latest)
-   and run it.
-2. **Convert your documents.**
-   - **One or more PDFs** — in **Convert PDF** → **Individual PDFs**, use
-     **Choose PDFs**, or select files in Explorer and right-click
-     **Convert PDF**. VERA writes a portable `.vera` archive beside
-     each file.
-   - **Entire library** — choose **PDF Directory** to batch-convert a folder
-     of PDFs, then use **File > Open Folder** to activate it. On your first
-     Search or Ask, VERA shows **Build library index?** — select
-     **Build index** to make the library fast. The footer reports completed
-     files, total files, the current archive, and indexed chunks as it runs.
-3. **Connect a model.** Go to **File > LLM Providers**, select a provider,
-   paste your **API Key**, select **Save Key**, then **Save & Close**. Keys
-   are stored encrypted on your machine. Local **Ollama** and **LM Studio**
-   servers work too — no key needed.
-4. **Search.** Open **Search** and query your documents. Hybrid retrieval
-   (semantic + keyword) works entirely offline.
-5. **Ask and verify.** Ask a question, then select a citation to see the
-   highlighted supporting text in the source document.
+```bash
+python -m pip install "vera-cli>=0.2.4"
+```
 
-The desktop app converts with local hashing embeddings; the model provider is
-only used for Ask responses. Use the CLI when you need a Sentence Transformers
-embedding model or explicit OCR control. For the complete walkthrough and
-troubleshooting, see [Run the desktop app](docs/desktop-app-getting-started.md).
-Long library inspections report per-archive progress in the same footer used
-for conversion and indexing.
+Convert a PDF and search it:
+
+```bash
+# Parse, OCR (if needed), chunk, embed, and index into one validated file
+vera convert manual.pdf manual.vera
+
+# Hybrid search (semantic + keyword) with page and heading citations
+vera search manual.vera "stormwater detention requirements" --top-k 5
+
+# Report pages, chunks, embedding model, parser, and metadata
+vera inspect manual.vera
+
+# Check integrity (exit code 0 = valid)
+vera validate manual.vera
+
+# Recover the embedded original PDF
+vera export manual.vera exported.pdf
+```
+
+The default embedding model is a deterministic local hashing embedder: no
+model downloads, no API keys, and no network access. For stronger retrieval
+quality, install Sentence Transformers support and select a model at convert
+time:
+
+```bash
+python -m pip install "vera-doc[ml]"
+vera convert manual.pdf --model all-MiniLM-L6-v2
+```
+
+See the [getting started guide](docs/getting-started.md) for the full
+walkthrough and [CLI recipes](docs/examples.md) for more patterns.
+
+## CLI functionality
+
+Every one-shot command accepts `--json` for machine-readable output, so the
+full command surface is scriptable by agents and applications:
+
+| Command | What it does |
+|---------|--------------|
+| `vera convert` | Convert a PDF (or a whole directory) into `.vera` archives, with selective OCR |
+| `vera search` | Hybrid, semantic, or keyword search over a file or a folder-as-corpus |
+| `vera index` | Build, update, and check a persistent library index over many archives |
+| `vera inspect` | Report pages, chunks, embedding model, parser, and archive metadata |
+| `vera validate` | Verify schema, hashes, embeddings, and index integrity |
+| `vera export` | Recover the original source document from the archive |
+| `vera eval` | Score retrieval quality against a query set (hit rate, MRR) |
+| `vera mcp` | Serve everything above to AI agents over MCP (stdio) |
+
+Common compositions:
+
+```bash
+# Search a folder of .vera files as one corpus (results carry a "file" field)
+vera search ./library "landscape buffer requirements" --top-k 5 --json
+
+# Build a persistent, rebuildable index for large libraries
+vera index build ./library --recursive
+vera index update ./library
+
+# Include neighboring chunks, figure metadata, or page-coordinate highlights
+vera search manual.vera "pipe sizing chart" --json --context-chunks 1 --figures --regions
+
+# Keyword mode for exact phrases and section numbers; semantic for paraphrases
+vera search manual.vera "section 4.2" --mode keyword
+vera search manual.vera "how big should the pond be" --mode semantic
+
+# Batch-convert a nested PDF library, then measure retrieval quality
+vera convert ./proposals --recursive --json
+vera eval manual.vera queries.json --mode all --top-k 5 --json
+```
+
+Every search result includes citation fields:
+
+```json
+{
+  "chunk_id": "chunk_0042",
+  "score": 0.91,
+  "text": "Detention is required when the proposed development increases...",
+  "page_start": 117,
+  "page_end": 118,
+  "heading_path": "Chapter 4 > 4.2 Detention Design",
+  "source_filename": "manual.pdf"
+}
+```
+
+On a 1,038-page stormwater manual (2,442 chunks), hybrid search hits 9/10
+real-world regulatory queries at MRR 0.900, tracked with
+[`vera eval`](docs/evaluation.md).
+
+## Agent integration
+
+Three integration surfaces share the same retrieval engine:
+
+- **CLI with `--json`** — any agent that can run shell commands can convert,
+  search, inspect, and validate archives. This repository's own
+  [AGENTS.md](AGENTS.md) teaches coding agents the workflow.
+- **MCP server** — `vera mcp` exposes `vera_search`, `vera_corpus_search`,
+  `vera_inspect`, `vera_validate`, `vera_figures`, `vera_get_page`, and
+  `vera_get_chunk_regions` as tools over stdio. Works with any MCP client;
+  see [Connect an MCP client](docs/mcp.md).
+- **Agent Skill** — a portable [SKILL.md](skills/vera/SKILL.md) package with a
+  complete [CLI reference](skills/vera/references/cli-reference.md) that drops
+  into Agent-Skills-compatible tools (Cursor and others). See
+  [Install the VERA Agent Skill](docs/agent-skills.md).
+
+The retrieval contract is the same everywhere: results always carry the source
+filename, page range, and heading path, so an agent can construct a citation
+such as *"(p. 117, Chapter 4 > 4.2 Detention Design)"* directly from result
+fields. Optional `--regions` output adds page numbers and bounding boxes so a
+viewer can highlight the exact source location of a result.
 
 ## How it works
 
-During conversion, `vera-ingest` extracts native PDF text, selectively OCRs
-image-based pages, and preserves headings, figures, and page coordinates.
-`vera-doc` then stores the chunks, embeddings, and keyword index in one
-validated `.vera` file. The desktop app, CLI, and MCP server all search that
-same archive:
+**Conversion** runs the full ingestion pipeline once, in five steps:
 
-<img src="convert.png" alt="VERA conversion workflow from PDF parsing and OCR through chunking, embedding, and keyword indexing into a portable .vera archive" width="60%">
+1. **Parse.** The PDF parser extracts text and layout from every page,
+   selectively OCRing image-based pages that have little or no native text.
+2. **Structure.** Each page is decomposed into typed layout blocks — headings,
+   paragraphs, tables, captions, and images — each with a page number and
+   bounding box.
+3. **Chunk.** Blocks are assembled into heading-aware chunks that keep their
+   provenance: source filename, page range, heading path, and the regions
+   they came from.
+4. **Embed and index.** Every chunk gets one vector from the chosen embedding
+   model and one row in the FTS5 keyword index.
+5. **Package.** Chunks, embeddings, the keyword index, figures, page geometry,
+   archive metadata, and the original PDF are written into a single SQLite
+   file, validated, and published atomically.
 
-At search time, hybrid retrieval in `vera-doc` fuses semantic and keyword
-rankings and returns chunks with their source file, page range, and heading
-path — grounded context for a person or an LLM, with no retrieval service
-required:
+```mermaid
+flowchart LR
+    PDF["PDF"] --> Parse["Parse + OCR"] --> Blocks["Layout blocks"] --> Chunks["Chunks with citations"]
+    Chunks --> Embed["Embeddings"]
+    Chunks --> FTS["Keyword index"]
+    Embed --> Vera[".vera file"]
+    FTS --> Vera
+    PDF -. "original stored too" .-> Vera
+```
 
-<img src="search.png" alt="VERA hybrid search workflow combining semantic and keyword search to provide cited context for an LLM response" width="60%">
+**Search** repeats none of that work. A query runs both retrieval paths
+against the local file and fuses them:
 
-On a 1,038-page stormwater manual (2,442 chunks), hybrid search hits 9/10
-real-world regulatory queries at MRR 0.900 — tracked continuously with
-[`vera eval`](docs/evaluation.md).
+1. The query is embedded with the same model recorded in the archive and
+   scored against the stored vectors by cosine similarity.
+2. The same query runs through the FTS5 keyword index, ranked with BM25.
+3. Both rankings are min-max normalized and combined with equal weight
+   (`--mode semantic` or `--mode keyword` uses just one path).
+4. The top chunks are returned with their score, text, source filename, page
+   range, and heading path.
 
-## What’s unique: how VERA is built
+```mermaid
+flowchart LR
+    Query["Query"] --> Semantic["Semantic ranking<br/>(cosine over stored vectors)"]
+    Query --> Keyword["Keyword ranking<br/>(FTS5 + BM25)"]
+    Semantic --> Fuse["Score fusion"]
+    Keyword --> Fuse
+    Fuse --> Results["Cited chunks<br/>(page, heading, score, text)"]
+```
 
-The distinctive idea is the portable `.vera` archive and the `vera-doc`
-engine that reads and writes it. The desktop app is a flagship product built
-on that same stack — not the definition of VERA.
+Both paths read the local SQLite file directly; no server process is
+involved.
 
-| Package | Role |
-|---------|------|
-| [`vera-doc`](https://pypi.org/project/vera-doc/) | Embeddable storage and search (`import vera`) |
-| [`vera-ingest`](https://pypi.org/project/vera-ingest/) | PDF extraction, OCR, chunking, and conversion into `.vera` |
-| [`vera-cli`](https://pypi.org/project/vera-cli/) / [`vera-mcp`](https://pypi.org/project/vera-mcp/) | Shell and agent frontends |
-| `vera-app` | Desktop product — a full implementation of the stack |
+## Inside a `.vera` file
+
+A `.vera` file is a plain SQLite 3 database with a standardized schema, fully
+specified in [the format spec](docs/vera-spec-v0.2.md). You can open one with
+any SQLite tool, though the CLI and Python API are the stable interface.
+
+### What each table stores
+
+| Table | Contents |
+|-------|----------|
+| `vera_metadata` | Format name/version, creator, embedding model, dimension, and normalization policy, plus a caller-owned `archive_metadata` JSON object (source filename and hash, parser identity, OCR diagnostics, page counts) |
+| `chunks` | The only searchable unit: final chunk text plus `metadata_json` carrying `source_filename`, `page_start`/`page_end`, `heading_path`, and highlight `regions` |
+| `embeddings` | Exactly one vector per chunk — little-endian float32, with the model name and dimension that produced it |
+| `chunks_fts` | SQLite FTS5 full-text index over chunk text, ranked with BM25 |
+| `attachments` | Opaque, SHA-256-hashed blobs: the original PDF, extracted figure images, and JSON viewer payloads for page and block geometry |
+| `chunk_attachments` | Links chunks to attachments with a semantic `role` (`"source"`, `"figure"`) |
+
+The archive records its own provenance: which parser, chunking strategy, and
+embedding model were used, and whether stored vectors are L2-normalized.
+`vera validate` checks schema, hashes, vector dimensions, and index
+consistency against these claims.
+
+### Blocks: how VERA understands document structure
+
+During conversion, the parser decomposes each page into normalized
+**layout blocks**. Every block has a stable ID, a page number, a bounding box
+in page points (origin top-left), and one of five types:
+
+| `block_type` | What it is | How VERA uses it |
+|--------------|------------|------------------|
+| `heading` | Section titles, with detected heading level | Starts new chunks and builds the `heading_path` breadcrumb every citation carries |
+| `paragraph` | Body text | The main content of chunks; its bbox becomes a highlight region |
+| `table` | Detected tables, exported as markdown | Searchable as chunk text, so table contents show up in results |
+| `caption` | Text adjacent to a figure | Joined to figures so search can return captioned figure metadata |
+| `image` | Extracted figures, charts, and drawings | Stored as figure attachments with page and bbox — surfaced via `--figures`, never embedded as text |
+
+Each chunk records the IDs of the blocks it was built from. That provenance
+chain — chunk to blocks to page and bounding boxes — is what allows
+`--regions` to return exact highlight rectangles for a search result, and
+allows a viewer to draw a result's location on the source page. The full
+mapping of blocks, figures, and regions onto the storage schema is documented
+in [Figures and highlight regions](docs/figures-and-regions.md).
+
+### Libraries of archives
+
+A folder of `.vera` files is already a corpus — `vera search ./library ...`
+searches them together and attributes each result to its file. For large
+collections, `vera index build` creates a persistent `.vera-index/` beside the
+archives. The index is derived and rebuildable: individual `.vera` files
+remain the source of truth, and the index can be discarded and rebuilt at any
+time. See [document libraries](docs/document-libraries.md) and the
+[index structure](docs/library-index-structure.md).
+
+## Parsers and embedders
+
+This release ships with built-in components:
+
+- **Parsing** — the `pymupdf` parser (PyMuPDF + pdfplumber): text extraction,
+  table detection, heading detection, and selective Tesseract OCR with
+  bundled English data. It lives inside `vera-ingest` and is selected with
+  `vera convert --parser pymupdf` (the default).
+- **Embedding** — two built-in models selected with `--model`: `hashing`
+  (deterministic lexical hashing; no extra dependencies or network access)
+  and Sentence Transformers models such as `all-MiniLM-L6-v2` or any
+  `sentence-transformers/<id>` (local neural embeddings via the `ml` extra).
+
+```bash
+vera convert manual.pdf --model hashing               # default: offline, deterministic
+vera convert manual.pdf --model all-MiniLM-L6-v2      # local neural model
+```
+
+The archive records which embedding model produced its vectors, and search
+resolves the same model to embed queries.
+
+### Plugin system (planned for v0.3)
+
+The format itself does not depend on one parser or one embedding provider,
+and the next release makes both pluggable through standard Python entry
+points. In development on the
+[`v0.3` branch](https://github.com/dkylewillis/vera/tree/v0.3):
+
+- **Ingest pipeline plugins** (`vera.ingest_pipelines` entry-point group) —
+  pipelines selected by `provider[:variant]` spec and configured with
+  repeatable `--pipeline-option KEY=VALUE` flags. PDF parsing moves into a
+  `vera-ingest-pymupdf` plugin package, and an optional
+  `vera-ingest-docling` plugin adds Docling layout models with hybrid
+  chunking.
+- **Embedding provider plugins** (`vera.embedders` entry-point group) —
+  models resolved from `provider:model-id` specs with provider-owned
+  `--embedder-option KEY=VALUE` flags, descriptor metadata for schema-driven
+  UIs, and declared credential environment variables for hosted providers.
+- **Strict resolution** — unknown pipeline or model names are rejected with
+  an error instead of falling back to a built-in.
+
+## The packages
+
+VERA is a mono-repo of independently installable packages with strict one-way
+dependencies pointing at the storage engine:
 
 ```text
 vera-ingest ─┐
@@ -101,44 +323,36 @@ vera-app ─────┤
 vera-mcp ─────┘
 ```
 
+| Package | Import / command | What it owns |
+|---------|------------------|--------------|
+| [`vera-doc`](https://pypi.org/project/vera-doc/) | `import vera` | The core: `.vera` schema and validation, transactional chunk/attachment CRUD, embedding storage, and keyword/semantic/hybrid/corpus search. Has no knowledge of PDFs. |
+| [`vera-ingest`](https://pypi.org/project/vera-ingest/) | `import vera_ingest` | Conversion: PDF parsing (PyMuPDF/pdfplumber), table extraction, selective OCR, chunking, atomic archive writing, and viewer helpers for pages, figures, and regions |
+| [`vera-cli`](https://pypi.org/project/vera-cli/) | `vera` | The command line: argument parsing, text/JSON output contracts, exit codes, and retrieval evaluation |
+| [`vera-mcp`](https://pypi.org/project/vera-mcp/) | `vera mcp` | Thin MCP adapter exposing search, inspection, figures, pages, and regions as agent tools |
+| `vera-app` | — | Electron/React desktop application with a Python sidecar, built on the same packages |
+
+In v0.3, PDF parsing moves out of `vera-ingest` into `vera-ingest-pymupdf`
+and `vera-ingest-docling` plugin packages, leaving `vera-ingest` as the
+provider-neutral registry and conversion orchestrator.
+
+The central boundary rule: `vera-doc` never imports extraction, UI, MCP, or
+evaluation code. It is a general embedded vector database — attachments are
+opaque bytes and metadata is caller-owned JSON — and every other package
+composes around it. Details in
+[Contributing and architecture](docs/architecture.md) and the
+[package overview](packages/README.md).
+
 **Who installs what**
 
-- End users → the [desktop app](https://github.com/dkylewillis/vera/releases/latest)
-- Other apps with ready-made chunks → `vera-doc` only
-- PDF pipelines → `vera-doc` + `vera-ingest`
-- Agents and scripts → CLI / MCP
+- Agents and scripts → `vera-cli` (optionally `vera-cli[mcp]`)
+- Apps with ready-made chunks → `vera-doc` only
+- PDF conversion in your own app → `vera-doc` + `vera-ingest` + `vera-ingest-pymupdf`
+- End users who want a GUI → the [desktop app](https://github.com/dkylewillis/vera/releases/latest)
 
-See [Contributing and architecture](docs/architecture.md) and the
-[package overview](packages/README.md) for boundaries and dependency rules.
+## Use VERA as a Python library
 
-## What VERA gives you
-
-- **Portable document archives** — each `.vera` file is self-contained;
-  copy it anywhere and it stays searchable.
-- **Grounded answers** — follow citations to the page, heading, and
-  highlighted source text.
-- **Libraries that stay fast** — a persistent local index makes searching
-  hundreds or even thousands of documents possible; update it as documents
-  change.
-- **Source-first review** — inspect pages and figures, validate archives, and
-  export the original PDF back out at any time. The desktop app keeps figure
-  search results lightweight and loads image previews only for the selected
-  result.
-
-<!-- TODO(assets): uncomment when captured — see docs/assets/readme/README.md
-<img src="docs/assets/readme/convert-single-pdf.png" alt="Convert PDF view converting a single PDF into a .vera archive" width="45%">
-<img src="docs/assets/readme/provider-setup.png" alt="LLM Providers dialog with a provider, API key field, and enabled models" width="45%"> -->
-
-## Build on VERA
-
-### Use VERA as a library
-
-Applications with ready-made chunks can use `vera-doc` directly without
-installing PDF/OCR dependencies:
-
-```bash
-python -m pip install "vera-doc>=0.2.4"
-```
+Applications that already have chunks need only `vera-doc` — no PDF or ML
+dependencies:
 
 ```python
 from vera import ChunkRecord, VeraDocument
@@ -156,69 +370,66 @@ with VeraDocument.open("knowledge.vera") as document:
     results = document.search(text="minimum pipe size", top_k=5)
 ```
 
-Archives record whether stored embeddings are L2-normalized, unnormalized, or
-unknown. Custom vector pipelines can set `embedding_normalization` at creation;
-`vera-doc` validates vectors when the archive declares L2 normalization.
+PDF conversion is composed explicitly through `vera_ingest`:
 
-### Convert sources
+```python
+from vera_ingest import convert
 
-PDF extraction and chunking live in the separate `vera-ingest` package and
-are composed by `vera convert`:
-
-```bash
-python -m pip install "vera-cli>=0.2.4"
+convert("manual.pdf", "manual.vera")
 ```
 
-```bash
-# Convert a PDF to a portable retrieval archive.
-vera convert input.pdf output.vera
+See the [Python API guide](docs/python-api.md) for attachments, metadata
+filters, corpus search, and embedding configuration.
 
-# Build a persistent local index for a document library.
-vera index build ./library --recursive
+## Design principles
 
-# Return grounded results for an application or agent.
-vera search ./library "What are the detention requirements?" --top-k 5 --json
-```
+1. **Run ingestion once.** The archive contains everything needed to search
+   it; the ingestion pipeline does not run again after conversion.
+2. **Preserve source truth.** The original document is stored inside the
+   archive, and every result points back to its page, heading, and region.
+3. **Be transparent.** The file declares its parser, chunking strategy,
+   embedding model, and normalization policy, and `vera validate` verifies
+   those declarations.
+4. **Avoid lock-in.** SQLite container, documented schema, pluggable parsers
+   and embedders — no dependence on any one vendor, model, or database.
+5. **Be useful before it is perfect.** A working local search file is worth
+   more than a perfect design that never ships.
 
-### CLI, MCP, and Agent Skill
+## Desktop app
 
-The default hybrid search combines semantic and keyword retrieval. Every result
-includes its source filename, page range, and heading path. Add
-`--context-chunks`, `--figures`, or `--regions` when the agent needs nearby
-text, figure metadata, or page coordinates.
+VERA also includes a desktop application for Windows: PDF conversion from the
+Explorer context menu, library search with highlighted citations, and an
+optional LLM provider connection for grounded question answering over
+documents. It is built on the same packages described above. Download it from
+[GitHub Releases](https://github.com/dkylewillis/vera/releases/latest) and see
+the [desktop app guide](docs/desktop-app-getting-started.md).
 
-- [CLI quick start and recipes](docs/getting-started.md)
-- [CLI reference](docs/cli-reference.md)
-- [Connect an MCP client](docs/mcp.md)
-- [Install the VERA Agent Skill](docs/agent-skills.md)
-- [Use the Python API](docs/python-api.md)
-- [Agent quick reference](AGENTS.md)
-- [VERA Agent Skill package (SKILL.md)](skills/vera/SKILL.md)
-- [VERA Agent Skill CLI reference](skills/vera/references/cli-reference.md)
+<img src="docs/assets/readme/hero-grounded-answer.png" alt="VERA desktop app with a .vera library in the sidebar, an answer with inline citations in the center, and the source PDF open in the document viewer with the supporting passage highlighted" width="85%">
+
+The screenshot shows the three panes working together: the library of `.vera`
+archives on the left, an answer with inline citations in the center, and the
+source document on the right with the cited passage highlighted via stored
+region coordinates.
 
 ## Documentation
 
-Preview the documentation locally with:
+Preview the documentation locally with `uv run --extra docs mkdocs serve`, or
+browse the [published docs](https://dkylewillis.github.io/vera/).
 
-```bash
-uv run --extra docs mkdocs serve
-```
-
-- [Desktop app guide](docs/desktop-app-getting-started.md)
-- [Convert documents](docs/conversion.md)
-- [Search documents](docs/searching.md)
-- [Search and index document libraries](docs/document-libraries.md)
-- [Work with figures and highlight regions](docs/figures-and-regions.md)
-- [Troubleshooting](docs/troubleshooting.md)
-- [Current VERA 0.2 format specification](docs/vera-spec-v0.2.md)
-- [Legacy VERA 0.1 format specification](docs/vera-spec-v0.1.md)
-- [Contributing and architecture](docs/architecture.md)
+- [Getting started (CLI)](docs/getting-started.md) · [CLI reference](docs/cli-reference.md) · [CLI recipes](docs/examples.md)
+- [Convert documents](docs/conversion.md) · [Search documents](docs/searching.md) · [Document libraries](docs/document-libraries.md)
+- [Figures and highlight regions](docs/figures-and-regions.md) · [Validation and export](docs/validation-and-export.md) · [Evaluation](docs/evaluation.md)
+- [Python API](docs/python-api.md) · [MCP integration](docs/mcp.md) · [Agent skills](docs/agent-skills.md) · [Agent quick reference](AGENTS.md)
+- [Format spec 0.2 (current)](docs/vera-spec-v0.2.md) · [Format spec 0.1 (legacy)](docs/vera-spec-v0.1.md)
+- [Architecture and contributing](docs/architecture.md) · [Troubleshooting](docs/troubleshooting.md)
 
 ## Status and support
 
-VERA is an experimental pre-1.0 project. The desktop installer is available from
-[GitHub Releases](https://github.com/dkylewillis/vera/releases) and currently
-targets Windows. The `.vera` schema and format may change before a stable
-release.
+VERA is an experimental pre-1.0 project. The `.vera` schema and format may
+change before a stable release. `main` is the maintenance line for VERA 0.2;
+feature work, including the plugin system, is integrated on the
+[`v0.3` branch](https://github.com/dkylewillis/vera/tree/v0.3). The desktop
+installer currently targets Windows and is available from
+[GitHub Releases](https://github.com/dkylewillis/vera/releases).
 
 VERA is licensed under [Apache-2.0](LICENSE).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Ports the README rewrite from [#14](https://github.com/dkylewillis/vera/pull/14) to the `main` (VERA 0.2 maintenance) line, adapted so every documented command, flag, package, and behavior exists on this branch.
- Same structure as the v0.3 version: vision (portable vector-embedded retrieval archive, no vector database required), CLI-first getting started, command table and composition recipes with a citation JSON sample, agent integration (`--json` contract, MCP tools, Agent Skill), numbered "How it works" steps with Mermaid diagrams, `.vera` internals (table-by-table storage map and the five layout block types), package overview, Python API, design principles, and the desktop app section with the `hero-grounded-answer.png` screenshot.
- Differences from the v0.3 README, matching what `main` actually ships:
  - "Parsers and embedders" documents the built-in `pymupdf` parser and the built-in `hashing` / Sentence Transformers embedding models with `main`'s alias-style `--model` specs (`all-MiniLM-L6-v2`, `sentence-transformers/<id>`).
  - A "Plugin system (planned for v0.3)" subsection describes the entry-point registries, `provider[:variant]` / `provider:model-id` specs, `--pipeline-option` / `--embedder-option` flags, the `vera-ingest-pymupdf` / `vera-ingest-docling` plugin packages, and strict unknown-name rejection as in-development work on the [`v0.3` branch](https://github.com/dkylewillis/vera/tree/v0.3), rather than as current functionality.
  - The package table and dependency diagram reflect `main`'s five packages (PDF parsing still inside `vera-ingest`), with a note about the v0.3 split.
  - No `ocr-languages` command row, and no links to `ROADMAP.md` or the plugin-authoring guides (these files exist only on `v0.3`).
- Removes the standalone `convert.png` / `search.png` workflow images from the README in favor of numbered steps and Mermaid diagrams; image files remain in the repo.

## Test plan

- [x] Relevant automated tests pass — `tests/test_documentation.py` (link resolution and doc contracts) passes on this branch.
- [x] Retrieval baselines were checked when search behavior changed — not applicable, docs-only change; existing eval numbers carried over unchanged.
- [x] CLI examples verified against this branch's parser: `vera convert` (default hashing), `vera search` (incl. `--json --context-chunks --figures --regions`), and `vera inspect` executed end-to-end on a sample PDF; `--help` output confirmed all documented flags exist on `main`.

## Documentation

- [x] User-visible behavior is documented in the README or relevant `docs/` guide.
- [ ] CLI/API/MCP references and examples reflect public contract changes — no contract changes.
- [ ] `skills/vera/` reflects agent-facing behavior changes — no behavior changes.
- [ ] Documentation-contract tests were updated when commands, options, JSON, exit codes, links, or documented workflows changed — none changed; existing tests pass unmodified.
- [ ] Not applicable: this change has no user-visible or agent-facing behavior.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c67800d-6513-4c4a-8b45-43b1fa3dcf76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c67800d-6513-4c4a-8b45-43b1fa3dcf76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

