### PR TITLE
fix: keep external plugins after relaunch and stop stale Validate timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,9 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
   Chat; show installed provider suggestions; hashing and MiniLM presets.
 - Packaged desktop app: opt-in external Python plugin runtime
   (`vera_plugin_host`) so extra ingest plugins installed with `pip` or
-  `pip install -e` run without being frozen into the sidecar.
+  `pip install -e` run without being frozen into the sidecar. A saved
+  interpreter is re-probed on launch (up to two minutes) and Convert refreshes
+  when that probe succeeds.
 
 - Typed `Citation` on search hits (`result.citation`) plus configurable hybrid
   `semantic_weight` / `keyword_weight` on `VeraDocument.search()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
   (`vera_plugin_host`) so extra ingest plugins installed with `pip` or
   `pip install -e` run without being frozen into the sidecar. A saved
   interpreter is re-probed on launch (up to two minutes) and Convert refreshes
-  when that probe succeeds.
+  when that probe succeeds. Validate does not show a previous timeout while a
+  new probe is still running.
 
 - Typed `Citation` on search hits (`result.citation`) plus configurable hybrid
   `semantic_weight` / `keyword_weight` on `VeraDocument.search()`.

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -295,7 +295,8 @@ Unknown pipeline names fail before parsing with an install-the-plugin message;
 VERA never silently falls back to PyMuPDF. The packaged desktop app can run
 extra pipelines from a trusted external Python environment after
 `python -m pip install` or `python -m pip install -e <clone>` and Validate
-under **File > LLM Providers**. On Docling memory errors
+under **File > LLM Providers**. Later launches re-probe that saved interpreter.
+On Docling memory errors
 (`bad_alloc`), VERA retries failed pages with a fresh converter and falls back
 to the `pypdfium2` PDF backend when needed; conversion rejects only when that
 recovery is exhausted. Force the low-memory backend with

--- a/docs/creating-an-ingest-pipeline.md
+++ b/docs/creating-an-ingest-pipeline.md
@@ -401,7 +401,9 @@ user-selected Python interpreter:
 1. Create a venv and install `vera-ingest` 0.3.x plus your plugin
    (`python -m pip install …` or `python -m pip install -e <clone>`).
 2. In VERA, open **File > LLM Providers**, enable **External Python plugins**,
-   choose that environment's interpreter, and **Validate**.
+   choose that environment's interpreter, and **Validate** once. Later launches
+   re-probe that saved interpreter and refresh Convert; first discovery can
+   take about a minute when Docling/Torch imports are cold.
 3. Convert lists extra providers as `(external)`. Bundled `pymupdf` wins on
    duplicate names. Treat the interpreter as trusted code; raw `PYTHONPATH`
    folders are not discovered.

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -93,7 +93,9 @@ to that worker package so plugins come from the selected environment after
 sidecar implementation. The worker speaks `ping`, `list_ingest_pipelines`,
 `describe_ingest_pipelines`, `convert`, `batch_convert`, `cancel`, and `skip`.
 Treat the selected interpreter as trusted code. Hugging Face tokens and
-`DOCLING_ARTIFACTS_PATH` are forwarded to the worker.
+`DOCLING_ARTIFACTS_PATH` are forwarded to the worker. A saved interpreter is
+re-probed on launch; Convert refreshes when that probe succeeds. The probe
+allows up to two minutes because a cold Docling/Torch import often exceeds 40s.
 
 ## Active Libraries and Collection Indexes
 

--- a/docs/desktop-app-getting-started.md
+++ b/docs/desktop-app-getting-started.md
@@ -184,10 +184,16 @@ the frozen sidecar. To use extra ingest plugins:
    ```
    Adding a clone to `PYTHONPATH` without installing it is not enough.
 2. In VERA, open **File > LLM Providers**, enable **External Python plugins**,
-   choose that environment's `python.exe`, and click **Validate**.
+   choose that environment's `python.exe`, and click **Validate** once.
 3. Convert lists extra providers as `(external)`. Bundled `pymupdf` wins when a
    plugin repeats that name. After installing or updating plugins, click
    **Refresh plugins**.
+
+On later launches VERA re-probes the saved interpreter in the background and
+refreshes Convert when that probe succeeds. You do not need to Validate after
+every launch. First discovery can take about a minute when Docling or Torch
+imports are cold; Convert may show Docling as not installed until that probe
+finishes.
 
 The selected environment must provide `vera-ingest` 0.3.x (plugin API version
 1). Plugins register under the `vera.ingest_pipelines` entry-point group.
