### PR TITLE
feat: run extra ingest plugins from a trusted external Python

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ Requires the integration package: `pip install "vera-cli[mcp]"` or `pip install 
 - Python 3.10+, dependencies managed with [uv](https://docs.astral.sh/uv/):
   `uv sync --extra dev --extra ml --extra app --extra mcp`
 - Run tests with `pytest` (all tests must pass before committing).
-- Storage/search code lives in [packages/vera-doc/src/vera](packages/vera-doc/src/vera), extraction lives in [packages/vera-ingest/src/vera_ingest](packages/vera-ingest/src/vera_ingest), MCP lives in [packages/vera-mcp/src/vera_mcp](packages/vera-mcp/src/vera_mcp), and CLI code lives in [packages/vera-cli/src/vera_cli](packages/vera-cli/src/vera_cli); the current format spec is
+- Storage/search code lives in [packages/vera-doc/src/vera](packages/vera-doc/src/vera), extraction lives in [packages/vera-ingest/src/vera_ingest](packages/vera-ingest/src/vera_ingest), MCP lives in [packages/vera-mcp/src/vera_mcp](packages/vera-mcp/src/vera_mcp), CLI code lives in [packages/vera-cli/src/vera_cli](packages/vera-cli/src/vera_cli), and the desktop plugin host lives in [packages/vera-app/src/vera_plugin_host](packages/vera-app/src/vera_plugin_host); the current format spec is
  [docs/vera-spec-v0.2.md](docs/vera-spec-v0.2.md) — keep code and spec in sync.
 - Keep human and agent documentation current. Any user-visible feature change
   must update the relevant [README](README.md), human guide under
@@ -190,7 +190,9 @@ non-obvious caveats for this environment; standard commands live in the sections
   (OpenAI/OpenRouter/Ollama/LM Studio) — there is no offline/extractive answer mode, so Ask is
   blocked without a provider/API key. For fully offline testing use the left-sidebar **Search**
   view (pure hybrid/semantic/keyword retrieval with grounded citations and highlights) or the
-  **Convert PDF** view; both run entirely through the sidecar with no LLM.
+  **Convert PDF** view. Convert keeps the bundled PyMuPDF pipeline in the sidecar; extra ingest
+  plugins require a validated external Python environment under **File > LLM Providers**. Ask is
+  blocked without a provider/API key.
 - MCP server (optional): `uv run --extra mcp vera mcp` (long-running stdio; no `--json`).
 - There are no PDFs in the repo; generate one with the `reportlab` dev dependency when you need
   a sample to `vera convert`.

--- a/README.md
+++ b/README.md
@@ -274,10 +274,12 @@ time. See [document libraries](docs/document-libraries.md) and the
 
 This release ships with built-in components:
 
-- **Parsing** — the `pymupdf` parser (PyMuPDF + pdfplumber): text extraction,
-  table detection, heading detection, and selective Tesseract OCR with
-  bundled English data. It lives inside `vera-ingest` and is selected with
-  `vera convert --parser pymupdf` (the default).
+- **Parsing** — the bundled `pymupdf` parser (PyMuPDF + pdfplumber): text
+  extraction, table detection, heading detection, and selective Tesseract OCR
+  with bundled English data. Additional parsers can register under the
+  `vera.ingest_pipelines` entry-point group and are selected with
+  `vera convert --parser <provider>`. The desktop app can also run those
+  plugins from a user-selected Python environment.
 - **Embedding** — two built-in models selected with `--model`: `hashing`
   (deterministic lexical hashing; no extra dependencies or network access)
   and Sentence Transformers models such as `all-MiniLM-L6-v2` or any
@@ -291,19 +293,24 @@ vera convert manual.pdf --model all-MiniLM-L6-v2      # local neural model
 The archive records which embedding model produced its vectors, and search
 resolves the same model to embed queries.
 
-### Plugin system (planned for v0.3)
+### Ingest pipeline plugins
 
-The format itself does not depend on one parser or one embedding provider,
-and the next release makes both pluggable through standard Python entry
-points. In development on the
+`vera-ingest` 0.2.x discovers extra parsers from the `vera.ingest_pipelines`
+entry-point group. The bundled parser remains `pymupdf`. Install a plugin into
+the same environment as `vera-ingest` with `python -m pip install <package>` or
+`python -m pip install -e <clone>`, then pass `--parser <provider>`. Unknown
+names fail before parsing. The desktop app can run those plugins from a trusted
+external Python environment without freezing them into the sidecar. See
+[Creating an ingest pipeline plugin](docs/creating-an-ingest-pipeline.md).
+
+A broader plugin split (moving PDF parsing into `vera-ingest-pymupdf` /
+`vera-ingest-docling`, plus embedding provider plugins) remains planned for
+v0.3. In development on the
 [`v0.3` branch](https://github.com/dkylewillis/vera/tree/v0.3):
 
 - **Ingest pipeline plugins** (`vera.ingest_pipelines` entry-point group) —
   pipelines selected by `provider[:variant]` spec and configured with
-  repeatable `--pipeline-option KEY=VALUE` flags. PDF parsing moves into a
-  `vera-ingest-pymupdf` plugin package, and an optional
-  `vera-ingest-docling` plugin adds Docling layout models with hybrid
-  chunking.
+  repeatable `--pipeline-option KEY=VALUE` flags.
 - **Embedding provider plugins** (`vera.embedders` entry-point group) —
   models resolved from `provider:model-id` specs with provider-owned
   `--embedder-option KEY=VALUE` flags, descriptor metadata for schema-driven
@@ -400,7 +407,9 @@ filters, corpus search, and embedding configuration.
 VERA also includes a desktop application for Windows: PDF conversion from the
 Explorer context menu, library search with highlighted citations, and an
 optional LLM provider connection for grounded question answering over
-documents. It is built on the same packages described above. Download it from
+documents. Packaged conversions use the bundled PyMuPDF pipeline; extra ingest
+plugins can run from a trusted external Python environment. It is built on the
+same packages described above. Download it from
 [GitHub Releases](https://github.com/dkylewillis/vera/releases/latest) and see
 the [desktop app guide](docs/desktop-app-getting-started.md).
 
@@ -427,9 +436,9 @@ browse the [published docs](https://dkylewillis.github.io/vera/).
 
 VERA is an experimental pre-1.0 project. The `.vera` schema and format may
 change before a stable release. `main` is the maintenance line for VERA 0.2;
-feature work, including the plugin system, is integrated on the
-[`v0.3` branch](https://github.com/dkylewillis/vera/tree/v0.3). The desktop
-installer currently targets Windows and is available from
+ingest pipeline discovery is available here, while the broader plugin split is
+integrated on the [`v0.3` branch](https://github.com/dkylewillis/vera/tree/v0.3).
+The desktop installer currently targets Windows and is available from
 [GitHub Releases](https://github.com/dkylewillis/vera/releases).
 
 VERA is licensed under [Apache-2.0](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ JSON-compatible caller data.
 
 `vera-ingest` publishes `vera_ingest`. It owns all source interpretation:
 
-- PDF parsing and table extraction;
+- PDF parsing and table extraction, plus optional ingest pipeline plugins;
 - selective OCR and bundled Tesseract data;
 - heading detection and chunk construction;
 - mapping pages, regions, figures, and provenance to chunk metadata;
@@ -64,8 +64,11 @@ helpers. The optional `vera-cli[mcp]` extra installs it for `vera mcp`.
 ### `vera-app`
 
 `vera-app` owns the Electron/React desktop application, Python sidecar, LLM
-providers, sessions, and application state. It depends on both `vera-doc` and
-`vera-ingest` (including viewer helpers), not on `vera-cli`.
+providers, sessions, and application state. Packaged conversions keep the
+frozen sidecar for search, indexing, Ask, and the bundled `pymupdf` pipeline.
+Optional ingest plugins run in a shipped `vera_plugin_host` worker launched
+with a user-selected Python interpreter. The app depends on both `vera-doc`
+and `vera-ingest` (including viewer helpers), not on `vera-cli`.
 
 ## Core Python API
 
@@ -130,10 +133,10 @@ packages/
   vera-ingest/
     src/vera_ingest/
       convert.py
-      ingest/
-        chunking.py
-        parsers/pdf.py
-        tessdata/
+      pipeline.py
+      chunking.py
+      parsers/pdf.py
+      tessdata/
   vera-cli/
     src/vera_cli/
       commands.py
@@ -142,6 +145,12 @@ packages/
     src/vera_mcp/
       server.py
   vera-app/
+    src/vera_app/
+      sidecar.py
+    src/vera_plugin_host/
+      worker.py
+    electron/
+      main.ts
 ```
 
 The root uv workspace links packages as editable dependencies. Published

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -29,7 +29,7 @@ Convert one PDF or a directory of PDFs.
 Options:
 
 - `--model MODEL` (`hashing`)
-- `--parser PARSER` (`pymupdf`)
+- `--parser PARSER` (`pymupdf`; additional providers when ingest plugins are installed)
 - `--chunk-size N` (`500`)
 - `--overlap N` (`75`)
 - `--store-original VALUE` (`true`)

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -58,8 +58,8 @@ OCR text is stored as ordinary paragraph blocks with page bounding boxes, so
 search results and highlight regions work normally. This first OCR path targets
 scanned prose. It does not reconstruct scanned tables, forms, or complex
 multi-column reading order. Use an external layout-aware OCR tool for those
-documents; Docling is a candidate for a future optional parser if representative
-corpus testing shows that need.
+documents; optional ingest plugins can provide layout-aware parsers. See
+[Creating an ingest pipeline plugin](creating-an-ingest-pipeline.md).
 
 ## Convert a directory
 
@@ -145,13 +145,27 @@ representative query set before adopting non-default values.
 
 ## Parser
 
-`vera-ingest` currently supports the `pymupdf` parser:
+The bundled parser is `pymupdf`:
 
 ```bash
 vera convert "input.pdf" --parser pymupdf
 ```
 
-Other parser names currently fail.
+Additional parsers are discovered from installed packages that register the
+`vera.ingest_pipelines` entry-point group:
+
+```bash
+python -m pip install vera-ingest-docling
+vera convert "input.pdf" --parser docling
+```
+
+Cloned plugins need an editable install so entry points are visible:
+
+```bash
+python -m pip install -e ./my-vera-plugin
+```
+
+Unknown names fail before parsing and never fall back to another pipeline.
 
 ## Storing the source PDF
 

--- a/docs/creating-an-ingest-pipeline.md
+++ b/docs/creating-an-ingest-pipeline.md
@@ -1,0 +1,97 @@
+# Creating an ingest pipeline plugin
+
+`vera-ingest` bundles the `pymupdf` parser. Extra parsers register as ordinary
+Python packages so the CLI and desktop app can discover them at runtime.
+
+## Entry points
+
+A plugin publishes two setuptools entry points:
+
+```toml
+[project.entry-points."vera.ingest_pipelines"]
+example = "my_vera_plugin:create_pipeline"
+
+[project.entry-points."vera.ingest_pipeline_descriptors"]
+example = "my_vera_plugin:create_descriptor"
+```
+
+The entry-point name is the provider (`example`). Users select it with
+`--parser example` or `--parser example:variant`.
+
+## Factories
+
+`create_pipeline(variant)` must return a callable
+`(source_path, output_path, **options) -> str` or an object with a matching
+`convert()` method. The return value is the output `.vera` path.
+
+`create_descriptor(variant)` must return a
+`vera_ingest.pipeline.PipelineDescriptor`.
+
+```python
+from vera_ingest.pipeline import PipelineDescriptor, UnknownIngestPipelineError
+
+def create_pipeline(variant: str = ""):
+    if (variant or "").strip().lower() not in {"", "default"}:
+        raise UnknownIngestPipelineError(
+            f"Unknown example pipeline variant {variant!r}; use 'example'."
+        )
+
+    def ingest(source_path: str, output_path: str, **options) -> str:
+        # Parse, chunk, write, and validate a .vera archive, then return output_path.
+        return output_path
+
+    return ingest
+
+def create_descriptor(variant: str = "") -> PipelineDescriptor:
+    return PipelineDescriptor(
+        provider="example",
+        spec="example",
+        label="example — custom parser",
+        description="Example ingest plugin.",
+        installed=True,
+    )
+```
+
+Known convert options include `model`, `chunk_size`, `overlap`,
+`store_original`, `ocr_mode`, `ocr_language`, `ocr_dpi`, and `cancel`. Plugins
+may ignore options they do not implement.
+
+## Install
+
+Published package:
+
+```bash
+python -m pip install my-vera-plugin
+vera convert "input.pdf" --parser example
+```
+
+Cloned repository (editable, keeps source in the clone):
+
+```bash
+git clone https://github.com/example/my-vera-plugin.git
+python -m pip install -e ./my-vera-plugin
+vera convert "input.pdf" --parser example
+```
+
+Editable installs create distribution metadata, which is what
+`importlib.metadata` uses to find entry points. Adding a clone to
+`PYTHONPATH` without installing it is not enough.
+
+The selected environment must provide `vera-ingest` 0.2.x (plugin API version
+1). Confirm discovery with:
+
+```python
+from vera_ingest import list_ingest_pipelines
+print(list_ingest_pipelines())
+```
+
+## Desktop app
+
+The packaged app does not freeze optional plugins into `vera-sidecar.exe`.
+Configure a trusted external Python interpreter under **File > LLM Providers**,
+install the plugin into that environment, then Validate / Refresh. Convert
+lists bundled pipelines from the sidecar and extra providers from the plugin
+host. Duplicate provider names keep the bundled implementation.
+
+See [Run the desktop app](desktop-app-getting-started.md) and
+[Desktop app architecture](desktop-app-architecture.md).

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -62,8 +62,35 @@ Initial actions:
 - `index_status`
 - `index_build`
 - `index_update`
+- `list_ingest_pipelines`
+- `describe_ingest_pipelines`
 
 This keeps the app UI independent from Python internals while preserving a simple local development loop.
+
+## External ingest plugin host
+
+Packaged conversions keep the frozen sidecar for search, indexing, Ask, and
+the bundled `pymupdf` pipeline. Optional ingest plugins run in a second
+JSON-lines process:
+
+```text
+Electron main
+  ├─ Frozen core sidecar (vera-sidecar.exe)
+  └─ External plugin host (`python -m vera_plugin_host`)
+```
+
+The plugin host is shipped as source under `python/plugin-host` and is launched
+with an absolute user-selected interpreter. That environment must provide a
+compatible `vera-ingest` (same `0.2.x` series and plugin API version 1) plus
+any plugin packages. Plugins are discovered from the `vera.ingest_pipelines`
+and `vera.ingest_pipeline_descriptors` entry-point groups, so published wheels
+and editable installs (`python -m pip install -e <clone>`) work; raw
+`PYTHONPATH` source folders do not. Bundled providers win when a plugin repeats
+a name such as `pymupdf`. The feature is advanced/trusted: the selected
+interpreter executes local code with the user's permissions. Hugging Face
+tokens and optional `DOCLING_ARTIFACTS_PATH` values are forwarded to the host.
+Conversion progress, cancel, and skip are routed to the process that owns the
+request.
 
 ## Active Libraries and Collection Indexes
 
@@ -245,6 +272,9 @@ so semantic embedding encode/query works when those packages are installed in
 the build environment, and excludes unrelated ML/dev imports (for example
 `torchvision`, `torchaudio`, `pandas`, `cv2`, `pytest`) that a local
 `--extra ml` / `--extra dev` venv would otherwise pull into the installer.
+The same dist step copies `vera_plugin_host` into `python/plugin-host` so a
+packaged app can launch ingest plugins with a user-selected interpreter
+without freezing those plugins into the sidecar.
 
 From the repo root:
 

--- a/docs/desktop-app-getting-started.md
+++ b/docs/desktop-app-getting-started.md
@@ -51,14 +51,20 @@ to stop both processes.
 
 Open a PDF from the app's Convert view to create a `.vera` archive, or use the
 native File menu to open an existing archive or document library.
-Desktop conversions use the supported PyMuPDF parser and deterministic
-local hashing embeddings. Use the CLI when you need a Sentence Transformers
-model or explicit OCR controls. Some Hub downloads warn about unauthenticated
-requests; save an optional Hugging Face token under **File > LLM Providers →
-Hugging Face** (or set `HF_TOKEN` / copy `.env.example` to `.env`) to raise
-rate limits. Conversion progress and the current filename appear in the footer
-status bar, so progress remains visible when you switch away from the Convert
-view.
+Desktop conversions default to the bundled PyMuPDF parser and deterministic
+local hashing embeddings. Convert can also use ingest plugins installed in a
+user-selected Python environment: enable **External Python plugins** under
+**File > LLM Providers**, choose an absolute `python.exe` path, then Validate.
+Install plugins with `python -m pip install <package>` or
+`python -m pip install -e <clone>` so VERA can discover their
+`vera.ingest_pipelines` entry points. Packaged releases do not bundle optional
+parsers. Use the CLI when you need a Sentence Transformers model or explicit
+OCR controls. Some Hub downloads warn about unauthenticated requests; save an
+optional Hugging Face token under **File > LLM Providers → Hugging Face** (or
+set `HF_TOKEN` / copy `.env.example` to `.env`) to raise rate limits. The token
+is also forwarded to the external plugin host. Conversion progress and the
+current filename appear in the footer status bar, so progress remains visible
+when you switch away from the Convert view.
 
 Use the **Chat / Search** switch above the center workspace to choose between
 LLM-backed conversation and direct retrieval. Search supports hybrid, semantic,
@@ -138,6 +144,40 @@ npm run app:release
 This removes the existing `packages/vera-app/release` directory, rebuilds the
 app and Python sidecar, and writes an NSIS installer into that directory.
 
+## External ingest plugins
+
+Packaged conversions keep the bundled PyMuPDF pipeline inside the frozen
+sidecar. Optional parsers run in a second process launched with a Python
+interpreter you select. Treat that interpreter as trusted code: installed
+plugins run with your user permissions.
+
+1. Create a virtual environment. Windows example:
+
+   ```bat
+   python -m venv %USERPROFILE%\vera-plugins
+   %USERPROFILE%\vera-plugins\Scripts\python.exe -m pip install "vera-ingest>=0.2.5"
+   ```
+
+2. Install a published plugin, or an editable clone so entry points are visible:
+
+   ```bat
+   python -m pip install vera-ingest-docling
+   python -m pip install -e C:\src\my-vera-plugin
+   ```
+
+   Adding a clone to `PYTHONPATH` without installing it is not enough.
+
+3. In VERA, open **File > LLM Providers**, enable **External Python plugins**,
+   choose that environment's `python.exe`, and click **Validate**.
+4. Convert lists extra providers as `(external)`. Bundled `pymupdf` wins when a
+   plugin repeats that name. After installing or updating plugins, click
+   **Refresh plugins**.
+
+The selected environment must provide `vera-ingest` 0.2.x (plugin API version
+1). Optional Hugging Face tokens and the **Model cache** field
+(`DOCLING_ARTIFACTS_PATH`) are forwarded to the plugin host. See
+[Creating an ingest pipeline plugin](creating-an-ingest-pipeline.md).
+
 ## Common startup problems
 
 - **`uv` is not recognized** — install `uv`, open a new terminal, and rerun the
@@ -160,6 +200,13 @@ app and Python sidecar, and writes an NSIS installer into that directory.
 
   Set `VERA_SIDECAR_PYTHON` to use a different interpreter, or exclude the
   repository and `%TEMP%` from real-time scanning, then retry.
+- **Validate fails for the external Python environment** — choose an absolute
+  `python.exe` path that exists, install `vera-ingest` 0.2.x into that
+  environment, then Validate again.
+- **An extra parser is missing from Convert** — install it with
+  `python -m pip install` or `python -m pip install -e <clone>` in the selected
+  environment, then **Refresh plugins**. Raw `PYTHONPATH` folders are not
+  discovered.
 
 ## Provider request errors
 

--- a/docs/packages/vera-app.md
+++ b/docs/packages/vera-app.md
@@ -16,7 +16,9 @@ Download `VERA Setup <version>.exe` from the
 
 ## First workflow
 
-1. Open **Convert PDF** and convert selected PDFs or a directory.
+1. Open **Convert PDF** and convert selected PDFs or a directory. Choose an
+   ingest pipeline; extra parsers appear after you validate an external Python
+   environment under **File > LLM Providers**.
 2. Use **File > Open Folder** to activate a document library.
 3. Open **Search** for fully local hybrid retrieval.
 4. To use **Ask**, configure a provider under **File > LLM Providers**.
