### PR TITLE
fix: unblock the 0.3 wheel build and the strict docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,21 @@ jobs:
           uv run ruff format --check packages tests benchmarks conftest.py
           uv run mypy packages/vera-doc/src
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      # Packaging errors otherwise surface for the first time in
+      # publish-pypi.yml, which only runs once a release is already published.
+      - name: Build every distribution
+        run: uv build --all-packages --out-dir dist
+
   app:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,8 @@ name: Docs
 
 on:
   push:
-    branches: [main]
+    branches: [main, v0.3]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -13,7 +12,9 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  # Keyed by ref so a build on another branch cannot cancel a Pages deploy from
+  # main; deploys still serialize because only main reaches the deploy job.
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -197,7 +197,7 @@ The plugin's embedder must record the full spec (for example,
 load the matching provider. See
 [Creating an embedding provider plugin](creating-an-embedding-provider.md)
 for the Options + descriptor authoring model and the
-[OpenAI plugin example](../packages/vera-doc/README.md#openai-embedding-plugin-example)
+[OpenAI plugin example](https://github.com/dkylewillis/vera/blob/main/packages/vera-doc/README.md#openai-embedding-plugin-example)
 for a complete entry-point sketch.
 
 Claude is an LLM rather than an embedding provider: Anthropic's Claude API has

--- a/docs/user-documentation.md
+++ b/docs/user-documentation.md
@@ -42,8 +42,8 @@ figures, and citation metadata in one portable `.vera` file.
 
 - [Repository architecture](architecture.md)
 - [Desktop app architecture](desktop-app-architecture.md)
-- [Changelog](../CHANGELOG.md)
-- [Roadmap](../ROADMAP.md)
+- [Changelog](https://github.com/dkylewillis/vera/blob/main/CHANGELOG.md)
+- [Roadmap](https://github.com/dkylewillis/vera/blob/main/ROADMAP.md)
 
 The README is the product overview, these pages are the human user
 documentation, and `skills/vera/` is the self-contained package for AI agents.

--- a/packages/vera-ingest-pymupdf/pyproject.toml
+++ b/packages/vera-ingest-pymupdf/pyproject.toml
@@ -36,6 +36,3 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/vera_ingest_pymupdf"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/vera_ingest_pymupdf/tessdata" = "vera_ingest_pymupdf/tessdata"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -31,6 +31,28 @@ def test_local_documentation_links_resolve():
             assert path.exists(), f"{document.relative_to(ROOT)} links to missing {raw_target}"
 
 
+def test_site_pages_only_link_relatively_within_the_docs_tree():
+    """MkDocs resolves relative links against the pages it builds, not the repo.
+
+    A link such as ``../CHANGELOG.md`` exists on disk, so
+    ``test_local_documentation_links_resolve`` accepts it, but
+    ``mkdocs build --strict`` fails it. Repo files outside ``docs/`` have to be
+    linked by URL.
+    """
+    link_pattern = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+    for document in DOCS.rglob("*.md"):
+        text = document.read_text(encoding="utf-8")
+        for raw_target in link_pattern.findall(text):
+            target = raw_target.split("#", 1)[0].strip()
+            if not target or "://" in target or target.startswith("mailto:"):
+                continue
+            path = (document.parent / unquote(target)).resolve()
+            assert path.is_relative_to(DOCS), (
+                f"{document.relative_to(ROOT)} links to {raw_target}, which is outside "
+                "docs/; mkdocs --strict cannot resolve it, so use a full URL"
+            )
+
+
 def test_documentation_index_lists_user_guides():
     index = (DOCS / "user-documentation.md").read_text(encoding="utf-8")
     guides = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two pre-existing v0.3 failures that only surface at release time, plus the CI gaps that let them sit unnoticed.

**`vera-ingest-pymupdf` could not build a wheel.** `packages = ["src/vera_ingest_pymupdf"]` already ships `src/vera_ingest_pymupdf/tessdata`, and the `force-include` table added the same files a second time, so hatchling refused:

```
ValueError: A second file is being added to the wheel archive at the same path:
`vera_ingest_pymupdf/tessdata/README.md`.
```

`publish-pypi.yml` runs exactly `uv build --package vera-ingest-pymupdf`, so the 0.3 release would have failed for the default PDF pipeline. Both tessdata files are git-tracked and unignored, and `vera-ingest` ships its own tessdata on `main` with the plain `packages = [...]` include and nothing else, so the `force-include` is redundant and is simply removed.

**`mkdocs build --strict` aborted on three links.** MkDocs resolves relative links against the pages it builds, not the repo, so `../CHANGELOG.md`, `../ROADMAP.md`, and `../packages/vera-doc/README.md#openai-embedding-plugin-example` were unresolvable even though all three exist on disk. They now use `github.com` URLs, matching the four out-of-tree links the docs already have (the Agent Skill links in `docs/index.md`, `docs/mcp.md`, `docs/cli-reference.md`, and `docs/user-documentation.md`).

**Neither failure was reachable from CI.** No job built wheels, so a packaging error would have waited for `publish-pypi.yml` on an already-published release. The Docs workflow only triggered on `main`, so a strict-build failure would land the moment v0.3 merged. This adds a `build` job running `uv build --all-packages`, extends the Docs triggers to v0.3, and keys the Pages concurrency group by ref so a build on another branch cannot cancel a deploy from `main`.

## Test plan

- [x] `uv build --all-packages` produces all 8 distributions; `uv build --package vera-ingest-pymupdf` succeeds on its own. The wheel contains `tessdata/README.md` and `tessdata/eng.traineddata` exactly once each.
- [x] Installed the built `vera-doc` + `vera-ingest` + `vera-ingest-pymupdf` wheels into a clean venv: the `pymupdf` pipeline registers through its entry point, the bundled tessdata directory resolves to `site-packages/vera_ingest_pymupdf/tessdata` with the full 4113088-byte `eng.traineddata`, and a real PDF converts, validates, and searches.
- [x] `uv run --extra docs mkdocs build --strict` exits 0; the three links render as absolute URLs in the built site and the `#openai-embedding-plugin-example` anchor still exists in `packages/vera-doc/README.md`.
- [x] `tests/test_documentation.py::test_site_pages_only_link_relatively_within_the_docs_tree` added for the rule mkdocs actually applies; it fails when any of the three links is restored and passes otherwise. The existing link test only checked the filesystem, where these resolved.
- [x] Full suite green: `ruff check`, `ruff format --check`, `mypy packages/vera-doc/src`, `uv run --extra dev pytest -q` (412 passed, 2 skipped), `npm run app:typecheck`, vitest (124 passed).
- [x] Retrieval baselines unaffected — no retrieval code is touched.

## Documentation

- [x] The changed pages are the documentation; link targets and anchors verified in the built site.
- [x] Not applicable otherwise: no CLI, JSON, exit-code, MCP, or agent-facing contract changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cc0cee9-93aa-4768-845b-4f8c41940a80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cc0cee9-93aa-4768-845b-4f8c41940a80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