@@ -219,11 +225,13 @@ Optional Hugging Face tokens and the **Model cache** field
   repository and `%TEMP%` from real-time scanning, then retry.
 - **Validate fails for the external Python environment** — choose an absolute
   interpreter path that exists, install `vera-ingest` 0.3.x into that
-  environment, then Validate again.
+  environment, then Validate again. A cold Docling/Torch import can take about
+  a minute; wait for Ready rather than assuming the probe hung.
 - **An extra parser is missing from Convert** — install it with
   `python -m pip install` or `python -m pip install -e <clone>` in the selected
-  environment, then **Refresh plugins**. Raw `PYTHONPATH` folders are not
-  discovered.
+  environment, then **Refresh plugins**. After a relaunch, wait for the
+  automatic re-probe before treating the parser as missing. Raw `PYTHONPATH`
+  folders are not discovered.
 
 ## Provider request errors
 

--- a/docs/desktop-app-getting-started.md
+++ b/docs/desktop-app-getting-started.md
@@ -226,7 +226,9 @@ Optional Hugging Face tokens and the **Model cache** field
 - **Validate fails for the external Python environment** — choose an absolute
   interpreter path that exists, install `vera-ingest` 0.3.x into that
   environment, then Validate again. A cold Docling/Torch import can take about
-  a minute; wait for Ready rather than assuming the probe hung.
+  a minute; the status stays on “Checking the Python environment…” until the
+  probe finishes. A timeout from an earlier attempt should not appear the
+  moment you click Validate.
 - **An extra parser is missing from Convert** — install it with
   `python -m pip install` or `python -m pip install -e <clone>` in the selected
   environment, then **Refresh plugins**. After a relaunch, wait for the

--- a/docs/packages/vera-app.md
+++ b/docs/packages/vera-app.md
@@ -41,7 +41,8 @@ only required for generated Ask responses.
 Packaged conversions keep PyMuPDF in the frozen sidecar. Extra ingest plugins
 run from a trusted external Python environment configured under
 **File > LLM Providers**. Install plugins with `python -m pip install` or
-`python -m pip install -e <clone>`, then Validate / Refresh. See
+`python -m pip install -e <clone>`, then Validate / Refresh. Later launches
+re-probe the saved interpreter. See
 [Creating an ingest pipeline plugin](../creating-an-ingest-pipeline.md) and
 [Desktop app architecture](../desktop-app-architecture.md).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -190,7 +190,9 @@ Unknown names fail before parsing and never fall back to another pipeline.
 The packaged desktop app can also run extra parsers from a trusted external
 Python environment. Install them with `python -m pip install` or
 `python -m pip install -e <clone>` in that environment, then Validate under
-**File > LLM Providers**. Raw `PYTHONPATH` folders are not discovered.
+**File > LLM Providers**. After a relaunch VERA re-probes that saved
+interpreter; wait for Convert to refresh before treating a parser as missing.
+Raw `PYTHONPATH` folders are not discovered.
 
 If Hugging Face Hub downloads warn about unauthenticated requests or hit rate
 limits, set `HF_TOKEN` (see `.env.example`) or save a token under **File >

--- a/packages/vera-app/electron/ingest-runtime.test.ts
+++ b/packages/vera-app/electron/ingest-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   parsePipelineProvider,
   pluginHostCompatibilityError,
   pluginHostSpawnCommand,
+  PLUGIN_HOST_VALIDATE_TIMEOUT_MS,
   processOwnerFor,
   shouldRouteToExternal,
 } from './ingest-runtime.js';