@@ -27,6 +29,13 @@ Download `VERA Setup <version>.exe` from the
 
 Search and conversion do not require a model-provider account. A provider is
 only required for generated Ask responses.
+
+Packaged conversions keep PyMuPDF in the frozen sidecar. Extra ingest plugins
+run from a trusted external Python environment configured under
+**File > LLM Providers**. Install plugins with `python -m pip install` or
+`python -m pip install -e <clone>`, then Validate / Refresh. See
+[Creating an ingest pipeline plugin](../creating-an-ingest-pipeline.md) and
+[Desktop app architecture](../desktop-app-architecture.md).
 
 ## Documentation
 

--- a/docs/packages/vera-ingest.md
+++ b/docs/packages/vera-ingest.md
@@ -49,12 +49,16 @@ convert(
 - **Chunking** produces page-bounded text records with citation metadata.
 - **Atomic conversion** validates a temporary archive before publishing it.
 
-The package currently supports the `pymupdf` parser. OCR is designed for
-scanned prose; it does not reconstruct complex scanned forms or tables.
+The package currently bundles the `pymupdf` parser. Additional parsers register
+as plugins under the `vera.ingest_pipelines` entry-point group; see
+[Creating an ingest pipeline plugin](../creating-an-ingest-pipeline.md).
+OCR is designed for scanned prose; it does not reconstruct complex scanned
+forms or tables.
 
 ## Documentation
 
 - [Convert documents](../conversion.md) — OCR, chunking, embedding, and batch conversion.
+- [Creating an ingest pipeline plugin](../creating-an-ingest-pipeline.md) — entry points for extra parsers.
 - [Figures and regions](../figures-and-regions.md) — extracted visual metadata and
   [schema storage map](../figures-and-regions.md#storage-map-vera-02-schema).
 - [Conversion recipes](../examples.md) — single files, scans, and nested libraries.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -219,6 +219,7 @@ convert(
     "input.pdf",
     "output.vera",
     model="hashing",
+    parser="pymupdf",
     chunk_size=500,
     overlap=75,
     store_original=True,
@@ -227,7 +228,9 @@ convert(
 ```
 
 `vera-ingest` parses and chunks the source, creates `ChunkRecord` objects and
-optional attachments, then writes them through `VeraDocument`.
+optional attachments, then writes them through `VeraDocument`. Extra parsers
+register under `vera.ingest_pipelines`; see
+[Creating an ingest pipeline plugin](creating-an-ingest-pipeline.md).
 
 ## Corpus and library indexes
 

--- a/docs/reference/vera-ingest.md
+++ b/docs/reference/vera-ingest.md
@@ -7,6 +7,14 @@ PDF parsing, chunking, and conversion to `.vera` archives.
       members:
         - convert
         - batch_convert
+        - list_ingest_pipelines
+        - list_ingest_pipeline_descriptors
+        - describe_ingest_pipeline
+        - get_ingest_pipeline
+        - register_ingest_pipeline
+        - PipelineDescriptor
+        - UnknownIngestPipelineError
+        - PLUGIN_API_VERSION
         - Chunk
         - ParsedBlock
         - ParsedPage

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -159,13 +159,31 @@ temporary output.
 
 ## Conversion fails for a parser name
 
-`vera-ingest` supports:
+`--parser` must name an installed ingest pipeline (`provider` or
+`provider:variant`). The bundled provider is `pymupdf`:
 
 ```bash
 vera convert "input.pdf" --parser pymupdf
 ```
 
-Other parser names are not currently implemented.
+Install extra parsers into the same environment as `vera-ingest`, then retry:
+
+```bash
+python -m pip install vera-ingest-docling
+vera convert "input.pdf" --parser docling
+```
+
+Cloned plugins need an editable install so entry points are visible:
+
+```bash
+python -m pip install -e ./my-vera-plugin
+```
+
+Unknown names fail before parsing and never fall back to another pipeline.
+
+In the packaged desktop app, extra parsers also need a validated external
+Python interpreter under **File > LLM Providers**. The frozen sidecar only
+bundles PyMuPDF.
 
 If Hugging Face Hub downloads warn about unauthenticated requests or hit rate
 limits, set `HF_TOKEN` (see `.env.example`) or save a token under **File >

--- a/docs/user-documentation.md
+++ b/docs/user-documentation.md
@@ -17,6 +17,7 @@ figures, and citation metadata in one portable `.vera` file.
 ## User guides
 
 - [Convert documents](conversion.md)
+- [Creating an ingest pipeline plugin](creating-an-ingest-pipeline.md)
 - [Search documents](searching.md)
 - [Search and index document libraries](document-libraries.md)
 - [Work with figures and highlight regions](figures-and-regions.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Overview and concepts: packages/vera-ingest.md
       - Guides:
           - Convert documents: conversion.md
+          - Creating an ingest pipeline plugin: creating-an-ingest-pipeline.md
       - Examples:
           - Python examples: packages/vera-ingest-examples.md
       - API reference:

--- a/packages/vera-app/README.md
+++ b/packages/vera-app/README.md
@@ -1,8 +1,8 @@
 # vera-app
 
-`vera-app` contains the Electron/React desktop application and its Python
-sidecar. It composes `vera-doc` for storage/search with `vera-ingest` for
-conversion.
+`vera-app` contains the Electron/React desktop application, its Python
+sidecar, and the shipped `vera_plugin_host` worker used with a user-selected
+interpreter for optional ingest plugins.
 
 See the [vera-app documentation](https://dkylewillis.github.io/vera/packages/vera-app/)
 for installation, user workflows, and architecture.

--- a/packages/vera-app/electron/ingest-runtime.test.ts
+++ b/packages/vera-app/electron/ingest-runtime.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BUNDLED_PIPELINE_PROVIDER,
+  conversionRuntimeOwner,
+  isBundledPipeline,
+  mergePipelineDescriptors,
+  normalizeExternalPython,
+  parsePipelineProvider,
+  pluginHostCompatibilityError,
+  pluginHostSpawnCommand,
+  processOwnerFor,
+  shouldRouteToExternal,
+} from './ingest-runtime.js';
+import type { PipelineDescriptor } from '../src/shared/contracts.js';
+
+const pymupdf: PipelineDescriptor = {
+  provider: 'pymupdf',
+  spec: 'pymupdf',
+  label: 'pymupdf',
+  installed: true,
+  source: 'bundled',
+};
+
+const docling: PipelineDescriptor = {
+  provider: 'docling',
+  spec: 'docling',
+  label: 'docling',
+  installed: true,
+  source: 'external',
+};
+
+describe('ingest-runtime', () => {
+  it('parses provider names from pipeline specs', () => {
+    expect(parsePipelineProvider('')).toBe(BUNDLED_PIPELINE_PROVIDER);
+    expect(parsePipelineProvider('docling:hybrid')).toBe('docling');
+    expect(isBundledPipeline('pymupdf')).toBe(true);
+    expect(isBundledPipeline('docling')).toBe(false);
+  });
+
+  it('keeps bundled providers when merging duplicates', () => {
+    const duplicate: PipelineDescriptor = { ...pymupdf, source: 'external', label: 'external pymupdf' };
+    const merged = mergePipelineDescriptors([pymupdf], [duplicate, docling]);
+    expect(merged.map((item) => item.provider)).toEqual(['pymupdf', 'docling']);
+    expect(merged[0]?.source).toBe('bundled');
+    expect(merged[1]?.source).toBe('external');
+  });
+
+  it('routes unknown providers to the external worker', () => {
+    expect(shouldRouteToExternal('pymupdf', ['pymupdf'])).toBe(false);
+    expect(shouldRouteToExternal('docling', ['pymupdf'])).toBe(true);
+    expect(shouldRouteToExternal('docling:hybrid', ['pymupdf'])).toBe(true);
+  });
+
+  it('rejects incompatible plugin hosts', () => {
+    expect(pluginHostCompatibilityError({
+      protocol: 1,
+      plugin_api: 1,
+      vera_ingest_version: '0.2.5',
+    })).toBeNull();
+    expect(pluginHostCompatibilityError({
+      protocol: 2,
+      plugin_api: 1,
+      vera_ingest_version: '0.2.5',
+    })).toMatch(/protocol/);
+    expect(pluginHostCompatibilityError({
+      protocol: 1,
+      plugin_api: 1,
+      vera_ingest_version: '0.3.0',
+    })).toMatch(/not compatible/);
+  });
+
+  it('normalizes external Python settings and disables empty interpreters', () => {
+    expect(normalizeExternalPython(null)).toEqual({ enabled: false, executable: '' });
+    expect(normalizeExternalPython({
+      enabled: true,
+      executable: '  C:\\venvs\\plugins\\Scripts\\python.exe  ',
+      artifacts_path: '  D:\\models  ',
+      validated_at: 42,
+    })).toEqual({
+      enabled: true,
+      executable: 'C:\\venvs\\plugins\\Scripts\\python.exe',
+      artifacts_path: 'D:\\models',
+      validated_at: 42,
+    });
+    expect(normalizeExternalPython({ enabled: true, executable: '   ' }).enabled).toBe(false);
+  });
+
+  it('builds plugin host spawn arguments for Windows interpreter paths', () => {
+    const command = pluginHostSpawnCommand({
+      pythonPath: 'C:\\Users\\me\\venv\\Scripts\\python.exe',
+      pluginHostRoot: 'C:\\Program Files\\VERA\\resources\\python\\plugin-host',
+      artifactsPath: 'D:\\docling-cache',
+      extraEnv: {
+        PATH: 'C:\\Windows',
+        PYTHONPATH: 'C:\\should-not-leak',
+        DOCLING_ARTIFACTS_PATH: 'C:\\old-cache',
+        HF_TOKEN: 'hf_test',
+      },
+    });
+    expect(command.executable).toBe('C:\\Users\\me\\venv\\Scripts\\python.exe');
+    expect(command.args).toEqual(['-m', 'vera_plugin_host']);
+    expect(command.env.PYTHONPATH).toBe('C:\\Program Files\\VERA\\resources\\python\\plugin-host');
+    expect(command.env.PYTHONUNBUFFERED).toBe('1');
+    expect(command.env.PYTHONNOUSERSITE).toBe('1');
+    expect(command.env.DOCLING_ARTIFACTS_PATH).toBe('D:\\docling-cache');
+    expect(command.env.HF_TOKEN).toBe('hf_test');
+  });
+
+  it('routes convert requests by provider and keeps cancel ownership', () => {
+    expect(conversionRuntimeOwner('search', 'docling', ['pymupdf'], true)).toBe('core');
+    expect(conversionRuntimeOwner('convert', 'pymupdf', ['pymupdf'], true)).toBe('core');
+    expect(conversionRuntimeOwner('convert', 'docling', ['pymupdf'], true)).toBe('external');
+    expect(conversionRuntimeOwner('batch_convert', 'docling', ['pymupdf'], false)).toBe('core');
+    const owners = new Map<string, 'core' | 'external'>([['req-ext', 'external'], ['req-core', 'core']]);
+    expect(processOwnerFor('req-ext', owners)).toBe('external');
+    expect(processOwnerFor('req-core', owners)).toBe('core');
+    expect(processOwnerFor('missing', owners)).toBe('core');
+  });
+});

--- a/packages/vera-app/electron/ingest-runtime.ts
+++ b/packages/vera-app/electron/ingest-runtime.ts
@@ -1,0 +1,229 @@
+import type {
+  ExternalPythonConfig,
+  PipelineDescriptor,
+  PythonEnvironmentProbe,
+} from '../src/shared/contracts.js';
+import {
+  COMPATIBLE_INGEST_MAJOR,
+  COMPATIBLE_INGEST_MINOR,
+  PLUGIN_API_VERSION,
+  PLUGIN_HOST_PROTOCOL,
+  SIDECAR_ACTIONS,
+} from '../src/shared/protocol.js';
+
+export const BUNDLED_PIPELINE_PROVIDER = 'pymupdf';
+
+export function parsePipelineProvider(spec: string | undefined | null): string {
+  const raw = (spec || '').trim().toLowerCase();
+  if (!raw) return BUNDLED_PIPELINE_PROVIDER;
+  const provider = raw.split(':', 1)[0]?.trim();
+  return provider || BUNDLED_PIPELINE_PROVIDER;
+}
+
+export function isBundledPipeline(spec: string | undefined | null): boolean {
+  return parsePipelineProvider(spec) === BUNDLED_PIPELINE_PROVIDER;
+}
+
+export function normalizePipelineDescriptor(
+  raw: unknown,
+  source: 'bundled' | 'external',
+): PipelineDescriptor | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const item = raw as Record<string, unknown>;
+  const provider = typeof item.provider === 'string' ? item.provider.trim().toLowerCase() : '';
+  const spec = typeof item.spec === 'string' && item.spec.trim()
+    ? item.spec.trim()
+    : provider;
+  if (!provider && !spec) return null;
+  const notes = Array.isArray(item.notes)
+    ? item.notes.filter((value): value is string => typeof value === 'string')
+    : [];
+  const fields = Array.isArray(item.fields)
+    ? item.fields.filter((value) => value && typeof value === 'object') as PipelineDescriptor['fields']
+    : [];
+  return {
+    provider: provider || parsePipelineProvider(spec),
+    variant: typeof item.variant === 'string' ? item.variant : '',
+    spec: spec || provider,
+    label: typeof item.label === 'string' ? item.label : spec || provider,
+    description: typeof item.description === 'string' ? item.description : '',
+    installed: item.installed !== false,
+    capabilities: item.capabilities && typeof item.capabilities === 'object'
+      ? item.capabilities as Record<string, unknown>
+      : {},
+    fields,
+    notes,
+    source,
+  };
+}
+
+export function mergePipelineDescriptors(
+  bundled: PipelineDescriptor[],
+  external: PipelineDescriptor[],
+): PipelineDescriptor[] {
+  const merged: PipelineDescriptor[] = [];
+  const seen = new Set<string>();
+  for (const descriptor of bundled) {
+    const key = descriptor.provider || parsePipelineProvider(descriptor.spec);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ ...descriptor, source: 'bundled' });
+  }
+  for (const descriptor of external) {
+    const key = descriptor.provider || parsePipelineProvider(descriptor.spec);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push({ ...descriptor, source: 'external' });
+  }
+  return merged;
+}
+
+export function shouldRouteToExternal(
+  parser: string | undefined | null,
+  bundledProviders: Iterable<string>,
+): boolean {
+  const provider = parsePipelineProvider(parser);
+  const bundled = new Set(
+    [...bundledProviders].map((item) => item.trim().toLowerCase()).filter(Boolean),
+  );
+  if (bundled.size === 0) {
+    return !isBundledPipeline(provider);
+  }
+  return !bundled.has(provider);
+}
+
+export function parseVersionParts(version: string | undefined | null): { major: number; minor: number } | null {
+  if (!version) return null;
+  const match = version.trim().match(/^(\d+)\.(\d+)/);
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+export function pluginHostCompatibilityError(probe: {
+  protocol?: number;
+  plugin_api?: number;
+  vera_ingest_version?: string;
+}): string | null {
+  if (probe.protocol !== PLUGIN_HOST_PROTOCOL) {
+    return `Incompatible plugin host protocol ${probe.protocol ?? '(missing)'}; expected ${PLUGIN_HOST_PROTOCOL}.`;
+  }
+  if (probe.plugin_api !== PLUGIN_API_VERSION) {
+    return `Incompatible ingest plugin API ${probe.plugin_api ?? '(missing)'}; expected ${PLUGIN_API_VERSION}.`;
+  }
+  const parts = parseVersionParts(probe.vera_ingest_version);
+  if (!parts) {
+    return 'The selected Python environment did not report a vera-ingest version.';
+  }
+  if (parts.major !== COMPATIBLE_INGEST_MAJOR || parts.minor !== COMPATIBLE_INGEST_MINOR) {
+    return (
+      `vera-ingest ${probe.vera_ingest_version} is not compatible with this app ` +
+      `(requires ${COMPATIBLE_INGEST_MAJOR}.${COMPATIBLE_INGEST_MINOR}.x).`
+    );
+  }
+  return null;
+}
+
+export function probeFromPing(
+  executable: string,
+  result: Record<string, unknown> | undefined,
+  pipelines: PipelineDescriptor[] = [],
+): PythonEnvironmentProbe {
+  const protocol = typeof result?.protocol === 'number' ? result.protocol : undefined;
+  const pluginApi = typeof result?.plugin_api === 'number' ? result.plugin_api : undefined;
+  const pythonVersion = typeof result?.python === 'string' ? result.python : undefined;
+  const veraIngestVersion = typeof result?.vera_ingest_version === 'string'
+    ? result.vera_ingest_version
+    : undefined;
+  const loadErrors = Array.isArray(result?.load_errors)
+    ? result.load_errors.filter((value): value is string => typeof value === 'string')
+    : [];
+  const compatibility = pluginHostCompatibilityError({
+    protocol,
+    plugin_api: pluginApi,
+    vera_ingest_version: veraIngestVersion,
+  });
+  return {
+    ok: !compatibility,
+    executable,
+    python_version: pythonVersion,
+    vera_ingest_version: veraIngestVersion,
+    protocol,
+    plugin_api: pluginApi,
+    pipelines,
+    load_errors: loadErrors,
+    error: compatibility || undefined,
+  };
+}
+
+export function fallbackBundledDescriptors(): PipelineDescriptor[] {
+  return [
+    {
+      provider: BUNDLED_PIPELINE_PROVIDER,
+      variant: '',
+      spec: BUNDLED_PIPELINE_PROVIDER,
+      label: 'pymupdf — default PDF pipeline',
+      description: 'Bundled PyMuPDF parser with selective Tesseract OCR.',
+      installed: true,
+      source: 'bundled',
+    },
+  ];
+}
+
+export function normalizeExternalPython(raw: unknown): ExternalPythonConfig {
+  if (!raw || typeof raw !== 'object') {
+    return { enabled: false, executable: '' };
+  }
+  const value = raw as Record<string, unknown>;
+  const executable = typeof value.executable === 'string' ? value.executable.trim() : '';
+  const artifacts = typeof value.artifacts_path === 'string' ? value.artifacts_path.trim() : '';
+  return {
+    enabled: Boolean(value.enabled) && Boolean(executable),
+    executable,
+    artifacts_path: artifacts || undefined,
+    validated_at: typeof value.validated_at === 'number' ? value.validated_at : undefined,
+  };
+}
+
+export function conversionRuntimeOwner(
+  action: string,
+  parser: string | undefined,
+  bundledProviders: Iterable<string>,
+  externalReady: boolean,
+): 'core' | 'external' {
+  if (!externalReady) return 'core';
+  if (action !== SIDECAR_ACTIONS.convert && action !== SIDECAR_ACTIONS.batchConvert) {
+    return 'core';
+  }
+  return shouldRouteToExternal(parser, bundledProviders) ? 'external' : 'core';
+}
+
+export function processOwnerFor(
+  requestId: string | undefined,
+  owners: ReadonlyMap<string, 'core' | 'external'>,
+): 'core' | 'external' {
+  if (requestId && owners.get(requestId) === 'external') return 'external';
+  return 'core';
+}
+
+export function pluginHostSpawnCommand(options: {
+  pythonPath: string;
+  pluginHostRoot: string;
+  artifactsPath?: string;
+  extraEnv?: NodeJS.ProcessEnv;
+}): { executable: string; args: string[]; env: NodeJS.ProcessEnv } {
+  const env: NodeJS.ProcessEnv = { ...(options.extraEnv || {}) };
+  env.PYTHONPATH = options.pluginHostRoot;
+  env.PYTHONUNBUFFERED = '1';
+  env.PYTHONNOUSERSITE = '1';
+  const artifacts = options.artifactsPath?.trim();
+  if (artifacts) {
+    env.DOCLING_ARTIFACTS_PATH = artifacts;
+  } else {
+    delete env.DOCLING_ARTIFACTS_PATH;
+  }
+  return {
+    executable: options.pythonPath,
+    args: ['-m', 'vera_plugin_host'],
+    env,
+  };
+}

--- a/packages/vera-app/electron/json-line-process.test.ts
+++ b/packages/vera-app/electron/json-line-process.test.ts
@@ -1,0 +1,93 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const spawn = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn }));
+
+import { JsonLineProcess } from './json-line-process.js';
+
+function fakeChild() {
+  const child = new EventEmitter() as unknown as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: { write: ReturnType<typeof vi.fn> };
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdin = { write: vi.fn((_data: string, cb?: (error?: Error | null) => void) => cb?.(null)) };
+  child.kill = vi.fn(() => {
+    child.emit('exit', 1, null);
+  });
+  return child;
+}
+
+describe('JsonLineProcess', () => {
+  afterEach(() => {
+    spawn.mockReset();
+  });
+
+  it('spawns with shell disabled for Windows python paths', async () => {
+    const child = fakeChild();
+    spawn.mockReturnValue(child);
+    const proc = new JsonLineProcess('plugin-host', () => ({
+      executable: 'C:\\Users\\me\\venv\\Scripts\\python.exe',
+      args: ['-m', 'vera_plugin_host'],
+      cwd: 'C:\\Users\\me\\AppData\\Roaming\\VERA',
+      env: { PYTHONPATH: 'C:\\Program Files\\VERA\\resources\\python\\plugin-host' },
+    }));
+    const pending = proc.request({ action: 'ping' });
+    expect(spawn).toHaveBeenCalledWith(
+      'C:\\Users\\me\\venv\\Scripts\\python.exe',
+      ['-m', 'vera_plugin_host'],
+      expect.objectContaining({
+        shell: false,
+        windowsHide: true,
+        cwd: 'C:\\Users\\me\\AppData\\Roaming\\VERA',
+      }),
+    );
+    child.stdout.emit('data', Buffer.from('{"id":"1","ok":true,"result":{"status":"ok"}}\n'));
+    await expect(pending).resolves.toMatchObject({ ok: true });
+  });
+
+  it('rejects in-flight work on crash and respawns for the next request', async () => {
+    const first = fakeChild();
+    const second = fakeChild();
+    spawn.mockReturnValueOnce(first).mockReturnValueOnce(second);
+    const proc = new JsonLineProcess('plugin-host', () => ({
+      executable: 'python',
+      args: ['-m', 'vera_plugin_host'],
+    }));
+    const crashed = proc.request({ action: 'convert' }, undefined, 'req-1');
+    first.emit('exit', 1, null);
+    await expect(crashed).rejects.toThrow(/exited/);
+
+    const recovered = proc.request({ action: 'ping' }, undefined, 'req-2');
+    expect(spawn).toHaveBeenCalledTimes(2);
+    second.stdout.emit('data', Buffer.from('{"id":"req-2","ok":true,"result":{"status":"ok"}}\n'));
+    await expect(recovered).resolves.toMatchObject({ ok: true });
+  });
+
+  it('sends skip and cancel to the process that owns the request', async () => {
+    const child = fakeChild();
+    spawn.mockReturnValue(child);
+    const proc = new JsonLineProcess('plugin-host', () => ({
+      executable: 'python',
+      args: ['-m', 'vera_plugin_host'],
+    }));
+    const convert = proc.request({ action: 'convert' }, undefined, 'job-1');
+    const skip = proc.skipConversion('job-1');
+    child.stdout.emit('data', Buffer.from('{"id":"1","ok":true,"result":{"skipped":true}}\n'));
+    await expect(skip).resolves.toEqual({ skipped: true });
+    expect(child.stdin.write).toHaveBeenCalledWith(
+      expect.stringContaining('"action":"skip"'),
+      expect.any(Function),
+    );
+    expect(child.stdin.write).toHaveBeenCalledWith(
+      expect.stringContaining('"target_id":"job-1"'),
+      expect.any(Function),
+    );
+    child.stdout.emit('data', Buffer.from('{"id":"job-1","ok":true,"result":{"output":"out.vera"}}\n'));
+    await expect(convert).resolves.toMatchObject({ ok: true });
+  });
+});

--- a/packages/vera-app/electron/json-line-process.ts
+++ b/packages/vera-app/electron/json-line-process.ts
@@ -1,0 +1,173 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { parseSidecarJsonLine } from './sidecar-json.js';
+
+export interface JsonLineRequest {
+  action: string;
+  [key: string]: unknown;
+}
+
+export interface JsonLineResponse {
+  id?: string;
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+  traceback?: string;
+  cancelled?: boolean;
+  provider_error_detail?: string;
+}
+
+export interface JsonLineEvent {
+  id: string;
+  event: string;
+  [key: string]: unknown;
+}
+
+export interface JsonLineSpawnCommand {
+  executable: string;
+  args: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+interface PendingRequest {
+  child: ChildProcessWithoutNullStreams;
+  resolve: (value: JsonLineResponse) => void;
+  reject: (reason?: unknown) => void;
+  onEvent?: (event: JsonLineEvent) => void;
+}
+
+export class JsonLineProcess {
+  private child: ChildProcessWithoutNullStreams | null = null;
+  private pending = new Map<string, PendingRequest>();
+  private nextId = 1;
+  private stdoutBuffer = '';
+
+  constructor(
+    private readonly label: string,
+    private readonly resolveCommand: () => JsonLineSpawnCommand,
+  ) {}
+
+  request(
+    payload: JsonLineRequest,
+    onEvent?: (event: JsonLineEvent) => void,
+    requestId?: string,
+  ): Promise<JsonLineResponse> {
+    const child = this.ensureStarted();
+    const id = requestId || String(this.nextId++);
+    const message = { ...payload, id };
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { child, resolve, reject, onEvent });
+      child.stdin.write(`${JSON.stringify(message)}\n`, (error) => {
+        if (error) {
+          this.pending.delete(id);
+          reject(error);
+        }
+      });
+    });
+  }
+
+  stop(): void {
+    if (this.child) {
+      this.child.kill();
+      this.child = null;
+    }
+    this.rejectPending(new Error(`${this.label} stopped`));
+  }
+
+  async cancelAnswer(requestId: string): Promise<{ cancelled: boolean }> {
+    const response = await this.request({ action: 'cancel', target_id: requestId });
+    const result = (response.result || {}) as { cancelled?: boolean };
+    return { cancelled: Boolean(result.cancelled) };
+  }
+
+  async skipConversion(requestId: string): Promise<{ skipped: boolean }> {
+    const response = await this.request({ action: 'skip', target_id: requestId });
+    const result = (response.result || {}) as { skipped?: boolean };
+    return { skipped: Boolean(result.skipped) };
+  }
+
+  cancelRequest(requestId: string): boolean {
+    const pending = this.pending.get(requestId);
+    if (!pending) return false;
+    this.pending.delete(requestId);
+    pending.reject(new Error('Request cancelled'));
+    pending.child.stdin.write(`${JSON.stringify({
+      id: null,
+      action: 'cancel',
+      target_id: requestId,
+    })}\n`);
+    return true;
+  }
+
+  restart(): void {
+    const child = this.child;
+    if (!child) return;
+    this.child = null;
+    this.rejectPending(new Error(`${this.label} restarted`), child);
+    child.kill();
+  }
+
+  get running(): boolean {
+    return this.child !== null;
+  }
+
+  private rejectPending(reason: Error, child?: ChildProcessWithoutNullStreams): void {
+    for (const [id, entry] of this.pending) {
+      if (child && entry.child !== child) continue;
+      this.pending.delete(id);
+      entry.reject(reason);
+    }
+  }
+
+  private ensureStarted(): ChildProcessWithoutNullStreams {
+    if (this.child) {
+      return this.child;
+    }
+    const command = this.resolveCommand();
+    this.child = spawn(command.executable, command.args, {
+      cwd: command.cwd,
+      env: command.env,
+      windowsHide: true,
+      shell: false,
+    });
+    this.child.stdout.on('data', (chunk: Buffer) => this.handleStdout(chunk.toString('utf8')));
+    this.child.stderr.on('data', (chunk: Buffer) => {
+      console.error(`[${this.label}] ${chunk.toString('utf8')}`);
+    });
+    const child = this.child;
+    child.on('error', (error: Error) => {
+      if (this.child === child) this.child = null;
+      this.rejectPending(error, child);
+    });
+    child.on('exit', () => {
+      if (this.child === child) this.child = null;
+      this.rejectPending(new Error(`${this.label} exited`), child);
+    });
+    return this.child;
+  }
+
+  private handleStdout(data: string): void {
+    this.stdoutBuffer += data;
+    const lines = this.stdoutBuffer.split('\n');
+    this.stdoutBuffer = lines.pop() || '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const parsed = parseSidecarJsonLine(line);
+      if (!parsed.ok) {
+        console.error(`[${this.label}] Ignoring invalid stdout line (${parsed.error}): ${line}`);
+        continue;
+      }
+      const response = parsed.payload as unknown as JsonLineResponse & { event?: string };
+      if (!response.id) continue;
+      const pending = this.pending.get(response.id);
+      if (!pending) continue;
+      if ('event' in response && !('ok' in response)) {
+        pending.onEvent?.(response as unknown as JsonLineEvent);
+        continue;
+      }
+      this.pending.delete(response.id);
+      pending.resolve(response);
+    }
+  }
+}

--- a/packages/vera-app/electron/main.ts
+++ b/packages/vera-app/electron/main.ts
@@ -1,15 +1,29 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, net, protocol, safeStorage, shell } from 'electron';
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, statSync, unlinkSync, watch, writeFileSync, type FSWatcher } from 'node:fs';
 import { basename, delimiter, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type {
   AppSettings,
   CredentialResult,
+  ExternalPythonConfig,
+  PipelineDescriptor,
   ProviderProfile,
+  PythonEnvironmentProbe,
   Session,
 } from '../src/shared/contracts.js';
-import { parseSidecarJsonLine } from './sidecar-json.js';
+import { SIDECAR_ACTIONS } from '../src/shared/protocol.js';
+import { JsonLineProcess, type JsonLineEvent, type JsonLineResponse } from './json-line-process.js';
+import {
+  conversionRuntimeOwner,
+  fallbackBundledDescriptors,
+  mergePipelineDescriptors,
+  normalizeExternalPython,
+  normalizePipelineDescriptor,
+  parsePipelineProvider,
+  pluginHostSpawnCommand,
+  processOwnerFor,
+  probeFromPing,
+} from './ingest-runtime.js';
 
 interface FolderEntry {
   path: string;
@@ -29,29 +43,8 @@ interface FolderWatcher {
   watcher: FSWatcher;
 }
 
-interface SidecarRequest {
-  id?: string;
-  action: string;
-  [key: string]: unknown;
-}
-
 interface SidecarPayload {
   action: string;
-  [key: string]: unknown;
-}
-
-interface SidecarResponse {
-  id?: string;
-  ok: boolean;
-  result?: unknown;
-  error?: string;
-  traceback?: string;
-  provider_error_detail?: string;
-}
-
-interface SidecarEvent {
-  id: string;
-  event: string;
   [key: string]: unknown;
 }
 
@@ -64,7 +57,63 @@ const DEFAULT_SETTINGS: AppSettings = {
   active_provider_id: '',
   active_model: '',
   active_mode_id: '',
+  ingest_pipeline: 'pymupdf',
+  external_python: { enabled: false, executable: '' },
 };
+
+const PLUGIN_HOST_VALIDATE_TIMEOUT_MS = 20_000;
+
+function pluginHostPythonPath(): string {
+  return app.isPackaged
+    ? join(process.resourcesPath, 'python', 'plugin-host')
+    : join(process.cwd(), 'src');
+}
+
+function sidecarCommand() {
+  const env = { ...process.env };
+  applyHfTokenEnv(env);
+  const packagedSidecar = join(process.resourcesPath, 'python', 'sidecar', 'vera-sidecar.exe');
+  const executable = app.isPackaged ? packagedSidecar : process.env.VERA_APP_PYTHON || 'python';
+  const args = app.isPackaged ? [] : ['-m', 'vera_app.sidecar'];
+  if (!app.isPackaged) {
+    const sourcePaths = [
+      join(process.cwd(), 'src'),
+      join(process.cwd(), '..', 'vera-doc', 'src'),
+      join(process.cwd(), '..', 'vera-ingest', 'src'),
+    ];
+    env.PYTHONPATH = [sourcePaths.join(delimiter), env.PYTHONPATH || ''].filter(Boolean).join(delimiter);
+  }
+  return { executable, args, cwd: process.cwd(), env };
+}
+
+let pluginWorkerExecutable = '';
+let pluginWorkerArtifacts = '';
+
+function pluginHostCommand() {
+  const settings = readSettings();
+  const executable = pluginWorkerExecutable || settings.external_python?.executable?.trim() || '';
+  if (!executable) {
+    throw new Error('Select a Python interpreter before using external ingest plugins.');
+  }
+  const env = { ...process.env };
+  applyHfTokenEnv(env);
+  const command = pluginHostSpawnCommand({
+    pythonPath: executable,
+    pluginHostRoot: pluginHostPythonPath(),
+    artifactsPath: pluginWorkerArtifacts || settings.external_python?.artifacts_path,
+    extraEnv: env,
+  });
+  return {
+    ...command,
+    cwd: app.getPath('userData'),
+  };
+}
+
+const sidecar = new JsonLineProcess('vera-sidecar', sidecarCommand);
+const pluginWorker = new JsonLineProcess('vera-plugin-host', pluginHostCommand);
+const requestOwners = new Map<string, 'core' | 'external'>();
+let bundledProviders = new Set<string>(['pymupdf']);
+let lastPythonProbe: PythonEnvironmentProbe | null = null;
 
 // Serve materialized source PDFs without shipping base64 through JSON IPC.
 // Must be registered before app.ready so fetch()/PDF.js can use the scheme.
@@ -110,155 +159,6 @@ function toSourceViewerResult(result: Record<string, unknown>): Record<string, u
     url: `vera-source://cache/${rel}`,
   };
 }
-
-class PythonSidecar {
-  private child: ChildProcessWithoutNullStreams | null = null;
-  private pending = new Map<string, {
-    child: ChildProcessWithoutNullStreams;
-    resolve: (value: SidecarResponse) => void;
-    reject: (reason?: unknown) => void;
-    onEvent?: (e: SidecarEvent) => void;
-  }>();
-  private nextId = 1;
-  private stdoutBuffer = '';
-
-  request(
-    payload: SidecarPayload,
-    onEvent?: (e: SidecarEvent) => void,
-    requestId?: string,
-  ): Promise<SidecarResponse> {
-    const child = this.ensureStarted();
-    const id = requestId || String(this.nextId++);
-    const message: SidecarRequest = { ...payload, id };
-    return new Promise((resolve, reject) => {
-      this.pending.set(id, { child, resolve, reject, onEvent });
-      child.stdin.write(`${JSON.stringify(message)}\n`, (error) => {
-        if (error) {
-          this.pending.delete(id);
-          reject(error);
-        }
-      });
-    });
-  }
-
-  stop(): void {
-    if (this.child) {
-      this.child.kill();
-      this.child = null;
-    }
-    this.rejectPending(new Error('VERA sidecar stopped'));
-  }
-
-  async cancelAnswer(requestId: string): Promise<{ cancelled: boolean }> {
-    const response = await this.request({ action: 'cancel', target_id: requestId });
-    const result = (response.result || {}) as { cancelled?: boolean };
-    return { cancelled: Boolean(result.cancelled) };
-  }
-
-  async skipConversion(requestId: string): Promise<{ skipped: boolean }> {
-    const response = await this.request({ action: 'skip', target_id: requestId });
-    const result = (response.result || {}) as { skipped?: boolean };
-    return { skipped: Boolean(result.skipped) };
-  }
-
-  cancelRequest(requestId: string): boolean {
-    const pending = this.pending.get(requestId);
-    if (!pending) return false;
-    this.pending.delete(requestId);
-    pending.reject(new Error('Request cancelled'));
-    pending.child.stdin.write(`${JSON.stringify({
-      id: null,
-      action: 'cancel',
-      target_id: requestId,
-    })}\n`);
-    return true;
-  }
-
-  /** Kill the sidecar so the next request respawns with updated env (e.g. HF_TOKEN). */
-  restart(): void {
-    const child = this.child;
-    if (!child) return;
-    this.child = null;
-    this.rejectPending(new Error('VERA sidecar restarted'), child);
-    child.kill();
-  }
-
-  private rejectPending(reason: Error, child?: ChildProcessWithoutNullStreams): void {
-    for (const [id, entry] of this.pending) {
-      if (child && entry.child !== child) continue;
-      this.pending.delete(id);
-      entry.reject(reason);
-    }
-  }
-
-  private ensureStarted(): ChildProcessWithoutNullStreams {
-    if (this.child) {
-      return this.child;
-    }
-
-    const env = { ...process.env };
-    applyHfTokenEnv(env);
-    const packagedSidecar = join(process.resourcesPath, 'python', 'sidecar', 'vera-sidecar.exe');
-    const executable = app.isPackaged ? packagedSidecar : process.env.VERA_APP_PYTHON || 'python';
-    const args = app.isPackaged ? [] : ['-m', 'vera_app.sidecar'];
-    if (!app.isPackaged) {
-      const sourcePaths = [
-        join(process.cwd(), 'src'),
-        join(process.cwd(), '..', 'vera-doc', 'src'),
-        join(process.cwd(), '..', 'vera-ingest', 'src'),
-      ];
-      env.PYTHONPATH = [sourcePaths.join(delimiter), env.PYTHONPATH || ''].filter(Boolean).join(delimiter);
-    }
-
-    this.child = spawn(executable, args, {
-      cwd: process.cwd(),
-      env,
-    });
-
-    this.child.stdout.on('data', (chunk: Buffer) => this.handleStdout(chunk.toString('utf8')));
-    this.child.stderr.on('data', (chunk: Buffer) => console.error(`[vera-sidecar] ${chunk.toString('utf8')}`));
-    const child = this.child;
-    child.on('exit', () => {
-      if (this.child === child) this.child = null;
-      this.rejectPending(new Error('VERA sidecar exited'), child);
-    });
-
-    return this.child;
-  }
-
-  private handleStdout(data: string): void {
-    this.stdoutBuffer += data;
-    const lines = this.stdoutBuffer.split('\n');
-    this.stdoutBuffer = lines.pop() || '';
-    for (const line of lines) {
-      if (!line.trim()) {
-        continue;
-      }
-      const parsed = parseSidecarJsonLine(line);
-      if (!parsed.ok) {
-        console.error(`[vera-sidecar] Ignoring invalid stdout line (${parsed.error}): ${line}`);
-        continue;
-      }
-      const response = parsed.payload as unknown as SidecarResponse & { event?: string };
-      if (!response.id) {
-        continue;
-      }
-      const pending = this.pending.get(response.id);
-      if (!pending) {
-        continue;
-      }
-      // Intermediate event (no `ok` field — not a final response).
-      if ('event' in response && !('ok' in response)) {
-        pending.onEvent?.(response as unknown as SidecarEvent);
-        continue;
-      }
-      this.pending.delete(response.id);
-      pending.resolve(response as SidecarResponse);
-    }
-  }
-}
-
-const sidecar = new PythonSidecar();
 
 function settingsPath(): string {
   return join(app.getPath('userData'), 'settings.json');
@@ -377,6 +277,7 @@ function withRuntime(settings: AppSettings): AppSettings {
       has_api_key: Boolean(keys[credentialKey(profile.base_url)]),
     })),
     has_hf_token: Boolean(resolveHfToken()),
+    external_python_status: lastPythonProbe,
   };
 }
 
