### PR TITLE
fix: keep torchgen in the sidecar build so torch still imports

### DIFF
--- a/packages/vera-app/scripts/build-sidecar.cjs
+++ b/packages/vera-app/scripts/build-sidecar.cjs
@@ -11,10 +11,13 @@ const entry = path.join("src", "vera_app", "sidecar.py");
 // support. Exclude packages that are often present in a local
 // `uv sync --extra ml --extra dev` venv but are not needed for text embeddings;
 // otherwise PyInstaller follows those imports and inflates the installer.
+//
+// `torchgen` must NOT be excluded despite the codegen-sounding name:
+// `torch/utils/_python_dispatch.py` imports it unconditionally, so dropping it
+// makes `import torch` fail at runtime and breaks every neural embedding model.
 const excludedModules = [
   "torchvision",
   "torchaudio",
-  "torchgen",
   "functorch",
   "tensorflow",
   "tensorboard",

--- a/tests/test_sidecar_build.py
+++ b/tests/test_sidecar_build.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = ROOT / "packages" / "vera-app" / "scripts" / "build-sidecar.cjs"
+
+# Packages the frozen sidecar needs for semantic (Sentence Transformers)
+# embeddings. Excluding any of them silently downgrades a built installer to
+# hashing-only embeddings.
+SEMANTIC_REQUIREMENTS = {
+    "torch",
+    "torchgen",
+    "transformers",
+    "sentence_transformers",
+    "tokenizers",
+    "safetensors",
+    "huggingface_hub",
+    "numpy",
+}
+
+_BLOCKED_IMPORT_PROBE = """
+import sys
+import importlib.abc
+
+blocked = sys.argv[1]
+
+
+class _Blocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == blocked or fullname.startswith(blocked + "."):
+            raise ModuleNotFoundError(f"No module named {fullname!r}", name=fullname)
+        return None
+
+
+sys.meta_path.insert(0, _Blocker())
+
+import torch  # noqa: F401
+"""
+
+
+def _excluded_modules() -> list[str]:
+    source = BUILD_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(r"const excludedModules = \[(.*?)\];", source, re.DOTALL)
+    assert match, "build-sidecar.cjs no longer declares an excludedModules array"
+    return re.findall(r'"([^"]+)"', match.group(1))
+
+
+def _is_installed(module: str) -> bool:
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def test_excluded_modules_reach_pyinstaller() -> None:
+    modules = _excluded_modules()
+    assert modules
+    assert '"--exclude-module"' in BUILD_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_semantic_embedding_dependencies_are_not_excluded() -> None:
+    excluded = set(_excluded_modules())
+    assert excluded.isdisjoint(SEMANTIC_REQUIREMENTS), (
+        "build-sidecar.cjs excludes modules the semantic embedder needs: "
+        f"{sorted(excluded & SEMANTIC_REQUIREMENTS)}"
+    )
+
+
+@pytest.mark.parametrize("module", sorted(_excluded_modules()))
+def test_excluded_module_is_not_needed_to_import_torch(module: str) -> None:
+    """Every exclusion must be droppable without breaking ``import torch``.
+
+    ``torchgen`` reads like build-time codegen but is imported unconditionally by
+    ``torch.utils._python_dispatch``, so excluding it produced a sidecar that
+    raised ``ModuleNotFoundError`` as soon as a neural model was selected.
+    """
+    pytest.importorskip("torch")
+    if not _is_installed(module):
+        pytest.skip(f"{module} is not installed; excluding it is a no-op here")
+    probe = subprocess.run(
+        [sys.executable, "-c", _BLOCKED_IMPORT_PROBE, module],
+        capture_output=True,
+        text=True,
+    )
+    assert probe.returncode == 0, (
+        f"excluding {module!r} breaks `import torch` in the frozen sidecar:\n"
+        f"{probe.stderr.strip()}"
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`1a846ed` ("enhance sidecar build process by managing dependencies") added `--exclude-module torchgen` to the PyInstaller build. The name reads like build-time codegen, but `torch/utils/_python_dispatch.py` imports it unconditionally, and that module is pulled in by `torch/nn/modules/module.py` — so excluding it breaks `import torch` itself.

The result is a frozen sidecar that works fine on the default `hashing` embedder and fails the moment a Sentence Transformers model is selected, which is the exact capability the commit set out to preserve. Built from `main` and driven over the sidecar's JSON-Lines protocol:

```
--- convert-ml: FAILED ---
No module named 'torchgen'
  File "vera/core/embeddings.py", line 64, in __init__
  File "sentence_transformers/__init__.py", line 10, in <module>
  ...
  File "torch/utils/_python_dispatch.py", line 13, in <module>
    import torchgen
ModuleNotFoundError: No module named 'torchgen'
```

Dropping `torchgen` from the list fixes it. Every other entry was checked by blocking it and re-importing the ML stack; `torchaudio`, `functorch`, `tensorboard`, `cv2`, `pytest`, `_pytest`, `py`, `IPython`, `jupyter`, and `notebook` are all safe, and `torchvision`, `tensorflow`, and `pandas` are not installed by any project extra, so excluding them stays a no-op guard against a polluted dev venv.

## Test plan

- [x] Rebuilt the sidecar with `npm --prefix packages/vera-app run build:sidecar` and exercised the frozen binary end to end: `ping`, `convert` (hashing and `all-MiniLM-L6-v2`), `inspect`, `validate`, hybrid/keyword/semantic `search` with `--regions`, `page`, and `export`.
- [x] Added `tests/test_sidecar_build.py`, which asserts the exclusion list keeps the semantic-embedding dependencies and blocks each excluded module in a subprocess to confirm `import torch` still succeeds. Both new tests fail with `torchgen` re-added and pass without it.
- [x] `uv run --extra dev python -m pytest -q` passes, as do `npm run app:typecheck` and vitest.
- [x] Retrieval baselines unaffected — build packaging only, no retrieval code touched.

## Documentation

- [x] `docs/desktop-app-architecture.md` needs no change: it lists `torchvision`, `torchaudio`, `pandas`, `cv2`, and `pytest` as examples and never named `torchgen`.
- [x] Not applicable otherwise: no user-visible CLI, JSON, exit-code, MCP, or agent-facing behavior changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cc0cee9-93aa-4768-845b-4f8c41940a80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cc0cee9-93aa-4768-845b-4f8c41940a80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

