### PR TITLE
fix: keep vera-doc writes working on legacy and large archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
   desktop search JSON.
 - Vectorized semantic scoring, batched attachment loads, and FTS writes that
   align `chunks_fts.rowid` with `chunks.rowid` (format 0.2 compatible; legacy
-  archives fall back to deleting by `chunk_id`).
+  archives fall back to deleting by `chunk_id` and to appending when another
+  chunk already occupies the matching FTS rowid).
 - `VeraDocument.iter_raw_chunks()` / `format_metadata()` for library indexing
   without private `VeraDocument` access.
 

--- a/packages/vera-doc/src/vera_doc/document.py
+++ b/packages/vera-doc/src/vera_doc/document.py
@@ -45,6 +45,11 @@ _EMBEDDING_NORMALIZATIONS = frozenset({"l2", "none", "unknown"})
 _L2_NORMALIZATION_RTOL = 1e-4
 _L2_NORMALIZATION_ATOL = 1e-6
 _MAX_TOP_K = 10_000
+# SQLite rejects statements with more host variables than
+# SQLITE_LIMIT_VARIABLE_NUMBER, which is 999 on builds older than 3.32 and
+# 32766 on current ones. Batch id lists well below the lower bound so a large
+# archive cannot outgrow whichever SQLite the caller happens to link.
+_SQL_VARIABLE_BATCH = 500
 _FTS_RUNTIME_MARKERS = (
     "database is locked",
     "database disk image is malformed",
@@ -55,6 +60,11 @@ _FTS_RUNTIME_MARKERS = (
     "attempt to write a readonly",
     "locking protocol",
 )
+
+
+def _batched(values: Sequence[str], size: int) -> Iterator[tuple[str, ...]]:
+    for start in range(0, len(values), size):
+        yield tuple(values[start : start + size])
 
 
 def _package_version() -> str:
@@ -561,13 +571,18 @@ class VeraDocument:
             FROM chunks c
             JOIN embeddings e ON e.chunk_id = c.chunk_id
         """
-        params: list[Any] = []
-        if requested is not None:
-            placeholders = ",".join("?" for _ in requested)
-            sql += f" WHERE c.chunk_id IN ({placeholders})"
-            params.extend(requested)
-        sql += " ORDER BY c.rowid"
-        rows = self._conn.execute(sql, params).fetchall()
+        if requested is None:
+            rows = self._conn.execute(f"{sql} ORDER BY c.rowid").fetchall()
+        else:
+            rows = []
+            for batch in _batched(requested, _SQL_VARIABLE_BATCH):
+                placeholders = ",".join("?" for _ in batch)
+                rows.extend(
+                    self._conn.execute(
+                        f"{sql} WHERE c.chunk_id IN ({placeholders}) ORDER BY c.rowid",
+                        batch,
+                    ).fetchall()
+                )
         refs = self._attachment_refs([str(row["chunk_id"]) for row in rows])
         records = [self._row_to_record(row, refs.get(str(row["chunk_id"]), ())) for row in rows]
         records = [record for record in records if self._metadata_matches(record, where)]
@@ -1061,22 +1076,23 @@ class VeraDocument:
         refs: dict[str, list[AttachmentRef]] = {chunk_id: [] for chunk_id in chunk_ids}
         if not chunk_ids:
             return {}
-        placeholders = ",".join("?" for _ in chunk_ids)
-        for row in self._conn.execute(
-            f"""
-            SELECT chunk_id, attachment_id, role
-            FROM chunk_attachments
-            WHERE chunk_id IN ({placeholders})
-            ORDER BY chunk_id, attachment_id, role
-            """,
-            tuple(chunk_ids),
-        ):
-            refs[str(row["chunk_id"])].append(
-                AttachmentRef(
-                    attachment_id=row["attachment_id"],
-                    role=row["role"] or None,
+        for batch in _batched(chunk_ids, _SQL_VARIABLE_BATCH):
+            placeholders = ",".join("?" for _ in batch)
+            for row in self._conn.execute(
+                f"""
+                SELECT chunk_id, attachment_id, role
+                FROM chunk_attachments
+                WHERE chunk_id IN ({placeholders})
+                ORDER BY chunk_id, attachment_id, role
+                """,
+                batch,
+            ):
+                refs[str(row["chunk_id"])].append(
+                    AttachmentRef(
+                        attachment_id=row["attachment_id"],
+                        role=row["role"] or None,
+                    )
                 )
-            )
         return {chunk_id: tuple(values) for chunk_id, values in refs.items()}
 
     def _chunk_rowid(self, chunk_id: str) -> int | None:
@@ -1088,7 +1104,10 @@ class VeraDocument:
 
     def _insert_fts_row(self, chunk_id: str, text: str) -> None:
         chunk_rowid = self._chunk_rowid(chunk_id)
-        if chunk_rowid is None:
+        if chunk_rowid is None or self._fts_rowid_taken(chunk_rowid, chunk_id):
+            # Archives written before FTS rows were aligned to chunks.rowid can
+            # have another chunk squatting this rowid. Appending keeps the write
+            # working; alignment is an optimization, not a format requirement.
             self._conn.execute(
                 "INSERT INTO chunks_fts(chunk_id, text) VALUES (?, ?)",
                 (chunk_id, text),
@@ -1098,6 +1117,13 @@ class VeraDocument:
             "INSERT INTO chunks_fts(rowid, chunk_id, text) VALUES (?, ?, ?)",
             (chunk_rowid, chunk_id, text),
         )
+
+    def _fts_rowid_taken(self, rowid: int, chunk_id: str) -> bool:
+        row = self._conn.execute(
+            "SELECT chunk_id FROM chunks_fts WHERE rowid = ?",
+            (rowid,),
+        ).fetchone()
+        return row is not None and str(row["chunk_id"]) != chunk_id
 
     def _replace_fts_row(self, chunk_id: str, text: str) -> None:
         self._delete_fts_row(chunk_id)

--- a/packages/vera-doc/tests/test_database.py
+++ b/packages/vera-doc/tests/test_database.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import numpy as np
@@ -109,6 +110,58 @@ def test_database_attachments_and_references(tmp_path: Path) -> None:
         assert database.get(["chunk"])[0].attachments == (AttachmentRef("source", role="source"),)
         with pytest.raises(ValueError, match="referenced"):
             database.delete_attachment("source")
+
+
+def test_writes_survive_archives_whose_fts_rowids_drifted(tmp_path: Path) -> None:
+    """Archives written before FTS rows tracked ``chunks.rowid`` stay writable.
+
+    The 0.2 writer re-inserted an edited chunk's FTS row without a rowid, which
+    appended it and offset every chunk added afterwards.
+    """
+    path = tmp_path / "legacy.vera"
+    with VeraDocument.create(path) as database:
+        database.add(
+            [
+                ChunkRecord(id="one", text="Alpha detention basin"),
+                ChunkRecord(id="two", text="Beta landscape buffer"),
+            ]
+        )
+        database._conn.execute("DELETE FROM chunks_fts WHERE chunk_id = 'one'")
+        database._conn.execute(
+            "INSERT INTO chunks_fts(chunk_id, text) VALUES ('one', 'Alpha detention basin')"
+        )
+        aligned = database._conn.execute(
+            "SELECT c.rowid = f.rowid AS aligned FROM chunks c "
+            "JOIN chunks_fts f ON f.chunk_id = c.chunk_id WHERE c.chunk_id = 'one'"
+        ).fetchone()
+        assert aligned["aligned"] == 0
+
+        database.add([ChunkRecord(id="three", text="Gamma pipe diameter")])
+        database.upsert([ChunkRecord(id="two", text="Beta landscape buffer revised")])
+
+        assert database.validate()["ok"] is True
+        for query, expected in (
+            ("Gamma pipe", "three"),
+            ("Beta landscape", "two"),
+            ("Alpha detention", "one"),
+        ):
+            hits = database.search(text=query, mode="keyword", top_k=1)
+            assert [hit.record.id for hit in hits] == [expected]
+
+
+def test_reads_batch_chunk_ids_below_the_sql_variable_limit(tmp_path: Path) -> None:
+    """``get()`` must not bind one host variable per chunk.
+
+    SQLite caps host variables at 999 on builds older than 3.32 and 32766 on
+    current ones, so an unbatched ``IN`` clause fails on large archives.
+    """
+    path = tmp_path / "many.vera"
+    ids = [f"chunk_{index:04d}" for index in range(1200)]
+    with VeraDocument.create(path) as database:
+        database.add([ChunkRecord(id=chunk_id, text=f"Section {chunk_id}") for chunk_id in ids])
+        database._conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        assert [record.id for record in database.get()] == ids
+        assert [record.id for record in database.get(ids)] == ids
 
 
 def test_database_batches_are_atomic(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two write-path regressions introduced by `618c677` ("Pre-0.3 structural cleanup"), found while reviewing the recent v0.3 commits. Both are invisible to the current test suite, `ruff`, `mypy`, and `vera validate`.

**1. Archives written by the 0.2 writer can no longer be appended to.** `_insert_fts_row` inserts into `chunks_fts` at an explicit rowid taken from `chunks.rowid`. The 0.2 writer edited a chunk by deleting its FTS row and re-inserting without a rowid, which appended it and permanently offset every chunk added afterwards. `_delete_fts_row` already carried a `chunk_id` fallback for that layout, but the insert had none, so it collided:

```
[legacy archive] chunks    : [(1, 'c1'), (2, 'c2'), (3, 'c3')]
[legacy archive] chunks_fts: [(2, 'c2'), (3, 'c1'), (4, 'c3')]
[new code] validate ok      : True
[new code] keyword search   : ['c1']          <- reads are fine
[new code] add new chunk    : IntegrityError: constraint failed
```

`vera validate` reports `ok: true` on such a file (`validation.py` compares row counts only) and the spec requires just one FTS row per chunk, so the archive is conforming — the writer simply refused it. The insert now appends when another chunk already occupies the matching rowid, mirroring the delete path. Alignment stays an optimization rather than a precondition.

**2. Unfiltered `get()` bound one SQL host variable per chunk.** The batched attachment read passes every returned `chunk_id` into a single `WHERE chunk_id IN (?,?,…)`. SQLite caps host variables at `SQLITE_LIMIT_VARIABLE_NUMBER` — 32766 on current builds (what CPython ships on Windows and macOS, the desktop app's platforms) and 999 on builds older than 3.32. The pre-cleanup code read attachments per row and used no host variables at all for this path:

```
archive: 40000 chunks, emulated variable limit 32766
new code  get(): OperationalError: too many SQL variables
old-style get(): OK (40000 records)
```

This is reachable from the CLI, not just the Python API: `vera search <directory> --context-chunks 1` calls `doc.get()` per file via `corpus.py`. Chunk id lists are now batched at 500, which also fixes the explicit-ids `get(ids)` path that carried the same ceiling before the cleanup.

## Test plan

- [x] Relevant automated tests pass — `ruff check`, `ruff format --check`, `mypy packages/vera-doc/src`, `uv run --extra dev pytest -q` (413 passed, 2 skipped), `npm run app:typecheck`, and vitest (124 passed).
- [x] Two regression tests added to `packages/vera-doc/tests/test_database.py`; both fail on `v0.3` without the fix and pass with it.
- [x] Retrieval baselines unaffected — no ranking, scoring, or output-contract code is touched. Reads, `validate`, and search results are byte-identical before and after.

## Documentation

- [x] `CHANGELOG.md` entry corrected: the legacy fallback covers appending as well as deleting by `chunk_id`.
- [x] Not applicable otherwise: no CLI, JSON, exit-code, MCP, or agent-facing contract changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cc0cee9-93aa-4768-845b-4f8c41940a80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cc0cee9-93aa-4768-845b-4f8c41940a80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