@@ -442,6 +343,10 @@ function readSettings(): AppSettings {
       active_provider_id: typeof raw.active_provider_id === 'string' ? raw.active_provider_id : '',
       active_model: activeModel,
       active_mode_id: typeof raw.active_mode_id === 'string' ? raw.active_mode_id : '',
+      ingest_pipeline: typeof raw.ingest_pipeline === 'string' && raw.ingest_pipeline.trim()
+        ? raw.ingest_pipeline.trim()
+        : 'pymupdf',
+      external_python: normalizeExternalPython(raw.external_python),
     };
     return withRuntime(merged);
   } catch {
@@ -458,7 +363,10 @@ function writeSettings(settings: AppSettings): AppSettings {
     active_provider_id: settings.active_provider_id || '',
     active_model: settings.active_model || '',
     active_mode_id: settings.active_mode_id || '',
+    ingest_pipeline: settings.ingest_pipeline?.trim() || 'pymupdf',
+    external_python: normalizeExternalPython(settings.external_python),
   };
+  syncPluginWorker(sanitized.external_python);
   const target = settingsPath();
   const temp = `${target}.tmp`;
   writeFileSync(temp, JSON.stringify(sanitized, null, 2), 'utf8');
@@ -502,6 +410,7 @@ function saveHfToken(token: string): CredentialResult {
   keys[HF_TOKEN_SECRET_KEY] = trimmed;
   writeApiKeys(keys);
   sidecar.restart();
+  pluginWorker.restart();
   return { ok: true, has_api_key: true };
 }
 
@@ -512,6 +421,7 @@ function clearHfToken(): CredentialResult {
     writeApiKeys(keys);
   }
   sidecar.restart();
+  pluginWorker.restart();
   return { ok: true, has_api_key: Boolean(environmentHfToken()) };
 }
 