@@ -57,6 +58,10 @@ describe('ingest-runtime', () => {
     expect(shouldRouteToExternal('pymupdf', ['pymupdf'])).toBe(false);
     expect(shouldRouteToExternal('docling', ['pymupdf'])).toBe(true);
     expect(shouldRouteToExternal('docling:hybrid', ['pymupdf'])).toBe(true);
+  });
+
+  it('gives cold plugin-host imports more than 20s to finish', () => {
+    expect(PLUGIN_HOST_VALIDATE_TIMEOUT_MS).toBeGreaterThanOrEqual(90_000);
   });
 
   it('rejects incompatible plugin hosts', () => {

--- a/packages/vera-app/electron/ingest-runtime.ts
+++ b/packages/vera-app/electron/ingest-runtime.ts
@@ -12,6 +12,8 @@ import {
 } from '../src/shared/protocol.js';
 
 export const BUNDLED_PIPELINE_PROVIDER = 'pymupdf';
+/** Cold Docling/Torch imports often exceed 40s; keep the launch probe above that. */
+export const PLUGIN_HOST_VALIDATE_TIMEOUT_MS = 120_000;
 
 export function parsePipelineProvider(spec: string | undefined | null): string {
   const raw = (spec || '').trim().toLowerCase();

--- a/packages/vera-app/electron/json-line-process.test.ts
+++ b/packages/vera-app/electron/json-line-process.test.ts
@@ -94,4 +94,17 @@ describe('JsonLineProcess', () => {
     child.stdout.emit('data', Buffer.from('{"id":"job-1","ok":true,"result":{"output":"out.vera"}}\n'));
     await expect(convert).resolves.toMatchObject({ ok: true });
   });
+
+  it('forceRestart kills in-flight work instead of waiting for idle', async () => {
+    const child = fakeChild();
+    spawn.mockReturnValue(child);
+    const proc = new JsonLineProcess('plugin-host', () => ({
+      executable: 'python',
+      args: ['-m', 'vera_plugin_host'],
+    }));
+    const pending = proc.request({ action: 'ping' });
+    proc.forceRestart();
+    await expect(pending).rejects.toThrow(/restarted/);
+    expect(child.kill).toHaveBeenCalled();
+  });
 });

--- a/packages/vera-app/electron/json-line-process.ts
+++ b/packages/vera-app/electron/json-line-process.ts
@@ -116,6 +116,11 @@ export class JsonLineProcess {
     this.killChild(`${this.label} restarted`);
   }
 
+  /** Kill even when a request is still in flight (timed-out probes). */
+  forceRestart(): void {
+    this.killChild(`${this.label} restarted`);
+  }
+
   get running(): boolean {
     return this.child !== null;
   }

--- a/packages/vera-app/electron/main.ts
+++ b/packages/vera-app/electron/main.ts
@@ -24,8 +24,10 @@ import {
   normalizePipelineDescriptor,
   parsePipelineProvider,
   pluginHostSpawnCommand,
+  PLUGIN_HOST_VALIDATE_TIMEOUT_MS,
   processOwnerFor,
   probeFromPing,
+  shouldRouteToExternal,
 } from './ingest-runtime.js';
 import { parseSidecarJsonLine } from './sidecar-json.js';
 
@@ -109,10 +111,10 @@ const DEFAULT_SETTINGS: AppSettings = {
   external_python: { enabled: false, executable: '' },
 };
 
-const PLUGIN_HOST_VALIDATE_TIMEOUT_MS = 20_000;
 let pluginWorkerExecutable = '';
 let pluginWorkerArtifacts = '';
 let lastPythonProbe: PythonEnvironmentProbe | null = null;
+let pythonProbeTask: Promise<PythonEnvironmentProbe> | null = null;
 const requestOwners = new Map<string, 'core' | 'external'>();
 let bundledProviders = new Set<string>(['pymupdf']);
 
@@ -411,6 +413,18 @@ function pluginHostCommand() {
 
 const pluginWorker = new JsonLineProcess('vera-plugin-host', pluginHostCommand);
 
+function broadcastPythonEnvironment(probe: PythonEnvironmentProbe): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) win.webContents.send(IPC_CHANNELS.pythonEnvironment, probe);
+  }
+}
+
+function setPythonProbe(probe: PythonEnvironmentProbe): PythonEnvironmentProbe {
+  lastPythonProbe = probe;
+  broadcastPythonEnvironment(probe);
+  return probe;
+}
+
 function syncPluginWorker(config: ExternalPythonConfig | null | undefined): void {
   const executable = config?.enabled ? config.executable.trim() : '';
   const artifacts = config?.enabled ? (config.artifacts_path || '').trim() : '';
@@ -519,6 +533,13 @@ async function routeSidecarRequest(
   }
   const settings = readSettings();
   const parser = typeof request.parser === 'string' ? request.parser : 'pymupdf';
+  if (
+    pythonProbeTask
+    && (request.action === SIDECAR_ACTIONS.convert || request.action === SIDECAR_ACTIONS.batchConvert)
+    && shouldRouteToExternal(parser, bundledProviders)
+  ) {
+    await pythonProbeTask.catch(() => undefined);
+  }
   const owner = conversionRuntimeOwner(
     request.action,
     parser,
@@ -535,21 +556,12 @@ async function routeSidecarRequest(
   }
 }
 
-async function validatePythonEnvironment(
-  executable: string,
-  artifactsPath?: string,
+async function runPythonProbe(
+  resolved: string,
+  artifacts: string,
 ): Promise<PythonEnvironmentProbe> {
-  const resolved = executable.trim();
-  if (!resolved) {
-    lastPythonProbe = { ok: false, error: 'Choose a Python interpreter.' };
-    return lastPythonProbe;
-  }
-  if (!existsSync(resolved)) {
-    lastPythonProbe = { ok: false, executable: resolved, error: `Python interpreter not found: ${resolved}` };
-    return lastPythonProbe;
-  }
   pluginWorkerExecutable = resolved;
-  pluginWorkerArtifacts = (artifactsPath || '').trim();
+  pluginWorkerArtifacts = artifacts;
   if (pluginWorker.running) pluginWorker.restart();
   try {
     const ping = await withTimeout(
@@ -558,33 +570,64 @@ async function validatePythonEnvironment(
       'Python environment probe',
     );
     if (!ping.ok) {
-      lastPythonProbe = {
+      return setPythonProbe({
         ok: false,
         executable: resolved,
         error: ping.error || 'Plugin host ping failed',
-      };
-      return lastPythonProbe;
+      });
     }
     const pingResult = (ping.result || {}) as Record<string, unknown>;
     const described = await pluginWorker.request({ action: SIDECAR_ACTIONS.describeIngestPipelines });
     const pipelines = described.ok ? descriptorsFromResult(described.result, 'external') : [];
-    lastPythonProbe = probeFromPing(resolved, pingResult, pipelines);
+    const probe = probeFromPing(resolved, pingResult, pipelines);
     if (described.ok && described.result && typeof described.result === 'object') {
       const loadErrors = (described.result as { load_errors?: unknown }).load_errors;
       if (Array.isArray(loadErrors)) {
-        lastPythonProbe.load_errors = loadErrors.filter((value): value is string => typeof value === 'string');
+        probe.load_errors = loadErrors.filter((value): value is string => typeof value === 'string');
       }
     }
-    return lastPythonProbe;
+    return setPythonProbe(probe);
   } catch (error) {
-    lastPythonProbe = {
+    pluginWorker.forceRestart();
+    return setPythonProbe({
       ok: false,
       executable: resolved,
       error: error instanceof Error ? error.message : 'Unable to start the plugin host',
-    };
-    pluginWorker.restart();
-    return lastPythonProbe;
+    });
   }
+}
+
+async function validatePythonEnvironment(
+  executable: string,
+  artifactsPath?: string,
+): Promise<PythonEnvironmentProbe> {
+  const resolved = executable.trim();
+  const artifacts = (artifactsPath || '').trim();
+  if (!resolved) {
+    return setPythonProbe({ ok: false, error: 'Choose a Python interpreter.' });
+  }
+  if (!existsSync(resolved)) {
+    return setPythonProbe({
+      ok: false,
+      executable: resolved,
+      error: `Python interpreter not found: ${resolved}`,
+    });
+  }
+  if (
+    pythonProbeTask
+    && resolved === pluginWorkerExecutable
+    && artifacts === pluginWorkerArtifacts
+  ) {
+    return pythonProbeTask;
+  }
+  if (pythonProbeTask) {
+    await pythonProbeTask.catch(() => undefined);
+  }
+  const task = runPythonProbe(resolved, artifacts);
+  pythonProbeTask = task.finally(() => {
+    if (pythonProbeTask === task) pythonProbeTask = null;
+  });
+  return task;
 }
 
 async function pickPythonInterpreter(): Promise<string | null> {

--- a/packages/vera-app/electron/main.ts
+++ b/packages/vera-app/electron/main.ts
@@ -564,8 +564,10 @@ async function runPythonProbe(
   pluginWorkerArtifacts = artifacts;
   if (pluginWorker.running) pluginWorker.restart();
   try {
+    const pingRequest = pluginWorker.request({ action: SIDECAR_ACTIONS.ping });
+    void pingRequest.catch(() => undefined);
     const ping = await withTimeout(
-      pluginWorker.request({ action: SIDECAR_ACTIONS.ping }),
+      pingRequest,
       PLUGIN_HOST_VALIDATE_TIMEOUT_MS,
       'Python environment probe',
     );

--- a/packages/vera-app/electron/preload.cts
+++ b/packages/vera-app/electron/preload.cts
@@ -1,4 +1,4 @@
-import type { AppSettings, Session, StreamEvent } from '../src/shared/contracts.js';
+import type { AppSettings, PythonEnvironmentProbe, Session, StreamEvent } from '../src/shared/contracts.js';
 import type { IPC_CHANNELS as IpcChannels } from '../src/shared/protocol.js';
 
 const { contextBridge, ipcRenderer } = require('electron');
@@ -43,6 +43,7 @@ const IPC_CHANNELS: typeof IpcChannels = {
   pickPythonInterpreter: 'vera:pickPythonInterpreter',
   validatePythonEnvironment: 'vera:validatePythonEnvironment',
   refreshExternalPipelines: 'vera:refreshExternalPipelines',
+  pythonEnvironment: 'vera:pythonEnvironment',
 };
 
 contextBridge.exposeInMainWorld('vera', {
@@ -96,5 +97,10 @@ contextBridge.exposeInMainWorld('vera', {
     const listener = (_event: unknown, data: StreamEvent) => callback(data);
     ipcRenderer.on(IPC_CHANNELS.answerEvent, listener);
     return () => ipcRenderer.removeListener(IPC_CHANNELS.answerEvent, listener);
+  },
+  onPythonEnvironment: (callback: (probe: PythonEnvironmentProbe) => void) => {
+    const listener = (_event: unknown, probe: PythonEnvironmentProbe) => callback(probe);
+    ipcRenderer.on(IPC_CHANNELS.pythonEnvironment, listener);
+    return () => ipcRenderer.removeListener(IPC_CHANNELS.pythonEnvironment, listener);
   },
 });

--- a/packages/vera-app/electron/protocol-contract.test.ts
+++ b/packages/vera-app/electron/protocol-contract.test.ts
@@ -67,5 +67,6 @@ describe('sidecar protocol contract', () => {
     expect(IPC_CHANNELS.pickPythonInterpreter).toBe('vera:pickPythonInterpreter');
     expect(IPC_CHANNELS.validatePythonEnvironment).toBe('vera:validatePythonEnvironment');
     expect(IPC_CHANNELS.refreshExternalPipelines).toBe('vera:refreshExternalPipelines');
+    expect(IPC_CHANNELS.pythonEnvironment).toBe('vera:pythonEnvironment');
   });
 });

--- a/packages/vera-app/src/renderer/components/PythonEnvironmentManager.test.tsx
+++ b/packages/vera-app/src/renderer/components/PythonEnvironmentManager.test.tsx
@@ -75,4 +75,20 @@ describe('PythonEnvironmentManager', () => {
     );
     expect(html).toContain('not compatible');
   });
+
+  it('hides a stale probe error while Validate is in flight', () => {
+    const html = renderToStaticMarkup(
+      <PythonEnvironmentManager
+        config={config}
+        status={{ ok: false, error: 'Python environment probe timed out after 20s' }}
+        busy
+        onConfigChange={() => undefined}
+        onPick={() => undefined}
+        onValidate={() => undefined}
+        onRefresh={() => undefined}
+      />,
+    );
+    expect(html).toContain('Checking the Python environment');
+    expect(html).not.toContain('timed out');
+  });
 });

--- a/packages/vera-app/src/renderer/components/PythonEnvironmentManager.tsx
+++ b/packages/vera-app/src/renderer/components/PythonEnvironmentManager.tsx
@@ -72,7 +72,9 @@ export function PythonEnvironmentManager({
           Refresh plugins
         </button>
       </div>
-      {status ? (
+      {busy ? (
+        <p className="sideMuted" role="status">Checking the Python environment…</p>
+      ) : status ? (
         <div className={status.ok ? 'pythonEnvStatus ok' : 'pythonEnvStatus error'} role="status">
           {!status.ok ? <AlertTriangle size={14} /> : null}
           <div>

--- a/packages/vera-app/src/renderer/main.tsx
+++ b/packages/vera-app/src/renderer/main.tsx
@@ -1631,6 +1631,11 @@ function App() {
     setSettingsOpen(true);
   }), []);
 
+  useEffect(() => window.vera.onPythonEnvironment((probe) => {
+    setPythonStatus(probe);
+    void reloadIngestPipelines();
+  }), []);
+
   const folderPathsKey = folders.map((folder) => folder.path).join('\n');
 
   // Keep folder headers scannable: expand the active library, collapse the rest.

--- a/packages/vera-app/src/renderer/main.tsx
+++ b/packages/vera-app/src/renderer/main.tsx
@@ -1386,7 +1386,8 @@ function App() {
     setIngestPipelineConfigs(saved.ingest_pipeline_configs || {});
     setHasHfToken(Boolean(saved.has_hf_token));
     setExternalPython(saved.external_python || { enabled: false, executable: '' });
-    setPythonStatus(saved.external_python_status || null);
+    // Probe status is runtime-only. Saving settings used to copy a stale
+    // timeout from a previous launch probe into the Validate UI.
     return saved;
   }
 

--- a/packages/vera-app/src/renderer/types.ts
+++ b/packages/vera-app/src/renderer/types.ts
@@ -79,6 +79,7 @@ export interface VeraApi {
   onOpenSettings(callback: () => void): () => void;
   onFolderChanged(callback: (path: string) => void): () => void;
   onAnswerEvent(callback: (data: StreamEvent) => void): () => void;
+  onPythonEnvironment(callback: (probe: PythonEnvironmentProbe) => void): () => void;
 }
 
 export interface FolderEntry {

--- a/packages/vera-app/src/shared/protocol.ts
+++ b/packages/vera-app/src/shared/protocol.ts
@@ -32,6 +32,7 @@ export const IPC_CHANNELS = {
   pickPythonInterpreter: 'vera:pickPythonInterpreter',
   validatePythonEnvironment: 'vera:validatePythonEnvironment',
   refreshExternalPipelines: 'vera:refreshExternalPipelines',
+  pythonEnvironment: 'vera:pythonEnvironment',
 } as const;
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS];

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -286,7 +286,9 @@ def test_hardening_json_contracts_are_documented():
     assert "external Python environment" in desktop
     assert "vera.ingest_pipelines" in desktop
     assert "pip install -e" in desktop
+    assert "re-probes the saved interpreter" in desktop
     assert "python -m vera_plugin_host" in desktop_architecture
+    assert "re-probed on launch" in desktop_architecture
     assert "trusted" in desktop_architecture
     assert "python/plugin-host/vera_plugin_host" in (
         ROOT / "packages" / "vera-app" / "package.json"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -287,6 +287,7 @@ def test_hardening_json_contracts_are_documented():
     assert "vera.ingest_pipelines" in desktop
     assert "pip install -e" in desktop
     assert "re-probes the saved interpreter" in desktop
+    assert "Checking the Python environment" in desktop
     assert "python -m vera_plugin_host" in desktop_architecture
     assert "re-probed on launch" in desktop_architecture
     assert "trusted" in desktop_architecture


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Follow-up to #23. That PR was squash-merged to `v0.3` before these two fixes were pushed to the old feature branch, so they never landed.
- Raise the external-Python probe timeout from 20s to 2 minutes so a cold Docling/Torch import (~42s) can finish on launch.
- Broadcast the probe result so Convert refreshes to `(external)` without clicking Validate again.
- Validate no longer copies a stale timeout into the UI the moment it is clicked; it shows “Checking the Python environment…” until this attempt finishes.

## Test plan

- [x] `npm run app:typecheck`
- [x] `npm --prefix packages/vera-app run test:unit`
- [x] Documentation-contract tests
- [ ] Packaged relaunch: saved Docling environment becomes `(external)` without clicking Validate
- [ ] Validate click does not flash a stale timeout while the probe is still running
- [ ] Retrieval baselines were checked when search behavior changed. (N/A)

## Documentation

- [x] User-visible behavior is documented in the README or relevant `docs/`
      guide.
- [x] CLI/API/MCP references and examples reflect public contract changes.
- [x] `skills/vera/` reflects agent-facing behavior changes.
- [x] Documentation-contract tests were updated when commands, options, JSON,
      exit codes, links, or documented workflows changed.
- [ ] Not applicable: this change has no user-visible or agent-facing behavior.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dc03d89-c86b-44f4-b2ce-d55bfc69e0ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dc03d89-c86b-44f4-b2ce-d55bfc69e0ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

