### PR TITLE
docs: finish the vera_doc rename in prose and docstrings

### DIFF
--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -171,7 +171,7 @@ plugins can register providers under the Python entry-point group
 `vera.embedders`, with optional `vera.embedder_descriptors` metadata for
 schema-driven Convert controls (`describe_embedding_providers` in the
 sidecar). From Python, pass a custom `embedding_function`
-to `vera_ingest.convert`, call `vera.register_embedder`, or pass
+to `vera_ingest.convert`, call `vera_doc.register_embedder`, or pass
 `embedder_options={...}` / CLI `--embedder-option KEY=VALUE` for
 provider-owned settings advertised by the provider's Options dataclass.
 Advertised integer bounds are enforced (hashing `dimension` is 8–4096). See

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -22,7 +22,7 @@ Tauri remains a possible future optimization if app size becomes the dominant co
 
 ```text
 packages/
-  vera-doc/   # Python document engine and importable `vera` package
+  vera-doc/   # Python document engine and importable `vera_doc` package
   vera-cli/   # terminal interface over vera-doc
   vera-app/   # Electron desktop app plus Python sidecar
 ```

--- a/docs/packages/vera-ingest.md
+++ b/docs/packages/vera-ingest.md
@@ -57,7 +57,7 @@ convert(
 ```
 
 Pass `embedding_function=` for a custom embedder, or use a
-`provider:model-id` model spec resolved by `vera.get_embedder`. New callers
+`provider:model-id` model spec resolved by `vera_doc.get_embedder`. New callers
 should pass `parser`, `pipeline_options`, and embedder settings
 (`model` / `embedding_function` / `embedder_options`); legacy
 kwargs such as `chunk_size` and `ocr_mode` remain compatibility aliases

--- a/docs/vera-spec-v0.1.md
+++ b/docs/vera-spec-v0.1.md
@@ -11,7 +11,7 @@
 
 VERA (Vector-Embedded Retrieval Archive) is a portable, single-file format for semantically searchable documents. An `.vera` file carries a source document together with its parsed structure, text chunks, vector embeddings, keyword index, extracted figures, and citation metadata, so that any compatible application can search the document without re-parsing, re-chunking, or re-embedding it.
 
-This document specifies what a conforming **writer** must produce and what a conforming **reader** can rely on. The reference implementation is the [`vera` Python package](https://github.com/dkylewillis/vera).
+This document specifies what a conforming **writer** must produce and what a conforming **reader** can rely on. The reference implementation is the [`vera-doc` Python package](https://github.com/dkylewillis/vera).
 
 The key words MUST, SHOULD, and MAY are to be interpreted as described in RFC 2119.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -19,7 +19,7 @@ Published on PyPI:
 
 ## `vera-doc`
 
-Publishes `vera`. Owns only storage and search:
+Publishes `vera_doc`. Owns only storage and search:
 
 - chunk-oriented `.vera` schema and validation;
 - typed chunk, attachment, and query-result objects;

--- a/packages/vera-ingest/README.md
+++ b/packages/vera-ingest/README.md
@@ -23,8 +23,8 @@ and OCR engine control which aliases are forwarded (Tesseract-shaped
 explicit `pipeline_options` win. Omitted `convert()` aliases mean the
 pipeline's own default (they are not replaced by 500/`eng`/…).
 
-It emits ready-made `vera.ChunkRecord` values and optional opaque attachments,
-then stores them through `vera.VeraDocument`. It also provides
+It emits ready-made `vera_doc.ChunkRecord` values and optional opaque attachments,
+then stores them through `vera_doc.VeraDocument`. It also provides
 `vera_ingest.viewer` helpers that interpret ingest-produced page, figure,
 region, and source-document conventions.
 
@@ -57,10 +57,10 @@ See the [conversion guide](https://github.com/dkylewillis/vera/blob/main/docs/co
 `convert()` and `batch_convert()` accept either:
 
 - `model="hashing"` / `model="sentence-transformers:all-MiniLM-L6-v2"` — resolved
-  through `vera.get_embedder` before PDF parsing begins, or
+  through `vera_doc.get_embedder` before PDF parsing begins, or
 - `embedding_function=<object>` — any object with `model_name`, `dimension`, and
   `embed(texts)`.
 
-Unknown model specs raise `vera.UnknownEmbeddingModelError`. To add a named
+Unknown model specs raise `vera_doc.UnknownEmbeddingModelError`. To add a named
 provider without forking VERA, register a factory with
-`vera.register_embedder` or ship a `vera.embedders` entry-point plugin.
+`vera_doc.register_embedder` or ship a `vera.embedders` entry-point plugin.

--- a/packages/vera-ingest/src/vera_ingest/convert.py
+++ b/packages/vera-ingest/src/vera_ingest/convert.py
@@ -199,8 +199,8 @@ def convert(
             ``embedding_function`` is provided. Accepts ``provider:model-id``
             or built-in legacy aliases.
         embedding_function: Optional custom embedder satisfying
-            :class:`~vera.EmbeddingFunction`. When omitted, ``model`` is
-            resolved via :func:`~vera.get_embedder` before parsing begins.
+            :class:`~vera_doc.EmbeddingFunction`. When omitted, ``model`` is
+            resolved via :func:`~vera_doc.get_embedder` before parsing begins.
         parser: Ingest pipeline spec in ``provider[:variant]`` form
             (default ``"pymupdf"``).
         chunk_size: Compatibility alias forwarded only when explicitly
@@ -224,7 +224,7 @@ def convert(
         pipeline_options: Explicit provider-owned options. These override
             compatibility aliases for the same keys.
         embedder_options: Explicit provider-owned embedding options forwarded
-            to :func:`~vera.get_embedder` when ``embedding_function`` is omitted.
+            to :func:`~vera_doc.get_embedder` when ``embedding_function`` is omitted.
         cancel: Optional cancellation token with ``raise_if_cancelled()``.
 
     Returns:

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -2,11 +2,13 @@ import re
 from pathlib import Path
 from urllib.parse import unquote
 
+import vera_doc
 from helpers.cli import leaf_commands as _leaf_commands
 from vera_cli.main import build_parser
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
+PACKAGES = ROOT / "packages"
 CLI_REFERENCE = DOCS / "cli-reference.md"
 
 
@@ -16,6 +18,22 @@ def _documentation_files() -> list[Path]:
         ROOT / "AGENTS.md",
         *DOCS.rglob("*.md"),
         *(ROOT / "skills" / "vera").rglob("*.md"),
+    ]
+
+
+def _prose_files() -> list[Path]:
+    """Documentation plus the prose that ships inside the packages.
+
+    Package READMEs become PyPI long descriptions and docstrings become the
+    published API reference, so both carry the same accuracy obligation as
+    ``docs/``.
+    """
+    return [
+        *_documentation_files(),
+        ROOT / "CONTRIBUTING.md",
+        PACKAGES / "README.md",
+        *PACKAGES.glob("*/README.md"),
+        *PACKAGES.glob("*/src/**/*.py"),
     ]
 
 
@@ -29,6 +47,26 @@ def test_local_documentation_links_resolve():
                 continue
             path = (document.parent / unquote(target)).resolve()
             assert path.exists(), f"{document.relative_to(ROOT)} links to missing {raw_target}"
+
+
+def test_prose_refers_to_the_storage_package_as_vera_doc():
+    """0.3 renamed the storage import from ``vera`` to ``vera_doc``.
+
+    Only names the package actually exports are matched, so the ``vera``
+    console script, the ``.vera`` extension, the ``vera.embedders`` and
+    ``vera.ingest_pipelines`` entry-point groups, and the
+    ``application/vnd.vera.*`` media types are all left alone.
+    """
+    exports = "|".join(sorted(vera_doc.__all__))
+    stale = re.compile(rf"\bvera\.({exports})\b")
+    violations = []
+    for document in _prose_files():
+        for number, line in enumerate(document.read_text(encoding="utf-8").splitlines(), 1):
+            violations.extend(
+                f"{document.relative_to(ROOT)}:{number} refers to {match.group(0)}"
+                for match in stale.finditer(line)
+            )
+    assert violations == [], "use vera_doc.<name>: " + "; ".join(violations)
 
 
 def test_documentation_index_lists_user_guides():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`618c677` renamed the storage import from `vera` to `vera_doc` and did the mechanical part completely — there is not a single stale `import vera` or `from vera import` left in the repo. What it missed is prose, where a module reference has no import statement to search for. Nine references still told readers to call functions on a module that no longer exists:

| File | Was | Now |
|------|-----|-----|
| `docs/conversion.md` | `vera.register_embedder` | `vera_doc.register_embedder` |
| `docs/packages/vera-ingest.md` | `vera.get_embedder` | `vera_doc.get_embedder` |
| `packages/vera-ingest/README.md` | `vera.ChunkRecord`, `vera.VeraDocument`, `vera.get_embedder`, `vera.UnknownEmbeddingModelError`, `vera.register_embedder` | `vera_doc.*` |
| `packages/vera-ingest/src/vera_ingest/convert.py` | `:class:`~vera.EmbeddingFunction``, `:func:`~vera.get_embedder`` ×2 | `vera_doc` equivalents |
| `packages/README.md` | "Publishes `vera`." | "Publishes `vera_doc`." |
| `docs/desktop-app-architecture.md` | "importable `vera` package" | "importable `vera_doc` package" |
| `docs/vera-spec-v0.1.md` | "[`vera` Python package]" | "[`vera-doc` Python package]" |

Two of these ship outside the repo. `packages/vera-ingest/README.md` is the PyPI long description for `vera-ingest`, and the `convert()` docstring cross-references render into the published API reference, where they appeared verbatim as `:func:`~vera.get_embedder`` rather than resolving to a link. After the change the reference page renders `vera_doc.EmbeddingFunction` and `vera_doc.get_embedder`.

Deliberately left alone: the `vera` console script, the `.vera` extension, the `vera.embedders` / `vera.ingest_pipelines` / `vera.embedder_descriptors` / `vera.embedder_models` entry-point groups (namespaces, not module paths), the `application/vnd.vera.*` media types, `vera.*` localStorage keys in the renderer, and the `dev.vera.desktop` Electron appId. `docs/reference/vera.md` also keeps its filename — its content already uses `::: vera_doc`, and renaming the page would need a redirect entry.

## Merge with v0.3

Merged `v0.3` after #19 landed. One conflict, in `tests/test_documentation.py`: both branches appended a new test at the same insertion point, #19's `test_site_pages_only_link_relatively_within_the_docs_tree` and this branch's `test_prose_refers_to_the_storage_package_as_vera_doc`. The two are independent and both are kept, with the link tests grouped together since #19's docstring refers to `test_local_documentation_links_resolve`. `docs/conversion.md` auto-merged — the branches changed different lines of it (line 174 here, the OpenAI plugin link at line 200 in #19) and both edits are present. The net diff against `v0.3` is exactly this PR's changes, with nothing from #19 reverted.

## Test plan

- [x] Verified all six replacement names are public exports of `vera_doc` before using them.
- [x] Re-swept the whole repo per occurrence rather than per line, which is how `vera.register_embedder` had stayed hidden: it shares a line with the legitimate `vera.embedders` entry-point group in `packages/vera-ingest/README.md`. Nothing stale remains.
- [x] `tests/test_documentation.py::test_prose_refers_to_the_storage_package_as_vera_doc` added. It matches only names `vera_doc` actually exports, so the look-alikes above cannot trip it, and it covers package READMEs and package sources — where every one of these had survived. Restoring a stale reference in a docs page, a package README, and a docstring makes it fail on all three with file and line.
- [x] Both documentation-contract tests re-checked after the merge: each still fails on its own regression and passes otherwise.
- [x] `uv run --extra docs mkdocs build --strict` now exits 0 on this branch, since #19's link fixes came in with the merge.
- [x] `uv build --package vera-ingest-pymupdf` still succeeds, confirming #19's packaging fix survived the merge.
- [x] Full suite green: `ruff check`, `ruff format --check`, `mypy packages/vera-doc/src`, `uv run --extra dev pytest -q` (413 passed, 2 skipped).
- [x] Retrieval baselines unaffected — documentation and one test only.

## Documentation

- [x] This change is the documentation fix; the published API reference was rebuilt and inspected.
- [x] Documentation-contract test added for the rule that was being violated.
- [x] Not applicable otherwise: no CLI, JSON, exit-code, MCP, or agent-facing contract changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cc0cee9-93aa-4768-845b-4f8c41940a80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cc0cee9-93aa-4768-845b-4f8c41940a80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