@@ -648,6 +558,193 @@ async function trashWorkspaceFile(filePath: string, folderPath: string): Promise
     unlinkSync(filePath);
     return 'deleted';
   }
+}
+
+function syncPluginWorker(config: ExternalPythonConfig | null | undefined): void {
+  const executable = config?.enabled ? config.executable.trim() : '';
+  const artifacts = config?.enabled ? (config.artifacts_path || '').trim() : '';
+  pluginWorkerArtifacts = artifacts;
+  if (!executable) {
+    if (pluginWorker.running) pluginWorker.restart();
+    pluginWorkerExecutable = '';
+    return;
+  }
+  if (executable !== pluginWorkerExecutable) {
+    if (pluginWorker.running) pluginWorker.restart();
+    pluginWorkerExecutable = executable;
+  }
+}
+
+function ownerFor(requestId: string | undefined): JsonLineProcess {
+  return processOwnerFor(requestId, requestOwners) === 'external' ? pluginWorker : sidecar;
+}
+
+function descriptorsFromResult(result: unknown, source: 'bundled' | 'external'): PipelineDescriptor[] {
+  const pipelines = result && typeof result === 'object'
+    ? (result as { pipelines?: unknown }).pipelines
+    : undefined;
+  if (!Array.isArray(pipelines)) return source === 'bundled' ? fallbackBundledDescriptors() : [];
+  const normalized = pipelines
+    .map((item) => normalizePipelineDescriptor(item, source))
+    .filter((item): item is PipelineDescriptor => item !== null);
+  return source === 'bundled' && normalized.length === 0 ? fallbackBundledDescriptors() : normalized;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs / 1000}s`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function describeMergedPipelines(): Promise<JsonLineResponse> {
+  const core = await sidecar.request({ action: SIDECAR_ACTIONS.describeIngestPipelines });
+  const bundled = core.ok
+    ? descriptorsFromResult(core.result, 'bundled')
+    : fallbackBundledDescriptors();
+  bundledProviders = new Set(bundled.map((item) => parsePipelineProvider(item.provider || item.spec)));
+  let external: PipelineDescriptor[] = [];
+  const settings = readSettings();
+  if (settings.external_python?.enabled && settings.external_python.executable && lastPythonProbe?.ok) {
+    try {
+      const worker = await pluginWorker.request({ action: SIDECAR_ACTIONS.describeIngestPipelines });
+      if (worker.ok) {
+        external = descriptorsFromResult(worker.result, 'external');
+        const loadErrors = worker.result && typeof worker.result === 'object'
+          ? (worker.result as { load_errors?: unknown }).load_errors
+          : [];
+        lastPythonProbe = {
+          ...lastPythonProbe,
+          pipelines: external,
+          load_errors: Array.isArray(loadErrors)
+            ? loadErrors.filter((value): value is string => typeof value === 'string')
+            : lastPythonProbe.load_errors,
+        };
+      }
+    } catch (error) {
+      lastPythonProbe = {
+        ok: false,
+        executable: settings.external_python.executable,
+        error: error instanceof Error ? error.message : 'External plugin host failed',
+      };
+    }
+  }
+  const pipelines = mergePipelineDescriptors(bundled, external);
+  if (core.ok) {
+    return { ...core, result: { pipelines } };
+  }
+  return { id: core.id, ok: true, result: { pipelines } };
+}
+
+async function listMergedPipelines(): Promise<JsonLineResponse> {
+  const described = await describeMergedPipelines();
+  const pipelines = described.result && typeof described.result === 'object'
+    ? (described.result as { pipelines?: PipelineDescriptor[] }).pipelines ?? []
+    : [];
+  return {
+    ...described,
+    result: { pipelines: pipelines.map((item) => item.spec || item.provider) },
+  };
+}
+
+async function routeSidecarRequest(
+  request: SidecarPayload,
+  onEvent: (event: JsonLineEvent) => void,
+  requestId?: string,
+): Promise<JsonLineResponse> {
+  if (request.action === SIDECAR_ACTIONS.describeIngestPipelines) {
+    return describeMergedPipelines();
+  }
+  if (request.action === SIDECAR_ACTIONS.listIngestPipelines) {
+    return listMergedPipelines();
+  }
+  const settings = readSettings();
+  const parser = typeof request.parser === 'string' ? request.parser : 'pymupdf';
+  const owner = conversionRuntimeOwner(
+    request.action,
+    parser,
+    bundledProviders,
+    Boolean(settings.external_python?.enabled && lastPythonProbe?.ok),
+  );
+  const target = owner === 'external' ? pluginWorker : sidecar;
+  const id = requestId;
+  if (id) requestOwners.set(id, owner);
+  try {
+    return await target.request(request, onEvent, requestId);
+  } finally {
+    if (id) requestOwners.delete(id);
+  }
+}
+
+async function validatePythonEnvironment(
+  executable: string,
+  artifactsPath?: string,
+): Promise<PythonEnvironmentProbe> {
+  const resolved = executable.trim();
+  if (!resolved) {
+    lastPythonProbe = { ok: false, error: 'Choose a Python interpreter.' };
+    return lastPythonProbe;
+  }
+  if (!existsSync(resolved)) {
+    lastPythonProbe = { ok: false, executable: resolved, error: `Python interpreter not found: ${resolved}` };
+    return lastPythonProbe;
+  }
+  pluginWorkerExecutable = resolved;
+  pluginWorkerArtifacts = (artifactsPath || '').trim();
+  if (pluginWorker.running) pluginWorker.restart();
+  try {
+    const ping = await withTimeout(
+      pluginWorker.request({ action: SIDECAR_ACTIONS.ping }),
+      PLUGIN_HOST_VALIDATE_TIMEOUT_MS,
+      'Python environment probe',
+    );
+    if (!ping.ok) {
+      lastPythonProbe = {
+        ok: false,
+        executable: resolved,
+        error: ping.error || 'Plugin host ping failed',
+      };
+      return lastPythonProbe;
+    }
+    const pingResult = (ping.result || {}) as Record<string, unknown>;
+    const described = await pluginWorker.request({ action: SIDECAR_ACTIONS.describeIngestPipelines });
+    const pipelines = described.ok ? descriptorsFromResult(described.result, 'external') : [];
+    lastPythonProbe = probeFromPing(resolved, pingResult, pipelines);
+    if (described.ok && described.result && typeof described.result === 'object') {
+      const loadErrors = (described.result as { load_errors?: unknown }).load_errors;
+      if (Array.isArray(loadErrors)) {
+        lastPythonProbe.load_errors = loadErrors.filter((value): value is string => typeof value === 'string');
+      }
+    }
+    return lastPythonProbe;
+  } catch (error) {
+    lastPythonProbe = {
+      ok: false,
+      executable: resolved,
+      error: error instanceof Error ? error.message : 'Unable to start the plugin host',
+    };
+    pluginWorker.restart();
+    return lastPythonProbe;
+  }
+}
+
+async function pickPythonInterpreter(): Promise<string | null> {
+  const options: Electron.OpenDialogOptions = {
+    title: 'Select Python interpreter',
+    properties: ['openFile'],
+    filters: process.platform === 'win32'
+      ? [{ name: 'Python', extensions: ['exe'] }]
+      : undefined,
+  };
+  const result = await dialog.showOpenDialog(options);
+  return result.canceled ? null : result.filePaths[0] || null;
 }
 
 const folderWatchers = new Map<string, FolderWatcher>();
@@ -858,14 +955,14 @@ app.whenReady().then(() => {
   ipcMain.handle('vera:deleteSession', async (_event, id: string) => deleteSession(id));
   ipcMain.handle('vera:request', async (event, payload: SidecarPayload, requestId?: string) => {
     const sender = event.sender;
-    const onEvent = (e: SidecarEvent) => {
+    const onEvent = (e: JsonLineEvent) => {
       if (!sender.isDestroyed()) sender.send('vera:answerEvent', e);
     };
     const prepared = withModesDir(withStoredApiKey(payload));
     const request = prepared.action === 'source'
       ? { ...prepared, cache_dir: sourceCacheDir() }
       : prepared;
-    const response = await sidecar.request(request, onEvent, requestId);
+    const response = await routeSidecarRequest(request, onEvent, requestId);
     if (
       response.ok
       && request.action === 'source'
@@ -888,13 +985,28 @@ app.whenReady().then(() => {
     }
     return response;
   });
-  ipcMain.handle('vera:cancelAnswer', (_event, requestId: string) => sidecar.cancelAnswer(requestId));
-  ipcMain.handle('vera:cancelRequest', (_event, requestId: string) => sidecar.cancelRequest(requestId));
-  ipcMain.handle('vera:skipConversion', (_event, requestId: string) => sidecar.skipConversion(requestId));
+  ipcMain.handle('vera:cancelAnswer', (_event, requestId: string) => ownerFor(requestId).cancelAnswer(requestId));
+  ipcMain.handle('vera:cancelRequest', (_event, requestId: string) => ownerFor(requestId).cancelRequest(requestId));
+  ipcMain.handle('vera:skipConversion', (_event, requestId: string) => ownerFor(requestId).skipConversion(requestId));
   ipcMain.handle('vera:listModes', async () => sidecar.request({ action: 'list_modes', modes_dir: modesDir() }));
   ipcMain.handle('vera:openModesFolder', async () => shell.openPath(modesDir()));
   ipcMain.handle('vera:getSettings', async () => readSettings());
   ipcMain.handle('vera:saveSettings', async (_event, settings: AppSettings) => writeSettings(settings));
+  ipcMain.handle('vera:pickPythonInterpreter', async () => pickPythonInterpreter());
+  ipcMain.handle('vera:validatePythonEnvironment', async (_event, executable: string, artifactsPath?: string) => {
+    return validatePythonEnvironment(String(executable || ''), artifactsPath);
+  });
+  ipcMain.handle('vera:refreshExternalPipelines', async () => {
+    const settings = readSettings();
+    if (!settings.external_python?.enabled || !settings.external_python.executable) {
+      lastPythonProbe = { ok: false, error: 'External Python is not configured.' };
+      return lastPythonProbe;
+    }
+    return validatePythonEnvironment(
+      settings.external_python.executable,
+      settings.external_python.artifacts_path,
+    );
+  });
   ipcMain.handle('vera:saveApiKey', async (_event, providerId: string, apiKey: string) => saveApiKey(providerId, apiKey));
   ipcMain.handle('vera:clearApiKey', async (_event, providerId: string) => clearApiKey(providerId));
   ipcMain.handle('vera:saveHfToken', async (_event, token: string) => saveHfToken(token));
@@ -932,6 +1044,10 @@ app.whenReady().then(() => {
     const result = await dialog.showSaveDialog({ title: 'Save file' });
     return result.canceled ? null : result.filePath;
   });
+  const startupPython = readSettings().external_python;
+  if (startupPython?.enabled && startupPython.executable) {
+    void validatePythonEnvironment(startupPython.executable, startupPython.artifacts_path);
+  }
   createWindow();
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -943,6 +1059,7 @@ app.whenReady().then(() => {
 app.on('before-quit', () => {
   stopFolderWatchers();
   sidecar.stop();
+  pluginWorker.stop();
 });
 
 app.on('window-all-closed', () => {

--- a/packages/vera-app/electron/preload.cts
+++ b/packages/vera-app/electron/preload.cts
@@ -15,6 +15,11 @@ contextBridge.exposeInMainWorld('vera', {
   clearApiKey: (providerId: string) => ipcRenderer.invoke('vera:clearApiKey', providerId),
   saveHfToken: (token: string) => ipcRenderer.invoke('vera:saveHfToken', token),
   clearHfToken: () => ipcRenderer.invoke('vera:clearHfToken'),
+  pickPythonInterpreter: () => ipcRenderer.invoke('vera:pickPythonInterpreter'),
+  validatePythonEnvironment: (executable: string, artifactsPath?: string) => (
+    ipcRenderer.invoke('vera:validatePythonEnvironment', executable, artifactsPath)
+  ),
+  refreshExternalPipelines: () => ipcRenderer.invoke('vera:refreshExternalPipelines'),
   getSessions: () => ipcRenderer.invoke('vera:getSessions'),
   saveSession: (session: Session) => ipcRenderer.invoke('vera:saveSession', session),
   deleteSession: (id: string) => ipcRenderer.invoke('vera:deleteSession', id),

--- a/packages/vera-app/electron/protocol.test.ts
+++ b/packages/vera-app/electron/protocol.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  IPC_CHANNELS,
+  PLUGIN_API_VERSION,
+  PLUGIN_HOST_PROTOCOL,
+  SIDECAR_ACTIONS,
+} from '../src/shared/protocol.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const preload = readFileSync(join(here, 'preload.cts'), 'utf8');
+
+describe('plugin host protocol contract', () => {
+  it('keeps IPC channel names stable', () => {
+    expect(IPC_CHANNELS.pickPythonInterpreter).toBe('vera:pickPythonInterpreter');
+    expect(IPC_CHANNELS.validatePythonEnvironment).toBe('vera:validatePythonEnvironment');
+    expect(IPC_CHANNELS.refreshExternalPipelines).toBe('vera:refreshExternalPipelines');
+    expect(IPC_CHANNELS.skipConversion).toBe('vera:skipConversion');
+    expect(SIDECAR_ACTIONS.describeIngestPipelines).toBe('describe_ingest_pipelines');
+    expect(PLUGIN_HOST_PROTOCOL).toBe(1);
+    expect(PLUGIN_API_VERSION).toBe(1);
+  });
+
+  it('exposes the new IPC methods on the preload bridge', () => {
+    for (const channel of Object.values(IPC_CHANNELS)) {
+      expect(preload).toContain(channel);
+    }
+  });
+});

--- a/packages/vera-app/package.json
+++ b/packages/vera-app/package.json
@@ -60,6 +60,10 @@
       {
         "from": "src/vera_app/modes_builtin",
         "to": "python/vera_app/modes_builtin"
+      },
+      {
+        "from": "src/vera_plugin_host",
+        "to": "python/plugin-host/vera_plugin_host"
       }
     ],
     "win": {

--- a/packages/vera-app/src/renderer/components/ProviderManagers.tsx
+++ b/packages/vera-app/src/renderer/components/ProviderManagers.tsx
@@ -12,7 +12,8 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
-import type { AppSettings, ProviderProfile } from '../types';
+import type { AppSettings, ExternalPythonConfig, ProviderProfile, PythonEnvironmentProbe } from '../types';
+import { PythonEnvironmentManager } from './PythonEnvironmentManager';
 import {
   defaultEnabledModels,
   emptyProvider,
@@ -118,8 +119,16 @@ export function ProviderManager({
   activeModel,
   activeModeId,
   hasHfToken = false,
+  ingestPipeline,
+  externalPython,
+  pythonStatus,
+  pythonBusy = false,
   onPersist,
   onRefresh,
+  onExternalPythonChange,
+  onPickPython,
+  onValidatePython,
+  onRefreshPipelines,
   onClose,
 }: {
   providers: ProviderProfile[];
@@ -127,8 +136,16 @@ export function ProviderManager({
   activeModel: string;
   activeModeId: string;
   hasHfToken?: boolean;
+  ingestPipeline: string;
+  externalPython: ExternalPythonConfig;
+  pythonStatus: PythonEnvironmentProbe | null;
+  pythonBusy?: boolean;
   onPersist: (next: AppSettings) => Promise<AppSettings>;
   onRefresh: () => Promise<AppSettings>;
+  onExternalPythonChange: (next: ExternalPythonConfig) => void;
+  onPickPython: () => void;
+  onValidatePython: () => void;
+  onRefreshPipelines: () => void;
   onClose: () => void;
 }) {
   const [list, setList] = useState<ProviderProfile[]>(() => providers.map(withPresetModels));
@@ -191,6 +208,8 @@ export function ProviderManager({
       active_provider_id: activeProfile ? nextActiveId : '',
       active_model: nextActiveModel,
       active_mode_id: overrides?.active_mode_id ?? activeModeId,
+      ingest_pipeline: overrides?.ingest_pipeline ?? ingestPipeline,
+      external_python: overrides?.external_python ?? externalPython,
     };
   }
 
@@ -673,9 +692,9 @@ export function ProviderManager({
             {expandedKey === '__hf__' ? (
               <div className="providerItemBody">
                 <p className="providerItemDescription">
-                  Optional token for Docling layout models and other Hub downloads. Stored securely
-                  like provider API keys and passed to the sidecar as <code>HF_TOKEN</code>. Get one
-                  at huggingface.co/settings/tokens.
+                    Optional token for Hub downloads used by some ingest plugins and embedders.
+                    Stored securely like provider API keys and passed to the sidecar and plugin host
+                    as <code>HF_TOKEN</code>. Get one at huggingface.co/settings/tokens.
                 </p>
                 <div className="editorActions">
                   <button className="secondaryAction" onClick={() => void clearHfToken()} disabled={busy || !hfTokenStored}>
@@ -685,6 +704,15 @@ export function ProviderManager({
               </div>
             ) : null}
           </section>
+          <PythonEnvironmentManager
+            config={externalPython}
+            status={pythonStatus}
+            busy={busy || pythonBusy}
+            onConfigChange={onExternalPythonChange}
+            onPick={onPickPython}
+            onValidate={onValidatePython}
+            onRefresh={onRefreshPipelines}
+          />
         </div>
 
         <footer className="modalFooter">

--- a/packages/vera-app/src/renderer/components/PythonEnvironmentManager.test.tsx
+++ b/packages/vera-app/src/renderer/components/PythonEnvironmentManager.test.tsx
@@ -1,0 +1,78 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { PythonEnvironmentManager } from './PythonEnvironmentManager';
+import type { ExternalPythonConfig, PythonEnvironmentProbe } from '../types';
+
+const idle: ExternalPythonConfig = { enabled: false, executable: '' };
+const configured: ExternalPythonConfig = {
+  enabled: true,
+  executable: '/home/user/vera-plugins/bin/python',
+};
+
+function renderManager(options: {
+  config?: ExternalPythonConfig;
+  status?: PythonEnvironmentProbe | null;
+  busy?: boolean;
+} = {}) {
+  (globalThis as unknown as { window: { vera: { platform: string } } }).window = {
+    vera: { platform: 'linux' },
+  };
+  return renderToStaticMarkup(
+    <PythonEnvironmentManager
+      config={options.config || idle}
+      status={options.status ?? null}
+      busy={Boolean(options.busy)}
+      onConfigChange={() => {}}
+      onPick={() => {}}
+      onValidate={() => {}}
+      onRefresh={() => {}}
+    />,
+  );
+}
+
+describe('PythonEnvironmentManager', () => {
+  it('warns that the interpreter is trusted local code', () => {
+    const html = renderManager();
+    expect(html).toContain('trusted');
+    expect(html).toContain('pip install -e');
+    expect(html).toContain('PYTHONPATH');
+  });
+
+  it('disables validate and refresh until an interpreter is chosen', () => {
+    const html = renderManager();
+    expect(html).toMatch(/Validate<\/button>/);
+    expect(html).toContain('disabled=""');
+    expect(html).toContain('Validate the interpreter after installing plugins.');
+  });
+
+  it('shows ready plugin status after a successful probe', () => {
+    const html = renderManager({
+      config: configured,
+      status: {
+        ok: true,
+        executable: configured.executable,
+        python_version: '3.12.3',
+        vera_ingest_version: '0.2.5',
+        pipelines: [{ provider: 'docling', spec: 'docling', installed: true, source: 'external' }],
+      },
+    });
+    expect(html).toContain('Ready');
+    expect(html).toContain('Plugins: docling');
+    expect(html).toContain('vera-ingest 0.2.5');
+  });
+
+  it('shows compatibility errors from a failed probe', () => {
+    const html = renderManager({
+      config: configured,
+      status: {
+        ok: false,
+        executable: configured.executable,
+        error: 'vera-ingest 0.3.0 is not compatible with this app (requires 0.2.x).',
+        load_errors: ['Failed to load ingest pipeline plugin \'broken\': ImportError()'],
+      },
+    });
+    expect(html).toContain('not compatible');
+    expect(html).toContain('broken');
+  });
+});

--- a/packages/vera-app/src/renderer/components/PythonEnvironmentManager.tsx
+++ b/packages/vera-app/src/renderer/components/PythonEnvironmentManager.tsx
@@ -1,0 +1,102 @@
+import { AlertTriangle, FolderOpen, RefreshCw } from 'lucide-react';
+import type { ExternalPythonConfig, PythonEnvironmentProbe } from '../types';
+
+export function PythonEnvironmentManager({
+  config,
+  status,
+  busy,
+  onConfigChange,
+  onPick,
+  onValidate,
+  onRefresh,
+}: {
+  config: ExternalPythonConfig;
+  status: PythonEnvironmentProbe | null;
+  busy: boolean;
+  onConfigChange: (next: ExternalPythonConfig) => void;
+  onPick: () => void;
+  onValidate: () => void;
+  onRefresh: () => void;
+}) {
+  const executable = config.executable;
+  return (
+    <section className="pythonEnvManager">
+      <h3>External Python plugins</h3>
+      <p className="providerItemDescription">
+        Advanced / trusted plugins. The selected interpreter can run arbitrary local code
+        with your permissions. Install plugins with
+        {' '}<code>python -m pip install …</code> or
+        {' '}<code>python -m pip install -e &lt;clone&gt;</code>.
+        Raw <code>PYTHONPATH</code> folders are not discovered.
+      </p>
+      <label className="miniCheck">
+        <input
+          type="checkbox"
+          checked={config.enabled}
+          onChange={(event) => onConfigChange({ ...config, enabled: event.target.checked })}
+          disabled={busy}
+        />
+        <span>Use an external Python environment for extra ingest plugins</span>
+      </label>
+      <label className="field">
+        <span>Python interpreter</span>
+        <div className="pathInput">
+          <input
+            value={executable}
+            onChange={(event) => onConfigChange({ ...config, executable: event.target.value })}
+            placeholder={window.vera.platform === 'win32' ? 'C:\\venvs\\vera-plugins\\Scripts\\python.exe' : '/path/to/venv/bin/python'}
+            disabled={busy}
+          />
+          <button type="button" className="secondaryAction compactAction" onClick={onPick} disabled={busy}>
+            <FolderOpen size={14} />Browse
+          </button>
+        </div>
+      </label>
+      <label className="field">
+        <span>Model cache (optional)</span>
+        <input
+          value={config.artifacts_path || ''}
+          onChange={(event) => onConfigChange({ ...config, artifacts_path: event.target.value })}
+          placeholder="DOCLING_ARTIFACTS_PATH"
+          disabled={busy}
+        />
+      </label>
+      <div className="editorActions">
+        <button type="button" className="secondaryAction" onClick={onValidate} disabled={busy || !executable.trim()}>
+          <RefreshCw size={14} className={busy ? 'spinning' : undefined} />
+          Validate
+        </button>
+        <button type="button" className="secondaryAction" onClick={onRefresh} disabled={busy || !config.enabled || !executable.trim()}>
+          Refresh plugins
+        </button>
+      </div>
+      {status ? (
+        <div className={status.ok ? 'pythonEnvStatus ok' : 'pythonEnvStatus error'} role="status">
+          {!status.ok ? <AlertTriangle size={14} /> : null}
+          <div>
+            {status.ok ? (
+              <>
+                <strong>Ready</strong>
+                <span>
+                  Python {status.python_version || '?'} · vera-ingest {status.vera_ingest_version || '?'}
+                </span>
+                <span>
+                  {(status.pipelines || []).length
+                    ? `Plugins: ${(status.pipelines || []).map((item) => item.spec || item.provider).join(', ')}`
+                    : 'No extra ingest plugins found in this environment.'}
+                </span>
+              </>
+            ) : (
+              <span>{status.error || 'External Python is not available.'}</span>
+            )}
+            {(status.load_errors || []).map((entry) => (
+              <span key={entry}>{entry}</span>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <p className="sideMuted">Validate the interpreter after installing plugins.</p>
+      )}
+    </section>
+  );
+}

--- a/packages/vera-app/src/renderer/lib/convertPresets.test.ts
+++ b/packages/vera-app/src/renderer/lib/convertPresets.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { PipelineDescriptor } from '../../shared/contracts';
+import {
+  pipelineInstallHint,
+  pipelineSelectOptions,
+  presetOptionAvailable,
+} from './convertPresets';
+
+const pymupdf: PipelineDescriptor = {
+  provider: 'pymupdf',
+  spec: 'pymupdf',
+  label: 'pymupdf — default PDF pipeline',
+  description: 'Bundled PyMuPDF parser',
+  installed: true,
+  source: 'bundled',
+};
+
+const docling: PipelineDescriptor = {
+  provider: 'docling',
+  spec: 'docling',
+  label: 'docling — HybridChunker',
+  description: 'Docling HybridChunker',
+  installed: true,
+  source: 'external',
+};
+
+describe('convertPresets', () => {
+  it('gates optional providers on sidecar availability', () => {
+    expect(presetOptionAvailable(
+      { value: 'docling', label: 'docling', requiresProvider: 'docling' },
+      ['pymupdf'],
+    )).toBe(false);
+    expect(presetOptionAvailable(
+      { value: 'docling', label: 'docling', requiresProvider: 'docling' },
+      ['pymupdf', 'docling'],
+    )).toBe(true);
+  });
+
+  it('builds select options from descriptors and missing install hints', () => {
+    expect(pipelineSelectOptions([pymupdf, docling]).map((option) => option.value)).toEqual([
+      'pymupdf',
+      'docling',
+    ]);
+    const withoutDocling = pipelineSelectOptions([pymupdf]);
+    expect(withoutDocling.map((option) => option.value)).toEqual(['pymupdf', 'docling']);
+    expect(withoutDocling[1]?.requiresProvider).toBe('docling');
+    expect(pipelineSelectOptions([pymupdf, docling])[1]?.source).toBe('external');
+    expect(presetOptionAvailable(withoutDocling[1]!, ['pymupdf'])).toBe(false);
+  });
+
+  it('returns packaged-aware install hints for missing optional pipelines', () => {
+    expect(pipelineInstallHint('docling', [pymupdf])).toContain('python -m pip install vera-ingest-docling');
+    expect(pipelineInstallHint('pymupdf', [pymupdf])).toBe('Bundled PyMuPDF parser');
+  });
+});

--- a/packages/vera-app/src/renderer/lib/convertPresets.ts
+++ b/packages/vera-app/src/renderer/lib/convertPresets.ts
@@ -1,0 +1,65 @@
+import type { PipelineDescriptor } from '../../shared/contracts';
+
+export type ConvertPresetOption = {
+  value: string;
+  label: string;
+  requiresProvider?: string;
+  source?: 'bundled' | 'external';
+};
+
+export const PIPELINE_INSTALL_HINTS: Record<string, { label: string; hint: string }> = {
+  docling: {
+    label: 'docling — HybridChunker',
+    hint: 'Install it in the configured Python environment with `python -m pip install vera-ingest-docling`, or clone the plugin and run `python -m pip install -e <folder>`, then Validate / Refresh.',
+  },
+};
+
+export function parsePipelineProvider(spec: string): string {
+  const raw = spec.trim().toLowerCase();
+  if (!raw) return 'pymupdf';
+  return raw.split(':', 1)[0] || 'pymupdf';
+}
+
+export function presetOptionAvailable(
+  option: ConvertPresetOption,
+  installed: string[],
+): boolean {
+  if (!option.requiresProvider) return true;
+  return installed.includes(option.requiresProvider);
+}
+
+export function pipelineSelectOptions(
+  descriptors: PipelineDescriptor[],
+): ConvertPresetOption[] {
+  const installed = descriptors.map((descriptor) => ({
+    value: descriptor.spec,
+    label: descriptor.label || descriptor.spec,
+    source: descriptor.source,
+  }));
+  const known = new Set([
+    ...installed.map((option) => option.value),
+    ...descriptors.map((item) => item.provider),
+  ]);
+  const missingHints = Object.entries(PIPELINE_INSTALL_HINTS)
+    .filter(([provider]) => !known.has(provider))
+    .map(([provider, meta]) => ({
+      value: provider,
+      label: meta.label,
+      requiresProvider: provider,
+    }));
+  return [...installed, ...missingHints];
+}
+
+export function pipelineInstallHint(
+  pipeline: string,
+  descriptors: PipelineDescriptor[],
+): string | null {
+  const descriptor = descriptors.find(
+    (item) => item.spec === pipeline || item.provider === parsePipelineProvider(pipeline),
+  );
+  if (descriptor?.installed) {
+    return descriptor.description || null;
+  }
+  const hint = PIPELINE_INSTALL_HINTS[parsePipelineProvider(pipeline)];
+  return hint?.hint ?? null;
+}

--- a/packages/vera-app/src/renderer/main.tsx
+++ b/packages/vera-app/src/renderer/main.tsx
@@ -48,6 +48,11 @@ import { backgroundTasksReducer, type BackgroundTask } from './lib/backgroundTas
 import { EMPTY_FIGURES, EMPTY_REGIONS } from './lib/constants';
 import { awaitConversionRequest } from './lib/conversion';
 import {
+  pipelineInstallHint,
+  pipelineSelectOptions,
+  presetOptionAvailable,
+} from './lib/convertPresets';
+import {
   convertDefaultsFromSelection,
   formatBox,
   formatPages,
@@ -59,7 +64,7 @@ import {
 import { figureCacheKey, mergeFigureData, sameSearchResult } from './lib/figures';
 import { syncCollapsedFolders } from './lib/explorer';
 import { defaultEnabledModels, filterDiscoveredModels, providerDisplayName, REASONING_EFFORTS, reasoningEffortLabel } from './lib/providers';
-import type { AppSettings, BatchConvertResult, ChatAnswerResult, ChatAttachment, ChatCitationResult, ExportResult, FigureResult, FolderEntry, InspectResult, LibraryIndexBuildReport, LibraryIndexStatus, Mode, PageResult, ProviderProfile, SearchResult, Session, SessionTurn, StreamEvent, SourceDocumentResult, ValidateResult, WorkspaceFolderResult } from './types';
+import type { AppSettings, BatchConvertResult, ChatAnswerResult, ChatAttachment, ChatCitationResult, ExportResult, ExternalPythonConfig, FigureResult, FolderEntry, InspectResult, LibraryIndexBuildReport, LibraryIndexStatus, Mode, PageResult, PipelineDescriptor, ProviderProfile, PythonEnvironmentProbe, SearchResult, Session, SessionTurn, StreamEvent, SourceDocumentResult, ValidateResult, WorkspaceFolderResult } from './types';
 import './styles.css';
 
 type SideView = 'explorer' | 'chats' | 'convert';
@@ -185,6 +190,11 @@ function App() {
   const [modes, setModes] = useState<Mode[]>([]);
   const [activeModeId, setActiveModeId] = useState('');
   const [hasHfToken, setHasHfToken] = useState(false);
+  const [ingestPipeline, setIngestPipeline] = useState('pymupdf');
+  const [ingestPipelineDescriptors, setIngestPipelineDescriptors] = useState<PipelineDescriptor[]>([]);
+  const [externalPython, setExternalPython] = useState<ExternalPythonConfig>({ enabled: false, executable: '' });
+  const [pythonStatus, setPythonStatus] = useState<PythonEnvironmentProbe | null>(null);
+  const [pythonBusy, setPythonBusy] = useState(false);
   const [modePickerOpen, setModePickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [modelPickerOpen, setModelPickerOpen] = useState(false);
@@ -1621,31 +1631,118 @@ function App() {
     }
   }
 
-  async function persistSettings(next: AppSettings): Promise<AppSettings> {
-    const saved = await window.vera.saveSettings(next);
+  function applyLoadedSettings(saved: AppSettings) {
     setProviders(saved.providers);
     setActiveProviderId(saved.active_provider_id);
     setActiveModel(saved.active_model || '');
     setActiveModeId(saved.active_mode_id || '');
     setHasHfToken(Boolean(saved.has_hf_token));
+    setIngestPipeline(saved.ingest_pipeline || 'pymupdf');
+    setExternalPython(saved.external_python || { enabled: false, executable: '' });
+    setPythonStatus(saved.external_python_status || null);
+  }
+
+  async function persistSettings(next: AppSettings): Promise<AppSettings> {
+    const saved = await window.vera.saveSettings({
+      ...next,
+      ingest_pipeline: next.ingest_pipeline ?? ingestPipeline,
+      external_python: next.external_python ?? externalPython,
+    });
+    applyLoadedSettings(saved);
     return saved;
   }
 
   async function refreshSettings(): Promise<AppSettings> {
     const saved = await window.vera.getSettings();
-    setProviders(saved.providers);
-    setActiveProviderId(saved.active_provider_id);
-    setActiveModel(saved.active_model || '');
-    setActiveModeId(saved.active_mode_id || '');
-    setHasHfToken(Boolean(saved.has_hf_token));
+    applyLoadedSettings(saved);
     return saved;
+  }
+
+  const pipelineOptionsForSelect = useMemo(
+    () => pipelineSelectOptions(ingestPipelineDescriptors),
+    [ingestPipelineDescriptors],
+  );
+  const activePipelineDescriptor = ingestPipelineDescriptors.find(
+    (item) => item.spec === ingestPipeline || item.provider === ingestPipeline,
+  );
+
+  async function saveIngestPipeline(next: string) {
+    setIngestPipeline(next);
+    await persistSettings({
+      providers,
+      active_provider_id: activeProviderId,
+      active_model: activeModel,
+      active_mode_id: activeModeId,
+      ingest_pipeline: next,
+      external_python: externalPython,
+    });
+  }
+
+  async function persistExternalPython(next: ExternalPythonConfig) {
+    setExternalPython(next);
+    await persistSettings({
+      providers,
+      active_provider_id: activeProviderId,
+      active_model: activeModel,
+      active_mode_id: activeModeId,
+      ingest_pipeline: ingestPipeline,
+      external_python: next,
+    });
+  }
+
+  async function reloadIngestPipelines() {
+    const response = await window.vera.request<{ pipelines: PipelineDescriptor[] }>({
+      action: 'describe_ingest_pipelines',
+    });
+    if (response.ok && response.result?.pipelines) {
+      setIngestPipelineDescriptors(response.result.pipelines);
+    }
+  }
+
+  async function pickPythonInterpreter() {
+    const selected = await window.vera.pickPythonInterpreter();
+    if (!selected) return;
+    await persistExternalPython({ ...externalPython, executable: selected, enabled: true });
+  }
+
+  async function validatePythonEnvironment() {
+    setPythonBusy(true);
+    try {
+      await persistExternalPython(externalPython);
+      const probe = await window.vera.validatePythonEnvironment(
+        externalPython.executable,
+        externalPython.artifacts_path,
+      );
+      setPythonStatus(probe);
+      if (probe.ok) {
+        await persistExternalPython({
+          ...externalPython,
+          enabled: true,
+          validated_at: Date.now(),
+        });
+        await reloadIngestPipelines();
+      }
+    } finally {
+      setPythonBusy(false);
+    }
+  }
+
+  async function refreshExternalPipelines() {
+    setPythonBusy(true);
+    try {
+      const probe = await window.vera.refreshExternalPipelines();
+      setPythonStatus(probe);
+      await reloadIngestPipelines();
+    } finally {
+      setPythonBusy(false);
+    }
   }
 
   async function selectActiveModel(providerId: string, model: string) {
     setModelPickerOpen(false);
     setActiveProviderId(providerId);
     setActiveModel(model);
-    await persistSettings({ providers, active_provider_id: providerId, active_model: model, active_mode_id: activeModeId });
+    await persistSettings({ providers, active_provider_id: providerId, active_model: model, active_mode_id: activeModeId, ingest_pipeline: ingestPipeline, external_python: externalPython });
   }
 
   async function refreshProviderModels(providerId: string) {
@@ -1922,7 +2019,7 @@ function App() {
             : { directory, recursive: batchRecursive }),
           overwrite: batchOverwrite,
           model: 'hashing',
-          parser: 'pymupdf',
+          parser: ingestPipeline || 'pymupdf',
           chunk_size: chunkSize,
           overlap,
           store_original: storeOriginal,
@@ -2146,11 +2243,31 @@ function App() {
     async function loadSettings() {
       const saved = await window.vera.getSettings();
       if (canceled) return;
-      setProviders(saved.providers);
-      setActiveProviderId(saved.active_provider_id);
-      setActiveModel(saved.active_model || '');
-      setActiveModeId(saved.active_mode_id || '');
-      setHasHfToken(Boolean(saved.has_hf_token));
+      applyLoadedSettings(saved);
+    }
+    async function loadIngestPipelines() {
+      const response = await window.vera.request<{ pipelines: PipelineDescriptor[] }>({
+        action: 'describe_ingest_pipelines',
+      });
+      if (canceled) return;
+      if (response.ok && response.result?.pipelines?.length) {
+        setIngestPipelineDescriptors(response.result.pipelines);
+        return;
+      }
+      const fallback = await window.vera.request<{ pipelines: string[] }>({
+        action: 'list_ingest_pipelines',
+      });
+      if (!canceled && fallback.ok) {
+        const pipelines = fallback.result?.pipelines?.length ? fallback.result.pipelines : ['pymupdf'];
+        setIngestPipelineDescriptors(pipelines.map((spec) => ({
+          provider: spec,
+          spec,
+          label: spec,
+          description: '',
+          installed: true,
+          source: spec === 'pymupdf' ? 'bundled' : 'external',
+        })));
+      }
     }
     async function loadSessions() {
       const saved = await window.vera.getSessions();
@@ -2200,6 +2317,7 @@ function App() {
       }
     }
     void loadSettings();
+    void loadIngestPipelines();
     void loadSessions();
     void loadFolders();
     return () => {
@@ -2682,7 +2800,38 @@ function App() {
                       <p className="sideMuted">Each archive is created beside its PDF with the same base filename. Existing archives are skipped unless overwrite is enabled.</p>
                     </>
                   ) : null}
-                  <p className="sideMuted">Conversions use the PyMuPDF parser and local hashing embeddings.</p>
+                  <p className="sideMuted">
+                    {activePipelineDescriptor?.installed
+                      ? (activePipelineDescriptor.description || 'Pipeline ready for conversion.')
+                      : (pipelineInstallHint(ingestPipeline, ingestPipelineDescriptors)
+                        || 'Choose an ingest pipeline.')}
+                    {' '}Packaged releases keep PyMuPDF bundled; extra parsers run in a trusted external Python environment. Conversions use local hashing embeddings. Configure the interpreter under File → LLM Providers.
+                  </p>
+                  <label className="field">
+                    <span>Ingest pipeline</span>
+                    <select
+                      value={
+                        pipelineOptionsForSelect.some((option) => option.value === ingestPipeline)
+                          ? ingestPipeline
+                          : ingestPipeline || 'pymupdf'
+                      }
+                      onChange={(event) => void saveIngestPipeline(event.target.value)}
+                      disabled={conversionInProgress}
+                    >
+                      {pipelineOptionsForSelect.map((option) => {
+                        const available = presetOptionAvailable(
+                          option,
+                          ingestPipelineDescriptors.map((item) => item.provider),
+                        );
+                        const suffix = option.source === 'external' ? ' (external)' : '';
+                        return (
+                          <option key={option.value} value={option.value} disabled={!available}>
+                            {available ? `${option.label}${suffix}` : `${option.label} (not installed)`}
+                          </option>
+                        );
+                      })}
+                    </select>
+                  </label>
                   <div className="convertGrid">
                     <label className="miniField">
                       <span>Chunk Size</span>
@@ -3787,8 +3936,16 @@ function App() {
           activeModel={activeModel}
           activeModeId={activeModeId}
           hasHfToken={hasHfToken}
+          ingestPipeline={ingestPipeline}
+          externalPython={externalPython}
+          pythonStatus={pythonStatus}
+          pythonBusy={pythonBusy}
           onPersist={persistSettings}
           onRefresh={refreshSettings}
+          onExternalPythonChange={(next) => void persistExternalPython(next)}
+          onPickPython={() => void pickPythonInterpreter()}
+          onValidatePython={() => void validatePythonEnvironment()}
+          onRefreshPipelines={() => void refreshExternalPipelines()}
           onClose={() => setSettingsOpen(false)}
         />
       ) : null}

--- a/packages/vera-app/src/renderer/styles.css
+++ b/packages/vera-app/src/renderer/styles.css
@@ -3912,7 +3912,42 @@ input.viewerPageInput:focus {
   color: var(--accent);
 }
 
-/* ── Provider modal ──────────────────────────────────── */
+.pythonEnvManager {
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.pythonEnvManager h3 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.pythonEnvStatus {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}
+
+.pythonEnvStatus.ok {
+  background: var(--bg-surface-2);
+}
+
+.pythonEnvStatus.error {
+  color: var(--danger, #b45309);
+}
+
+.pythonEnvStatus div {
+  display: grid;
+  gap: 2px;
+}
 
 .modalBackdrop {
   position: fixed;

--- a/packages/vera-app/src/renderer/types.ts
+++ b/packages/vera-app/src/renderer/types.ts
@@ -2,6 +2,9 @@ import type {
   AppSettings,
   ChatCitationResult,
   CredentialResult,
+  ExternalPythonConfig,
+  PipelineDescriptor,
+  PythonEnvironmentProbe,
   Session,
   StreamEvent,
 } from '../shared/contracts';
@@ -13,8 +16,11 @@ export type {
   ContentPart,
   ContextChunkResult,
   CredentialResult,
+  ExternalPythonConfig,
   FigureResult,
+  PipelineDescriptor,
   ProviderProfile,
+  PythonEnvironmentProbe,
   RegionResult,
   SearchResult,
   Session,
@@ -43,6 +49,9 @@ export interface VeraApi {
   skipConversion(requestId: string): Promise<{ skipped: boolean }>;
   getSettings(): Promise<AppSettings>;
   saveSettings(settings: AppSettings): Promise<AppSettings>;
+  pickPythonInterpreter(): Promise<string | null>;
+  validatePythonEnvironment(executable: string, artifactsPath?: string): Promise<PythonEnvironmentProbe>;
+  refreshExternalPipelines(): Promise<PythonEnvironmentProbe>;
   saveApiKey(providerId: string, apiKey: string): Promise<CredentialResult>;
   clearApiKey(providerId: string): Promise<CredentialResult>;
   saveHfToken(token: string): Promise<CredentialResult>;

--- a/packages/vera-app/src/shared/contracts.ts
+++ b/packages/vera-app/src/shared/contracts.ts
@@ -149,12 +149,58 @@ export interface AppSettings {
   active_provider_id: string;
   active_model: string;
   active_mode_id: string;
+  ingest_pipeline?: string;
+  external_python?: ExternalPythonConfig | null;
   /**
    * Runtime-only: true when a Hugging Face token is available from secure
    * storage or the process environment (`HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN`).
    * Not persisted in settings.json.
    */
   has_hf_token?: boolean;
+  /** Runtime-only probe of the configured external Python environment. */
+  external_python_status?: PythonEnvironmentProbe | null;
+}
+
+export type PipelineRuntimeSource = 'bundled' | 'external';
+
+export interface PipelineFieldDescriptor {
+  key: string;
+  label: string;
+  type?: string;
+  default?: unknown;
+  unit?: string;
+}
+
+export interface PipelineDescriptor {
+  provider: string;
+  variant?: string;
+  spec: string;
+  label?: string;
+  description?: string;
+  installed: boolean;
+  capabilities?: Record<string, unknown>;
+  fields?: PipelineFieldDescriptor[];
+  notes?: string[];
+  source?: PipelineRuntimeSource;
+}
+
+export interface ExternalPythonConfig {
+  enabled: boolean;
+  executable: string;
+  artifacts_path?: string;
+  validated_at?: number;
+}
+
+export interface PythonEnvironmentProbe {
+  ok: boolean;
+  executable?: string;
+  python_version?: string;
+  vera_ingest_version?: string;
+  protocol?: number;
+  plugin_api?: number;
+  pipelines?: PipelineDescriptor[];
+  load_errors?: string[];
+  error?: string;
 }
 
 export interface CredentialResult {

--- a/packages/vera-app/src/shared/protocol.ts
+++ b/packages/vera-app/src/shared/protocol.ts
@@ -1,0 +1,28 @@
+/** Shared IPC channel names and sidecar actions used by Electron and the renderer. */
+
+export const IPC_CHANNELS = {
+  request: 'vera:request',
+  cancelAnswer: 'vera:cancelAnswer',
+  cancelRequest: 'vera:cancelRequest',
+  skipConversion: 'vera:skipConversion',
+  getSettings: 'vera:getSettings',
+  saveSettings: 'vera:saveSettings',
+  pickPythonInterpreter: 'vera:pickPythonInterpreter',
+  validatePythonEnvironment: 'vera:validatePythonEnvironment',
+  refreshExternalPipelines: 'vera:refreshExternalPipelines',
+} as const;
+
+export const SIDECAR_ACTIONS = {
+  ping: 'ping',
+  convert: 'convert',
+  batchConvert: 'batch_convert',
+  listIngestPipelines: 'list_ingest_pipelines',
+  describeIngestPipelines: 'describe_ingest_pipelines',
+  cancel: 'cancel',
+  skip: 'skip',
+} as const;
+
+export const PLUGIN_HOST_PROTOCOL = 1;
+export const PLUGIN_API_VERSION = 1;
+export const COMPATIBLE_INGEST_MAJOR = 0;
+export const COMPATIBLE_INGEST_MINOR = 2;

--- a/packages/vera-app/src/vera_app/sidecar.py
+++ b/packages/vera-app/src/vera_app/sidecar.py
@@ -22,6 +22,11 @@ from vera import (
 )
 from vera.corpus import VeraCorpus
 from vera_ingest import batch_convert, convert
+from vera_ingest.pipeline import (
+    ensure_pymupdf_registered,
+    list_ingest_pipeline_descriptors,
+    list_ingest_pipelines,
+)
 from vera_ingest.viewer import (
     export_source_document,
     figures,
@@ -42,6 +47,8 @@ from vera_app.llm import (
     list_models,
 )
 from vera_app.modes import Mode, load_modes, resolve_mode
+
+ensure_pymupdf_registered()
 
 Request = dict[str, Any]
 Response = dict[str, Any]
@@ -1318,6 +1325,16 @@ def _page(request: Request) -> dict[str, Any] | None:
         doc.close()
 
 
+def _list_ingest_pipelines(_request: Request) -> dict[str, Any]:
+    return {"pipelines": list_ingest_pipelines()}
+
+
+def _describe_ingest_pipelines(_request: Request) -> dict[str, Any]:
+    return {
+        "pipelines": [item.as_dict() for item in list_ingest_pipeline_descriptors()],
+    }
+
+
 def _list_models(request: Request) -> dict[str, Any]:
     config = LlmConfig.from_request(request.get("llm"))
     models = list_models(config)
@@ -1341,6 +1358,8 @@ HANDLERS: dict[str, Handler] = {
     "page": _page,
     "list_models": _list_models,
     "list_modes": _list_modes,
+    "list_ingest_pipelines": _list_ingest_pipelines,
+    "describe_ingest_pipelines": _describe_ingest_pipelines,
 }
 
 _stdout_lock = threading.Lock()

--- a/packages/vera-app/src/vera_plugin_host/__init__.py
+++ b/packages/vera-app/src/vera_plugin_host/__init__.py
@@ -1,0 +1,10 @@
+"""Lightweight JSON-lines ingest worker for a user-selected Python environment.
+
+The packaged desktop app ships this package as an extra resource and launches
+it with an external interpreter. That interpreter must provide ``vera-ingest``
+and any ingest plugins; it does not need ``vera-app``.
+"""
+
+from .worker import PROTOCOL_VERSION, main
+
+__all__ = ["PROTOCOL_VERSION", "main"]

--- a/packages/vera-app/src/vera_plugin_host/__main__.py
+++ b/packages/vera-app/src/vera_plugin_host/__main__.py
@@ -1,0 +1,4 @@
+from .worker import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/vera-app/src/vera_plugin_host/cancellation.py
+++ b/packages/vera-app/src/vera_plugin_host/cancellation.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+
+class CancelledError(RuntimeError):
+    """Raised when a user cancels in-flight plugin-host work."""
+
+
+class SkipCurrentError(RuntimeError):
+    """Raised when a user skips the current conversion item."""
+
+
+class CancellationToken:
+    """Cooperatively cancel or skip conversion work in the plugin host."""
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._skip_event = threading.Event()
+        self._lock = threading.Lock()
+        self._response: Any | None = None
+
+    @property
+    def cancelled(self) -> bool:
+        return self._event.is_set()
+
+    @property
+    def skip_requested(self) -> bool:
+        return self._skip_event.is_set()
+
+    def raise_if_cancelled(self) -> None:
+        if self.cancelled:
+            raise CancelledError()
+
+    def raise_if_interrupted(self) -> None:
+        self.raise_if_cancelled()
+        if self.skip_requested:
+            raise SkipCurrentError("File skipped")
+
+    def _close_response(self) -> None:
+        with self._lock:
+            response = self._response
+        if response is not None:
+            try:
+                response.close()
+            except Exception:
+                pass
+
+    def cancel(self) -> None:
+        self._event.set()
+        self._close_response()
+
+    def skip(self) -> None:
+        self._skip_event.set()
+        self._close_response()
+
+    def clear_skip(self) -> None:
+        self._skip_event.clear()
+
+    def register_response(self, response: Any) -> None:
+        with self._lock:
+            if self.cancelled or self.skip_requested:
+                try:
+                    response.close()
+                except Exception:
+                    pass
+                self.raise_if_interrupted()
+            self._response = response
+
+    def unregister_response(self, response: Any) -> None:
+        with self._lock:
+            if self._response is response:
+                self._response = None

--- a/packages/vera-app/src/vera_plugin_host/worker.py
+++ b/packages/vera-app/src/vera_plugin_host/worker.py
@@ -1,0 +1,310 @@
+"""JSON-lines ingest worker: discovery, convert, batch convert, cancel/skip."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import traceback
+from collections.abc import Callable
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+from vera_ingest import batch_convert, convert
+from vera_ingest.pipeline import (
+    PLUGIN_API_VERSION,
+    convert_options_from_mapping,
+    list_ingest_pipeline_descriptors,
+    list_ingest_pipeline_load_errors,
+    list_ingest_pipelines,
+)
+
+from .cancellation import CancellationToken, CancelledError, SkipCurrentError
+
+PROTOCOL_VERSION = 1
+Request = dict[str, Any]
+Response = dict[str, Any]
+Handler = Callable[..., Any]
+
+
+def _ingest_version() -> str:
+    try:
+        return version("vera-ingest")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def handle_ping(_request: Request) -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "protocol": PROTOCOL_VERSION,
+        "plugin_api": PLUGIN_API_VERSION,
+        "python": sys.version.split()[0],
+        "python_executable": sys.executable,
+        "vera_ingest_version": _ingest_version(),
+        "pipelines": list_ingest_pipelines(),
+        "load_errors": list_ingest_pipeline_load_errors(),
+    }
+
+
+def handle_list_ingest_pipelines(_request: Request) -> dict[str, Any]:
+    return {"pipelines": list_ingest_pipelines()}
+
+
+def handle_describe_ingest_pipelines(_request: Request) -> dict[str, Any]:
+    return {
+        "pipelines": [item.as_dict() for item in list_ingest_pipeline_descriptors()],
+        "load_errors": list_ingest_pipeline_load_errors(),
+        "plugin_api": PLUGIN_API_VERSION,
+        "vera_ingest_version": _ingest_version(),
+    }
+
+
+def _convert_kwargs(request: Request) -> dict[str, Any]:
+    options = convert_options_from_mapping(request)
+    parser = str(request.get("parser") or "pymupdf")
+    options["parser"] = parser
+    if "model" not in options:
+        options["model"] = "hashing"
+    if "chunk_size" in options:
+        options["chunk_size"] = int(options["chunk_size"])
+    if "overlap" in options:
+        options["overlap"] = int(options["overlap"])
+    if "ocr_dpi" in options:
+        options["ocr_dpi"] = int(options["ocr_dpi"])
+    if "store_original" in options:
+        options["store_original"] = bool(options["store_original"])
+    return options
+
+
+def handle_convert(
+    request: Request,
+    write_event: Callable[[dict[str, Any]], None] | None = None,
+    cancel: CancellationToken | None = None,
+) -> dict[str, str]:
+    input_path = str(request["input"])
+    if write_event:
+        write_event(
+            {
+                "event": "conversion_progress",
+                "completed": 0,
+                "total": 1,
+                "input": input_path,
+            }
+        )
+    output = convert(
+        input_path,
+        str(request["output"]),
+        cancel=cancel,
+        **_convert_kwargs(request),
+    )
+    if write_event:
+        write_event(
+            {
+                "event": "conversion_progress",
+                "completed": 1,
+                "total": 1,
+                "input": input_path,
+            }
+        )
+    return {"output": output}
+
+
+def handle_batch_convert(
+    request: Request,
+    write_event: Callable[[dict[str, Any]], None] | None = None,
+    cancel: CancellationToken | None = None,
+) -> dict[str, Any]:
+    def report_progress(completed: int, total: int, input_path: str) -> None:
+        if cancel:
+            cancel.raise_if_interrupted()
+        if write_event:
+            write_event(
+                {
+                    "event": "conversion_progress",
+                    "completed": completed,
+                    "total": total,
+                    "input": input_path,
+                }
+            )
+
+    raw_paths = request.get("paths")
+    paths: list[str] | None = None
+    if isinstance(raw_paths, list):
+        paths = [str(item) for item in raw_paths if str(item).strip()]
+        if not paths:
+            paths = None
+
+    directory = request.get("directory")
+    progress_label = (
+        f"{len(paths)} selected PDF{'s' if len(paths) != 1 else ''}"
+        if paths is not None
+        else str(directory or "")
+    )
+    if write_event:
+        write_event(
+            {
+                "event": "conversion_progress",
+                "completed": 0,
+                "total": 0,
+                "input": progress_label,
+                "phase": "discovering",
+            }
+        )
+    if cancel:
+        cancel.raise_if_interrupted()
+
+    return batch_convert(
+        None if paths is not None else str(directory),
+        paths=paths,
+        recursive=bool(request.get("recursive", True)),
+        overwrite=bool(request.get("overwrite", False)),
+        progress=report_progress,
+        cancel=cancel,
+        **_convert_kwargs(request),
+    )
+
+
+HANDLERS: dict[str, Handler] = {
+    "ping": handle_ping,
+    "list_ingest_pipelines": handle_list_ingest_pipelines,
+    "describe_ingest_pipelines": handle_describe_ingest_pipelines,
+    "convert": handle_convert,
+    "batch_convert": handle_batch_convert,
+}
+
+_stdout_lock = threading.Lock()
+_inflight_lock = threading.Lock()
+_inflight_requests: dict[str, CancellationToken] = {}
+
+
+def _write_response(response: Response) -> None:
+    with _stdout_lock:
+        print(json.dumps(response), flush=True)
+
+
+def _cancelled_error_message(action: str, exc: BaseException | None = None) -> str:
+    if exc and str(exc):
+        return str(exc)
+    if action in {"convert", "batch_convert"}:
+        return "Conversion cancelled"
+    return "Request cancelled"
+
+
+def handle(request: Request, cancel: CancellationToken | None = None) -> Response:
+    request_id = request.get("id")
+    action = str(request.get("action", ""))
+    try:
+        if action not in HANDLERS:
+            raise ValueError(f"Unknown action: {action}")
+        if action in {"convert", "batch_convert"}:
+
+            def _emit(data: dict[str, Any]) -> None:
+                _write_response({**data, "id": request_id})
+
+            result = HANDLERS[action](request, write_event=_emit, cancel=cancel)
+        else:
+            result = HANDLERS[action](request)
+        return {"id": request_id, "ok": True, "result": result}
+    except CancelledError as exc:
+        return {
+            "id": request_id,
+            "ok": False,
+            "error": _cancelled_error_message(action, exc),
+            "cancelled": True,
+        }
+    except SkipCurrentError as exc:
+        return {
+            "id": request_id,
+            "ok": False,
+            "error": str(exc) or "File skipped",
+            "cancelled": True,
+        }
+    except Exception as exc:
+        if cancel and cancel.cancelled:
+            return {
+                "id": request_id,
+                "ok": False,
+                "error": _cancelled_error_message(action),
+                "cancelled": True,
+            }
+        return {
+            "id": request_id,
+            "ok": False,
+            "error": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+
+
+def _run_cancellable_request(
+    request: Request,
+    request_id: str,
+    cancel: CancellationToken,
+) -> None:
+    try:
+        _write_response(handle(request, cancel=cancel))
+    finally:
+        with _inflight_lock:
+            _inflight_requests.pop(request_id, None)
+
+
+def main() -> int:
+    """Read JSON-lines requests from stdin and write responses to stdout."""
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError as exc:
+            response: Response = {"id": None, "ok": False, "error": str(exc)}
+        else:
+            action = str(request.get("action", ""))
+            if action == "cancel":
+                target_id = str(request.get("target_id") or "")
+                with _inflight_lock:
+                    cancel = _inflight_requests.get(target_id)
+                if cancel:
+                    cancel.cancel()
+                response = {
+                    "id": request.get("id"),
+                    "ok": True,
+                    "result": {"target_id": target_id, "cancelled": bool(cancel)},
+                }
+            elif action == "skip":
+                target_id = str(request.get("target_id") or "")
+                with _inflight_lock:
+                    cancel = _inflight_requests.get(target_id)
+                if cancel:
+                    cancel.skip()
+                response = {
+                    "id": request.get("id"),
+                    "ok": True,
+                    "result": {"target_id": target_id, "skipped": bool(cancel)},
+                }
+            elif action in {"convert", "batch_convert"}:
+                request_id = str(request.get("id") or "")
+                if not request_id:
+                    response = {
+                        "id": None,
+                        "ok": False,
+                        "error": f"{action} requests require an id",
+                    }
+                else:
+                    cancel = CancellationToken()
+                    with _inflight_lock:
+                        _inflight_requests[request_id] = cancel
+                    threading.Thread(
+                        target=_run_cancellable_request,
+                        args=(request, request_id, cancel),
+                        daemon=True,
+                    ).start()
+                    continue
+            else:
+                response = handle(request)
+        _write_response(response)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/vera-ingest/README.md
+++ b/packages/vera-ingest/README.md
@@ -22,6 +22,7 @@ python -m pip install ./packages/vera-doc ./packages/vera-ingest
 ```
 
 See the [vera-ingest documentation](https://dkylewillis.github.io/vera/packages/vera-ingest/)
-for concepts, examples, and API reference.
+for concepts, examples, and API reference. Extra parsers register as plugins;
+see [Creating an ingest pipeline plugin](https://dkylewillis.github.io/vera/creating-an-ingest-pipeline/).
 
 See the [conversion guide](https://github.com/dkylewillis/vera/blob/main/docs/conversion.md).

--- a/packages/vera-ingest/pyproject.toml
+++ b/packages/vera-ingest/pyproject.toml
@@ -24,6 +24,12 @@ Homepage = "https://github.com/dkylewillis/vera"
 Repository = "https://github.com/dkylewillis/vera"
 Documentation = "https://dkylewillis.github.io/vera/packages/vera-ingest/"
 
+[project.entry-points."vera.ingest_pipelines"]
+pymupdf = "vera_ingest.pipeline:create_pymupdf_pipeline"
+
+[project.entry-points."vera.ingest_pipeline_descriptors"]
+pymupdf = "vera_ingest.pipeline:create_pymupdf_descriptor"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/vera-ingest/src/vera_ingest/__init__.py
+++ b/packages/vera-ingest/src/vera_ingest/__init__.py
@@ -8,6 +8,18 @@ from .chunking import (
 )
 from .convert import batch_convert, convert
 from .parsers import ParsedBlock, ParsedPage, parse_pdf, parse_pdf_structured
+from .pipeline import (
+    PLUGIN_API_VERSION,
+    PipelineDescriptor,
+    UnknownIngestPipelineError,
+    describe_ingest_pipeline,
+    get_ingest_pipeline,
+    list_ingest_pipeline_descriptors,
+    list_ingest_pipeline_load_errors,
+    list_ingest_pipelines,
+    register_ingest_pipeline,
+    register_ingest_pipeline_descriptor,
+)
 from .viewer import (
     export_source_document,
     figures,
@@ -20,8 +32,18 @@ from .viewer import (
 )
 
 __all__ = [
+    "PLUGIN_API_VERSION",
+    "PipelineDescriptor",
+    "UnknownIngestPipelineError",
     "convert",
     "batch_convert",
+    "describe_ingest_pipeline",
+    "get_ingest_pipeline",
+    "list_ingest_pipeline_descriptors",
+    "list_ingest_pipeline_load_errors",
+    "list_ingest_pipelines",
+    "register_ingest_pipeline",
+    "register_ingest_pipeline_descriptor",
     "Chunk",
     "ParsedBlock",
     "ParsedPage",

--- a/packages/vera-ingest/src/vera_ingest/convert.py
+++ b/packages/vera-ingest/src/vera_ingest/convert.py
@@ -20,6 +20,11 @@ from vera.core.validation import validate_document
 
 from .chunking import build_chunks_from_blocks
 from .parsers import ParsedBlock, parse_pdf_structured
+from .pipeline import (
+    get_ingest_pipeline,
+    invoke_ingest_pipeline,
+    parse_ingest_pipeline_spec,
+)
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -113,7 +118,9 @@ def convert(
         input_path: Source PDF path.
         output_path: Destination ``.vera`` path.
         model: Embedding model name (default ``"hashing"``).
-        parser: PDF parser backend (currently only ``"pymupdf"``).
+        parser: Ingest pipeline spec (``provider`` or ``provider:variant``).
+            The bundled backend is ``"pymupdf"``; additional providers are
+            discovered from the ``vera.ingest_pipelines`` entry-point group.
         chunk_size: Target chunk size in characters.
         overlap: Character overlap between consecutive chunks.
         store_original: When ``True``, embed the original PDF as an attachment.
@@ -127,14 +134,62 @@ def convert(
 
     Raises:
         FileNotFoundError: When ``input_path`` does not exist.
-        ValueError: When no searchable text is extracted or the parser is unsupported.
+        ValueError: When no searchable text is extracted or the parser is unknown.
     """
     source = Path(input_path)
     target = Path(output_path)
     if not source.exists():
         raise FileNotFoundError(input_path)
-    if parser != "pymupdf":
-        raise ValueError("v0.1 currently supports parser='pymupdf'")
+    provider, _variant = parse_ingest_pipeline_spec(parser)
+    if provider != "pymupdf":
+        pipeline = get_ingest_pipeline(parser)
+        return invoke_ingest_pipeline(
+            pipeline,
+            str(source),
+            str(target),
+            model=model,
+            parser=parser,
+            chunk_size=chunk_size,
+            overlap=overlap,
+            store_original=store_original,
+            ocr_mode=ocr_mode,
+            ocr_language=ocr_language,
+            ocr_dpi=ocr_dpi,
+            cancel=cancel,
+        )
+    return convert_with_pymupdf(
+        str(source),
+        str(target),
+        model=model,
+        chunk_size=chunk_size,
+        overlap=overlap,
+        store_original=store_original,
+        ocr_mode=ocr_mode,
+        ocr_language=ocr_language,
+        ocr_dpi=ocr_dpi,
+        cancel=cancel,
+    )
+
+
+def convert_with_pymupdf(
+    input_path: str,
+    output_path: str,
+    *,
+    model: str = "hashing",
+    chunk_size: int = 500,
+    overlap: int = 75,
+    store_original: bool = True,
+    ocr_mode: str = "auto",
+    ocr_language: str = "eng",
+    ocr_dpi: int = 300,
+    cancel: Any | None = None,
+) -> str:
+    """Convert a PDF with the bundled PyMuPDF pipeline."""
+    source = Path(input_path)
+    target = Path(output_path)
+    if not source.exists():
+        raise FileNotFoundError(input_path)
+    parser = "pymupdf"
 
     _raise_if_cancelled(cancel)
     source_data = source.read_bytes()

--- a/packages/vera-ingest/src/vera_ingest/pipeline.py
+++ b/packages/vera-ingest/src/vera_ingest/pipeline.py
@@ -1,0 +1,352 @@
+"""Ingest pipeline registry and optional plugin discovery.
+
+Built-in conversion uses the ``pymupdf`` provider. Additional parsers register
+under the ``vera.ingest_pipelines`` and ``vera.ingest_pipeline_descriptors``
+entry-point groups so CLI and desktop hosts can discover them at runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_API_VERSION = 1
+_ENTRY_POINT_GROUP = "vera.ingest_pipelines"
+_DESCRIPTOR_ENTRY_POINT_GROUP = "vera.ingest_pipeline_descriptors"
+
+_REGISTRY_LOCK = threading.RLock()
+_PIPELINE_FACTORIES: dict[str, Callable[[str], Any]] = {}
+_DESCRIPTOR_FACTORIES: dict[str, Callable[[str], "PipelineDescriptor"]] = {}
+_LOAD_ERRORS: list[str] = []
+_ENTRY_POINTS_LOADED = False
+
+
+class UnknownIngestPipelineError(ValueError):
+    """Raised when a parser spec does not match an installed pipeline."""
+
+
+@dataclass
+class PipelineDescriptor:
+    """Metadata describing an ingest pipeline for CLI and desktop discovery."""
+
+    provider: str
+    variant: str = ""
+    spec: str = ""
+    label: str = ""
+    description: str = ""
+    installed: bool = True
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    fields: list[dict[str, Any]] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        spec = self.spec or format_ingest_pipeline_spec(self.provider, self.variant)
+        return {
+            "provider": self.provider,
+            "variant": self.variant,
+            "spec": spec,
+            "label": self.label or spec,
+            "description": self.description,
+            "installed": self.installed,
+            "capabilities": dict(self.capabilities),
+            "fields": list(self.fields),
+            "notes": list(self.notes),
+        }
+
+
+def parse_ingest_pipeline_spec(spec: str) -> tuple[str, str]:
+    """Split ``provider`` or ``provider:variant`` into normalized parts."""
+    raw = (spec or "").strip().lower()
+    if not raw:
+        return "pymupdf", ""
+    if ":" in raw:
+        provider, variant = raw.split(":", 1)
+        provider = provider.strip()
+        variant = variant.strip()
+        if not provider:
+            raise UnknownIngestPipelineError("Ingest parser pipeline spec is empty.")
+        return provider, variant
+    return raw, ""
+
+
+def format_ingest_pipeline_spec(provider: str, variant: str = "") -> str:
+    key = (provider or "").strip().lower()
+    normalized_variant = (variant or "").strip().lower()
+    if not normalized_variant or normalized_variant == "default":
+        return key
+    return f"{key}:{normalized_variant}"
+
+
+def register_ingest_pipeline(
+    provider: str,
+    factory: Callable[[str], Any],
+    *,
+    replace: bool = False,
+) -> None:
+    """Register a pipeline factory called with the requested variant."""
+    if not callable(factory):
+        raise TypeError("ingest pipeline factory must be callable")
+    key = (provider or "").strip().lower()
+    if not key:
+        raise ValueError("ingest pipeline provider must be non-empty")
+    with _REGISTRY_LOCK:
+        if key in _PIPELINE_FACTORIES and not replace:
+            raise ValueError(f"ingest pipeline provider {provider!r} is already registered")
+        _PIPELINE_FACTORIES[key] = factory
+
+
+def register_ingest_pipeline_descriptor(
+    provider: str,
+    factory: Callable[[str], PipelineDescriptor],
+    *,
+    replace: bool = False,
+) -> None:
+    """Register a descriptor factory called with the requested variant."""
+    if not callable(factory):
+        raise TypeError("ingest pipeline descriptor factory must be callable")
+    key = (provider or "").strip().lower()
+    if not key:
+        raise ValueError("ingest pipeline provider must be non-empty")
+    with _REGISTRY_LOCK:
+        if key in _DESCRIPTOR_FACTORIES and not replace:
+            raise ValueError(f"ingest pipeline descriptor for {provider!r} is already registered")
+        _DESCRIPTOR_FACTORIES[key] = factory
+
+
+def reset_ingest_pipeline_registry() -> None:
+    """Drop discovered factories. Used by tests."""
+    global _ENTRY_POINTS_LOADED
+    with _REGISTRY_LOCK:
+        _PIPELINE_FACTORIES.clear()
+        _DESCRIPTOR_FACTORIES.clear()
+        _LOAD_ERRORS.clear()
+        _ENTRY_POINTS_LOADED = False
+
+
+def list_ingest_pipeline_load_errors() -> list[str]:
+    _ensure_entry_points_loaded()
+    with _REGISTRY_LOCK:
+        return list(_LOAD_ERRORS)
+
+
+def _unknown_pipeline_message(spec: str, available: str) -> str:
+    return (
+        f"Unknown ingest parser pipeline {spec!r}. "
+        f"Installed providers: {available}. "
+        f"Install a plugin registered under the '{_ENTRY_POINT_GROUP}' "
+        "entry-point group, or call register_ingest_pipeline()."
+    )
+
+
+def _safe_load_entry_point(entry: Any, provider: str, *, kind: str) -> Any | None:
+    try:
+        return entry.load()
+    except Exception as exc:  # noqa: BLE001 - one broken plugin must not hide others
+        message = f"Failed to load {kind} plugin {provider!r}: {exc!r}"
+        logger.warning("%s", message)
+        with _REGISTRY_LOCK:
+            _LOAD_ERRORS.append(message)
+        return None
+
+
+def _collect_entry_point_factories(group: str, *, kind: str) -> list[tuple[str, Any]]:
+    loaded: list[tuple[str, Any]] = []
+    discovered_groups = entry_points()
+    if hasattr(discovered_groups, "select"):
+        discovered = list(discovered_groups.select(group=group))
+    else:
+        discovered = list(discovered_groups.get(group, []))  # type: ignore[union-attr]
+    for entry in discovered:
+        provider = str(getattr(entry, "name", "") or "").strip().lower()
+        if not provider:
+            continue
+        factory = _safe_load_entry_point(entry, provider, kind=kind)
+        if callable(factory):
+            loaded.append((provider, factory))
+    return loaded
+
+
+def _ensure_entry_points_loaded() -> None:
+    global _ENTRY_POINTS_LOADED
+    with _REGISTRY_LOCK:
+        if _ENTRY_POINTS_LOADED:
+            return
+    pipeline_factories = _collect_entry_point_factories(_ENTRY_POINT_GROUP, kind="ingest pipeline")
+    descriptor_factories = _collect_entry_point_factories(
+        _DESCRIPTOR_ENTRY_POINT_GROUP, kind="ingest pipeline descriptor"
+    )
+    with _REGISTRY_LOCK:
+        if _ENTRY_POINTS_LOADED:
+            return
+        for provider, factory in pipeline_factories:
+            _PIPELINE_FACTORIES.setdefault(provider, factory)
+        for provider, factory in descriptor_factories:
+            _DESCRIPTOR_FACTORIES.setdefault(provider, factory)
+        _ENTRY_POINTS_LOADED = True
+
+
+def list_ingest_pipelines() -> list[str]:
+    """Return sorted installed provider names."""
+    ensure_pymupdf_registered()
+    _ensure_entry_points_loaded()
+    with _REGISTRY_LOCK:
+        return sorted(_PIPELINE_FACTORIES)
+
+
+def generic_pipeline_descriptor(provider: str, variant: str = "") -> PipelineDescriptor:
+    spec = format_ingest_pipeline_spec(provider, variant)
+    return PipelineDescriptor(
+        provider=provider,
+        variant=variant,
+        spec=spec,
+        label=spec,
+        description=f"Installed ingest pipeline {spec}.",
+        installed=True,
+    )
+
+
+def describe_ingest_pipeline(spec: str = "pymupdf") -> PipelineDescriptor:
+    """Return metadata for an installed pipeline without instantiating it."""
+    ensure_pymupdf_registered()
+    provider, variant = parse_ingest_pipeline_spec(spec)
+    _ensure_entry_points_loaded()
+    with _REGISTRY_LOCK:
+        if provider not in _PIPELINE_FACTORIES:
+            available = ", ".join(sorted(_PIPELINE_FACTORIES)) or "(none)"
+            raise UnknownIngestPipelineError(_unknown_pipeline_message(spec, available))
+        factory = _DESCRIPTOR_FACTORIES.get(provider)
+    if factory is None:
+        return generic_pipeline_descriptor(provider, variant)
+    descriptor = factory(variant)
+    if not isinstance(descriptor, PipelineDescriptor):
+        raise TypeError(
+            f"Ingest pipeline descriptor for {provider!r} must return PipelineDescriptor."
+        )
+    return descriptor
+
+
+def list_ingest_pipeline_descriptors() -> list[PipelineDescriptor]:
+    """Return descriptors for each installed provider using its default variant."""
+    return [describe_ingest_pipeline(provider) for provider in list_ingest_pipelines()]
+
+
+def get_ingest_pipeline(spec: str = "pymupdf") -> Any:
+    """Resolve an installed pipeline factory result."""
+    ensure_pymupdf_registered()
+    provider, variant = parse_ingest_pipeline_spec(spec)
+    _ensure_entry_points_loaded()
+    with _REGISTRY_LOCK:
+        factory = _PIPELINE_FACTORIES.get(provider)
+        if factory is None:
+            available = ", ".join(sorted(_PIPELINE_FACTORIES)) or "(none)"
+            raise UnknownIngestPipelineError(_unknown_pipeline_message(spec, available))
+    pipeline = factory(variant)
+    if not (callable(pipeline) or callable(getattr(pipeline, "convert", None))):
+        raise TypeError(
+            f"Ingest pipeline provider {provider!r} returned an object that is "
+            "neither callable nor has a convert() method."
+        )
+    return pipeline
+
+
+def invoke_ingest_pipeline(
+    pipeline: Any,
+    source_path: str,
+    output_path: str,
+    **options: Any,
+) -> str:
+    """Call a pipeline callable or a legacy ``.convert()`` object."""
+    convert_fn = getattr(pipeline, "convert", None)
+    if callable(convert_fn) and not callable(pipeline):
+        result = convert_fn(source_path, output_path, **options)
+    else:
+        result = pipeline(source_path, output_path, **options)
+    if not isinstance(result, str) or not result:
+        raise TypeError("ingest pipeline must return the output path string")
+    return result
+
+
+def pymupdf_pipeline_descriptor(variant: str = "") -> PipelineDescriptor:
+    del variant
+    return PipelineDescriptor(
+        provider="pymupdf",
+        variant="",
+        spec="pymupdf",
+        label="pymupdf — default PDF pipeline",
+        description="Bundled PyMuPDF parser with selective Tesseract OCR.",
+        installed=True,
+        capabilities={"overlap_supported": True, "ocr_engine": "tesseract"},
+        fields=[
+            {"key": "chunk_size", "label": "Chunk size", "type": "integer", "default": 500},
+            {"key": "overlap", "label": "Overlap", "type": "integer", "default": 75},
+            {"key": "ocr_mode", "label": "OCR mode", "type": "string", "default": "auto"},
+            {"key": "ocr_language", "label": "OCR language", "type": "string", "default": "eng"},
+            {"key": "ocr_dpi", "label": "OCR DPI", "type": "integer", "default": 300},
+        ],
+    )
+
+
+def create_pymupdf_pipeline(variant: str = "") -> Callable[..., str]:
+    """Entry-point factory for the bundled PyMuPDF pipeline."""
+    normalized = (variant or "").strip().lower()
+    if normalized not in {"", "default"}:
+        raise UnknownIngestPipelineError(
+            f"Unknown PyMuPDF pipeline variant {variant!r}; use 'pymupdf'."
+        )
+
+    def ingest(source_path: str, output_path: str, **options: Any) -> str:
+        from .convert import convert_with_pymupdf
+
+        filtered = {
+            key: value
+            for key, value in options.items()
+            if key in {
+                "model",
+                "chunk_size",
+                "overlap",
+                "store_original",
+                "ocr_mode",
+                "ocr_language",
+                "ocr_dpi",
+                "cancel",
+            }
+        }
+        return convert_with_pymupdf(source_path, output_path, **filtered)
+
+    return ingest
+
+
+def create_pymupdf_descriptor(variant: str = "") -> PipelineDescriptor:
+    return pymupdf_pipeline_descriptor(variant)
+
+
+def ensure_pymupdf_registered(*, replace: bool = True) -> None:
+    """Register the bundled pipeline without relying on package metadata."""
+    register_ingest_pipeline("pymupdf", create_pymupdf_pipeline, replace=replace)
+    register_ingest_pipeline_descriptor("pymupdf", create_pymupdf_descriptor, replace=replace)
+
+
+def convert_options_from_mapping(values: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Pick known convert kwargs from a sidecar/plugin-host request mapping."""
+    if not values:
+        return {}
+    keys = (
+        "model",
+        "chunk_size",
+        "overlap",
+        "store_original",
+        "ocr_mode",
+        "ocr_language",
+        "ocr_dpi",
+    )
+    options: dict[str, Any] = {}
+    for key in keys:
+        if key in values and values[key] is not None:
+            options[key] = values[key]
+    return options

--- a/skills/vera/SKILL.md
+++ b/skills/vera/SKILL.md
@@ -150,7 +150,11 @@ authorization:
   Image-based or low-text pages use selective local OCR by default. Use
   `--ocr off` only when the user explicitly requests it, or `--ocr force` when
   automatic detection misses a scan. English OCR is bundled; other languages
-  require installed Tesseract language data.
+  require installed Tesseract language data. `--parser PARSER` selects the
+  bundled `pymupdf` parser or an installed ingest plugin from the
+  `vera.ingest_pipelines` entry-point group. Unknown names fail before parsing.
+  Plugins require `python -m pip install` or `python -m pip install -e <clone>`;
+  raw `PYTHONPATH` folders are not discovered.
 - `convert --overwrite` replaces existing outputs.
 - `index build` and `index update` write `.vera-index/`.
 - `export` writes the embedded source document.

--- a/skills/vera/references/cli-reference.md
+++ b/skills/vera/references/cli-reference.md
@@ -23,7 +23,9 @@ Convert one PDF or a directory of PDFs.
 Options:
 
 - `--model MODEL` defaults to `hashing`.
-- `--parser PARSER` defaults to `pymupdf`.
+- `--parser PARSER` defaults to `pymupdf`. Additional `provider` or
+  `provider:variant` names resolve through installed
+  `vera.ingest_pipelines` entry points. Unknown names fail before parsing.
 - `--chunk-size N` defaults to `500`.
 - `--overlap N` defaults to `75`.
 - `--store-original VALUE` defaults to `true`. Values `1`, `true`, `yes`, `y`,

--- a/tests/support/echo_ingest_plugin/pyproject.toml
+++ b/tests/support/echo_ingest_plugin/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "echo-ingest-plugin"
+version = "0.0.1"
+description = "Test ingest pipeline used by VERA plugin-host tests"
+requires-python = ">=3.10"
+dependencies = ["vera-ingest"]
+
+[project.entry-points."vera.ingest_pipelines"]
+echo = "echo_ingest_plugin:create_pipeline"
+
+[project.entry-points."vera.ingest_pipeline_descriptors"]
+echo = "echo_ingest_plugin:create_descriptor"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/echo_ingest_plugin"]

--- a/tests/support/echo_ingest_plugin/src/echo_ingest_plugin/__init__.py
+++ b/tests/support/echo_ingest_plugin/src/echo_ingest_plugin/__init__.py
@@ -1,0 +1,47 @@
+"""Minimal ingest plugin used to verify entry-point discovery."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vera_ingest.pipeline import PipelineDescriptor, UnknownIngestPipelineError
+
+
+def create_pipeline(variant: str = ""):
+    normalized = (variant or "").strip().lower()
+    if normalized not in {"", "default"}:
+        raise UnknownIngestPipelineError(
+            f"Unknown echo pipeline variant {variant!r}; use 'echo'."
+        )
+
+    def ingest(source_path: str, output_path: str, **options: Any) -> str:
+        from vera_ingest.convert import convert_with_pymupdf
+
+        filtered = {
+            key: value
+            for key, value in options.items()
+            if key in {
+                "model",
+                "chunk_size",
+                "overlap",
+                "store_original",
+                "ocr_mode",
+                "ocr_language",
+                "ocr_dpi",
+                "cancel",
+            }
+        }
+        return convert_with_pymupdf(source_path, output_path, **filtered)
+
+    return ingest
+
+
+def create_descriptor(variant: str = "") -> PipelineDescriptor:
+    del variant
+    return PipelineDescriptor(
+        provider="echo",
+        spec="echo",
+        label="echo — test ingest plugin",
+        description="Test plugin used by VERA plugin-host tests.",
+        installed=True,
+    )

--- a/tests/test_app_sidecar.py
+++ b/tests/test_app_sidecar.py
@@ -1177,3 +1177,17 @@ def test_list_models_parses_openai_and_ollama_shapes(monkeypatch):
 
     ollama_config = LlmConfig.from_request({"base_url": "http://localhost:11434/v1", "auth_type": "none"})
     assert llm_module.list_models(ollama_config) == ["llama3.1", "qwen2"]
+
+
+def test_sidecar_describes_bundled_pymupdf_pipeline():
+    listed = handle({"id": "list", "action": "list_ingest_pipelines"})
+    assert listed["ok"] is True
+    assert "pymupdf" in listed["result"]["pipelines"]
+
+    described = handle({"id": "desc", "action": "describe_ingest_pipelines"})
+    assert described["ok"] is True
+    specs = {item["spec"] for item in described["result"]["pipelines"]}
+    assert "pymupdf" in specs
+    pymupdf = next(item for item in described["result"]["pipelines"] if item["spec"] == "pymupdf")
+    assert pymupdf["installed"] is True
+    assert pymupdf["provider"] == "pymupdf"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -56,6 +56,7 @@ def test_documentation_index_lists_user_guides():
         "examples.md",
         "troubleshooting.md",
         "conversion.md",
+        "creating-an-ingest-pipeline.md",
         "searching.md",
         "document-libraries.md",
         "figures-and-regions.md",
@@ -159,6 +160,11 @@ def test_hardening_json_contracts_are_documented():
     assert "Token-level `answer_delta`" in desktop_architecture
     assert "PyMuPDF parser" in desktop
     assert "local hashing embeddings" in desktop
+    assert "external Python environment" in desktop
+    assert "vera.ingest_pipelines" in desktop
+    assert "pip install -e" in desktop
+    assert "python -m vera_plugin_host" in desktop_architecture
+    assert "trusted" in desktop_architecture
     assert "Hugging Face" in desktop
     assert "HF_TOKEN" in desktop
     assert "Hugging Face" in (DOCS / "packages" / "vera-app.md").read_text(encoding="utf-8")

--- a/tests/test_ingest_pipeline.py
+++ b/tests/test_ingest_pipeline.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from test_convert_search import make_pdf
+from vera_ingest.convert import convert
+from vera_ingest.pipeline import (
+    PLUGIN_API_VERSION,
+    PipelineDescriptor,
+    UnknownIngestPipelineError,
+    describe_ingest_pipeline,
+    get_ingest_pipeline,
+    list_ingest_pipeline_descriptors,
+    list_ingest_pipelines,
+    register_ingest_pipeline,
+    register_ingest_pipeline_descriptor,
+    reset_ingest_pipeline_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    reset_ingest_pipeline_registry()
+    yield
+    reset_ingest_pipeline_registry()
+
+
+def test_plugin_api_version_is_stable():
+    assert PLUGIN_API_VERSION == 1
+
+
+def test_list_pipelines_includes_bundled_pymupdf():
+    assert "pymupdf" in list_ingest_pipelines()
+    descriptor = describe_ingest_pipeline("pymupdf")
+    assert descriptor.provider == "pymupdf"
+    assert descriptor.spec == "pymupdf"
+    assert any(item.spec == "pymupdf" for item in list_ingest_pipeline_descriptors())
+
+
+def test_unknown_parser_names_installed_providers(tmp_path):
+    pdf = tmp_path / "manual.pdf"
+    make_pdf(pdf)
+    with pytest.raises(UnknownIngestPipelineError, match="tika"):
+        convert(str(pdf), str(tmp_path / "out.vera"), parser="tika")
+
+
+def test_registered_plugin_convert_is_dispatched(tmp_path):
+    pdf = tmp_path / "manual.pdf"
+    output = tmp_path / "plugin.vera"
+    make_pdf(pdf)
+    captured: dict[str, object] = {}
+
+    def factory(variant: str):
+        def ingest(source_path: str, output_path: str, **options):
+            captured["variant"] = variant
+            captured["source"] = source_path
+            captured["options"] = options
+            return convert(source_path, output_path, parser="pymupdf", **{
+                key: value for key, value in options.items() if key != "parser"
+            })
+
+        return ingest
+
+    register_ingest_pipeline("echo", factory, replace=True)
+    register_ingest_pipeline_descriptor(
+        "echo",
+        lambda variant: PipelineDescriptor(
+            provider="echo",
+            variant=variant,
+            spec="echo",
+            label="echo",
+            installed=True,
+        ),
+        replace=True,
+    )
+
+    result = convert(str(pdf), str(output), parser="echo", model="hashing", chunk_size=400)
+    assert Path(result).is_file()
+    assert captured["source"] == str(pdf)
+    assert captured["options"]["chunk_size"] == 400
+    pipeline = get_ingest_pipeline("echo")
+    assert callable(pipeline)
+
+
+def test_entry_points_discover_dist_info_plugin(tmp_path, monkeypatch):
+    from importlib.metadata import entry_points
+
+    (tmp_path / "echo_ingest_plugin.py").write_text(
+        "from vera_ingest.pipeline import PipelineDescriptor\n"
+        "def create_pipeline(variant=''):\n"
+        "    return lambda source_path, output_path, **options: output_path\n"
+        "def create_descriptor(variant=''):\n"
+        "    return PipelineDescriptor(provider='echo', spec='echo', label='echo', installed=True)\n",
+        encoding="utf-8",
+    )
+    dist = tmp_path / "echo_ingest_plugin-0.0.1.dist-info"
+    dist.mkdir()
+    (dist / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: echo-ingest-plugin\nVersion: 0.0.1\n",
+        encoding="utf-8",
+    )
+    (dist / "entry_points.txt").write_text(
+        "[vera.ingest_pipelines]\n"
+        "echo = echo_ingest_plugin:create_pipeline\n\n"
+        "[vera.ingest_pipeline_descriptors]\n"
+        "echo = echo_ingest_plugin:create_descriptor\n",
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    if hasattr(entry_points, "cache_clear"):
+        entry_points.cache_clear()
+    reset_ingest_pipeline_registry()
+    assert "echo" in list_ingest_pipelines()
+    descriptor = describe_ingest_pipeline("echo")
+    assert descriptor.provider == "echo"
+
+
+def test_broken_entry_point_is_reported_without_hiding_pymupdf(monkeypatch):
+    class Boom:
+        name = "broken"
+
+        def load(self):
+            raise ImportError("missing plugin dependency")
+
+    class Groups:
+        def select(self, group):
+            if group == "vera.ingest_pipelines":
+                return [Boom()]
+            return []
+
+        def get(self, group, default=None):
+            return self.select(group)
+
+    monkeypatch.setattr("vera_ingest.pipeline.entry_points", lambda: Groups())
+    reset_ingest_pipeline_registry()
+    from vera_ingest.pipeline import list_ingest_pipeline_load_errors
+
+    errors = list_ingest_pipeline_load_errors()
+    assert any("broken" in entry for entry in errors)
+    assert "pymupdf" in list_ingest_pipelines()

--- a/tests/test_plugin_host.py
+++ b/tests/test_plugin_host.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from test_convert_search import make_pdf
+from vera_ingest.pipeline import (
+    PipelineDescriptor,
+    register_ingest_pipeline,
+    register_ingest_pipeline_descriptor,
+    reset_ingest_pipeline_registry,
+)
+from vera_plugin_host.cancellation import CancellationToken
+from vera_plugin_host.worker import PROTOCOL_VERSION, handle, handle_convert
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    reset_ingest_pipeline_registry()
+    yield
+    reset_ingest_pipeline_registry()
+
+
+def test_plugin_host_ping_reports_versions():
+    response = handle({"id": "ping", "action": "ping"})
+    assert response["ok"] is True
+    result = response["result"]
+    assert result["protocol"] == PROTOCOL_VERSION
+    assert result["plugin_api"] == 1
+    assert "pymupdf" in result["pipelines"]
+    assert result["python_executable"]
+
+
+def test_plugin_host_describes_registered_plugin():
+    register_ingest_pipeline("echo", lambda _variant: (lambda *args, **kwargs: args[1]), replace=True)
+    register_ingest_pipeline_descriptor(
+        "echo",
+        lambda variant: PipelineDescriptor(provider="echo", spec="echo", label="echo", installed=True),
+        replace=True,
+    )
+    response = handle({"id": "desc", "action": "describe_ingest_pipelines"})
+    assert response["ok"] is True
+    specs = {item["spec"] for item in response["result"]["pipelines"]}
+    assert "pymupdf" in specs
+    assert "echo" in specs
+
+
+def test_plugin_host_convert_uses_bundled_pymupdf(tmp_path):
+    pdf = tmp_path / "manual.pdf"
+    output = tmp_path / "manual.vera"
+    make_pdf(pdf)
+    response = handle({
+        "id": "convert",
+        "action": "convert",
+        "input": str(pdf),
+        "output": str(output),
+        "parser": "pymupdf",
+        "model": "hashing",
+    })
+    assert response["ok"] is True
+    assert Path(response["result"]["output"]).is_file()
+
+
+def test_plugin_host_unknown_action():
+    response = handle({"id": "bad", "action": "answer"})
+    assert response["ok"] is False
+    assert "Unknown action" in response["error"]
+
+
+def test_plugin_host_cancel_token_aborts_convert(tmp_path):
+    pdf = tmp_path / "manual.pdf"
+    make_pdf(pdf)
+    cancel = CancellationToken()
+    cancel.cancel()
+    response = handle(
+        {
+            "id": "convert",
+            "action": "convert",
+            "input": str(pdf),
+            "output": str(tmp_path / "out.vera"),
+        },
+        cancel=cancel,
+    )
+    assert response["ok"] is False
+    assert response.get("cancelled") is True
+
+
+def test_plugin_host_skip_token_aborts_current_file(tmp_path):
+    pdf = tmp_path / "manual.pdf"
+    make_pdf(pdf)
+    cancel = CancellationToken()
+    cancel.skip()
+    response = handle(
+        {
+            "id": "convert",
+            "action": "convert",
+            "input": str(pdf),
+            "output": str(tmp_path / "out.vera"),
+        },
+        cancel=cancel,
+    )
+    assert response["ok"] is False
+    assert response.get("cancelled") is True
+    assert "skip" in response["error"].lower()
+
+
+def test_plugin_host_emits_conversion_progress(monkeypatch, tmp_path):
+    events: list[dict] = []
+
+    def fake_convert(source_path, output_path, **options):
+        return str(output_path)
+
+    monkeypatch.setattr("vera_plugin_host.worker.convert", fake_convert)
+    result = handle_convert(
+        {
+            "id": "convert",
+            "action": "convert",
+            "input": str(tmp_path / "manual.pdf"),
+            "output": str(tmp_path / "out.vera"),
+        },
+        write_event=events.append,
+    )
+    assert result["output"].endswith("out.vera")
+    assert [event["event"] for event in events] == ["conversion_progress", "conversion_progress"]
+    assert events[0]["completed"] == 0
+    assert events[1]["completed"] == 1
+
+
+def _plugin_host_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            [
+                str(ROOT / "packages" / "vera-app" / "src"),
+                str(ROOT / "packages" / "vera-ingest" / "src"),
+                str(ROOT / "packages" / "vera-doc" / "src"),
+            ]
+        ),
+        "PYTHONUNBUFFERED": "1",
+    }
+
+
+def test_plugin_host_stdio_ping_roundtrip():
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "vera_plugin_host"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=_plugin_host_env(),
+    )
+    try:
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        proc.stdin.write(json.dumps({"id": "1", "action": "ping"}) + "\n")
+        proc.stdin.flush()
+        line = proc.stdout.readline()
+        payload = json.loads(line)
+        assert payload["ok"] is True
+        assert payload["result"]["protocol"] == 1
+        assert "pymupdf" in payload["result"]["pipelines"]
+    finally:
+        proc.stdin.close()
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def test_plugin_host_stdio_malformed_request():
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "vera_plugin_host"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=_plugin_host_env(),
+    )
+    try:
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        proc.stdin.write("not-json\n")
+        proc.stdin.flush()
+        payload = json.loads(proc.stdout.readline())
+        assert payload["ok"] is False
+        assert payload["id"] is None
+    finally:
+        proc.stdin.close()
+        proc.terminate()
+        proc.wait(timeout=5)

--- a/tests/test_plugin_install_discovery.py
+++ b/tests/test_plugin_install_discovery.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -13,18 +14,60 @@ ROOT = Path(__file__).resolve().parents[1]
 PLUGIN_SRC = ROOT / "tests" / "support" / "echo_ingest_plugin"
 
 
+def _uv() -> str | None:
+    found = shutil.which("uv")
+    if found:
+        return found
+    candidate = Path.home() / ".local" / "bin" / "uv"
+    return str(candidate) if candidate.is_file() else None
+
+
 def _venv_python(venv: Path) -> Path:
     if sys.platform == "win32":
         return venv / "Scripts" / "python.exe"
     return venv / "bin" / "python"
 
 
+def _create_venv(venv: Path) -> Path:
+    uv = _uv()
+    if uv:
+        subprocess.run([uv, "venv", str(venv)], check=True)
+        return _venv_python(venv)
+    created = subprocess.run(
+        [sys.executable, "-m", "venv", str(venv)],
+        capture_output=True,
+        text=True,
+    )
+    if created.returncode != 0:
+        raise RuntimeError(
+            "Unable to create a clean plugin-host venv. Install uv or a Python "
+            f"with ensurepip.\n{created.stderr}"
+        )
+    return _venv_python(venv)
+
+
 def _install(python: Path, *packages: str, editable: bool = False) -> None:
+    uv = _uv()
+    if uv:
+        command = [uv, "pip", "install", "--python", str(python)]
+        if editable:
+            command.append("-e")
+        command.extend(packages)
+        subprocess.run(command, check=True, cwd=ROOT)
+        return
     command = [str(python), "-m", "pip", "install", "-q"]
     if editable:
         command.append("-e")
     command.extend(packages)
     subprocess.run(command, check=True, cwd=ROOT)
+
+
+def _uninstall(python: Path, package: str) -> None:
+    uv = _uv()
+    if uv:
+        subprocess.run([uv, "pip", "uninstall", "--python", str(python), "-y", package], check=True)
+        return
+    subprocess.run([str(python), "-m", "pip", "uninstall", "-q", "-y", package], check=True)
 
 
 def _plugin_host_ping(python: Path) -> dict:
@@ -62,8 +105,7 @@ def _plugin_host_ping(python: Path) -> dict:
 
 def test_plugin_host_discovers_pip_and_editable_plugin_installs(tmp_path):
     venv = tmp_path / "plugin-env"
-    subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
-    python = _venv_python(venv)
+    python = _create_venv(venv)
     _install(
         python,
         str(ROOT / "packages" / "vera-doc"),
@@ -75,7 +117,7 @@ def test_plugin_host_discovers_pip_and_editable_plugin_installs(tmp_path):
     assert "echo" in wheel_result["pipelines"]
     assert "pymupdf" in wheel_result["pipelines"]
 
-    subprocess.run([str(python), "-m", "pip", "uninstall", "-q", "-y", "echo-ingest-plugin"], check=True)
+    _uninstall(python, "echo-ingest-plugin")
     missing = _plugin_host_ping(python)
     assert "echo" not in missing["pipelines"]
 

--- a/tests/test_plugin_install_discovery.py
+++ b/tests/test_plugin_install_discovery.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from vera_plugin_host.worker import PROTOCOL_VERSION
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_SRC = ROOT / "tests" / "support" / "echo_ingest_plugin"
+
+
+def _venv_python(venv: Path) -> Path:
+    if sys.platform == "win32":
+        return venv / "Scripts" / "python.exe"
+    return venv / "bin" / "python"
+
+
+def _install(python: Path, *packages: str, editable: bool = False) -> None:
+    command = [str(python), "-m", "pip", "install", "-q"]
+    if editable:
+        command.append("-e")
+    command.extend(packages)
+    subprocess.run(command, check=True, cwd=ROOT)
+
+
+def _plugin_host_ping(python: Path) -> dict:
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(ROOT / "packages" / "vera-app" / "src"),
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONNOUSERSITE": "1",
+    }
+    proc = subprocess.Popen(
+        [str(python), "-m", "vera_plugin_host"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+    try:
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        proc.stdin.write('{"id":"1","action":"ping"}\n')
+        proc.stdin.flush()
+        line = proc.stdout.readline()
+        assert line, proc.stderr.read()
+        payload = json.loads(line)
+        assert payload["ok"] is True, payload
+        return payload["result"]
+    finally:
+        if proc.stdin:
+            proc.stdin.close()
+        proc.terminate()
+        proc.wait(timeout=10)
+
+
+def test_plugin_host_discovers_pip_and_editable_plugin_installs(tmp_path):
+    venv = tmp_path / "plugin-env"
+    subprocess.run([sys.executable, "-m", "venv", str(venv)], check=True)
+    python = _venv_python(venv)
+    _install(
+        python,
+        str(ROOT / "packages" / "vera-doc"),
+        str(ROOT / "packages" / "vera-ingest"),
+    )
+    _install(python, str(PLUGIN_SRC))
+    wheel_result = _plugin_host_ping(python)
+    assert wheel_result["protocol"] == PROTOCOL_VERSION
+    assert "echo" in wheel_result["pipelines"]
+    assert "pymupdf" in wheel_result["pipelines"]
+
+    subprocess.run([str(python), "-m", "pip", "uninstall", "-q", "-y", "echo-ingest-plugin"], check=True)
+    missing = _plugin_host_ping(python)
+    assert "echo" not in missing["pipelines"]
+
+    _install(python, str(PLUGIN_SRC), editable=True)
+    editable_result = _plugin_host_ping(python)
+    assert "echo" in editable_result["pipelines"]

--- a/tests/test_sidecar_build.py
+++ b/tests/test_sidecar_build.py
@@ -66,7 +66,10 @@ def test_excluded_modules_reach_pyinstaller() -> None:
     assert '"--exclude-module"' in BUILD_SCRIPT.read_text(encoding="utf-8")
 
 
-def test_semantic_embedding_dependencies_are_not_excluded() -> None:
+def test_packaged_app_ships_plugin_host_source() -> None:
+    package_json = (ROOT / "packages" / "vera-app" / "package.json").read_text(encoding="utf-8")
+    assert "python/plugin-host/vera_plugin_host" in package_json
+    assert (ROOT / "packages" / "vera-app" / "src" / "vera_plugin_host" / "__main__.py").is_file()
     excluded = set(_excluded_modules())
     assert excluded.isdisjoint(SEMANTIC_REQUIREMENTS), (
         "build-sidecar.cjs excludes modules the semantic embedder needs: "


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Packaged desktop conversions keep the frozen sidecar for search, Ask, indexing, and the bundled PyMuPDF pipeline.
- Optional ingest plugins run in a shipped `vera_plugin_host` worker launched with a user-selected Python interpreter (`pip install` or `pip install -e`; raw `PYTHONPATH` folders are not discovered).
- Electron merges bundled and external pipeline descriptors, routes convert/cancel/skip to the owning process, and exposes interpreter validation under File → LLM Providers.
- `vera-ingest` discovers extra parsers from the `vera.ingest_pipelines` entry-point group. Duplicate provider names keep the bundled implementation.

## Test plan

- [x] Full `uv run --extra dev python -m pytest -q` (including plugin host handshake, discovery, convert, progress, cancel/skip, malformed JSON, and a clean uv venv covering both a regular install and `pip install -e` of a sample plugin).
- [x] `npm run app:typecheck` and `npm --prefix packages/vera-app run test:unit` (routing, Windows spawn args, descriptor merging, protocol IPC, Convert install hints, environment manager).
- [x] `npm run app:build` (Electron main + renderer production build). Unpacked Windows `app:dist` was not run here; this environment is Linux and the packaged target is Windows.
- [x] Manual Convert + LLM Providers walkthrough: ingest pipeline selector, interpreter Browse/Validate, Ready status for Python 3.12.3 / vera-ingest 0.2.5 / pymupdf.
- [x] Retrieval baselines were checked when search behavior changed. — not applicable; search behavior is unchanged.

[Convert view with ingest pipeline selector](https://cursor.com/agents/bc-7dc03d89-c86b-44f4-b2ce-d55bfc69e0ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconvert_ingest_pipeline.webp)
[LLM Providers external Python section after successful Validate](https://cursor.com/agents/bc-7dc03d89-c86b-44f4-b2ce-d55bfc69e0ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpython_environment_ready.webp)
[convert_and_external_python_ui.mp4](https://cursor.com/agents/bc-7dc03d89-c86b-44f4-b2ce-d55bfc69e0ea/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconvert_and_external_python_ui.mp4)

## Documentation

- [x] User-visible behavior is documented in the README or relevant `docs/` guide.
- [x] CLI/API/MCP references and examples reflect public contract changes.
- [x] `skills/vera/` reflects agent-facing behavior changes.
- [x] Documentation-contract tests were updated when commands, options, JSON, exit codes, links, or documented workflows changed.
- [ ] Not applicable: this change has no user-visible or agent-facing behavior.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dc03d89-c86b-44f4-b2ce-d55bfc69e0ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dc03d89-c86b-44f4-b2ce-d55bfc69e0ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

