### PR TITLE
Prepare v0.3.0 release readiness: docs, tests, and CLI gaps (#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,4 +94,4 @@ jobs:
         env:
           HF_HUB_OFFLINE: "1"
           TRANSFORMERS_OFFLINE: "1"
-        run: uv run --extra dev --extra docling pytest -q -m "docling and not docling_integration"
+        run: uv run --extra dev --extra docling pytest -q packages/vera-ingest-docling/tests -m "not docling_integration"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
   plugins page and no `vera_plugin_host`. Docling model artifacts download when
   you select Advanced layout (`prepare_docling`) into an app-owned
   `DOCLING_ARTIFACTS_PATH` cache (incomplete caches resume from Hugging Face
-  instead of failing offline). Convert drives
+  instead of failing offline). Convert shows model-preparation status and
+  confirms before stopping an in-progress download. Convert drives
   `EmbedderConfigForm` from descriptors, persists `embedder_configs`, and
   gates conversion on `preflight_embedder`. Search reports
   `skipped_semantic_model_groups` when a query embedder is unavailable.
@@ -65,6 +66,11 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
   chunk already occupies the matching FTS rowid).
 - `VeraDocument.iter_raw_chunks()` / `format_metadata()` for library indexing
   without private `VeraDocument` access.
+- `vera ocr-languages list` and `vera ocr-languages download` for Tesseract
+  language data used by the PyMuPDF pipeline (English is bundled; other
+  languages are fetched into a local cache).
+- `vera-lab` contributor layout lab (workspace `dev` extra only; not
+  published to PyPI).
 
 ### Changed
 
@@ -94,6 +100,13 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
   falling back to PyMuPDF.
 - There is no silent fallback to a different embedding model or ingest
   pipeline when a named provider is missing or fails to load.
+
+### Fixed
+
+- `vera mcp` prints an install hint and exits 2 when the optional `mcp`
+  extra is not installed, instead of raising `ImportError`.
+- PyMuPDF conversion imports `pymupdf` directly, so `vera convert` no longer
+  prints a deprecated `fitz` API warning on every run.
 
 ### Desktop
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ copied, shared, or handed to an LLM agent and searched in place — no vector
 database, embedding service, or retrieval server is required.
 
 ```bash
-pip install vera-cli
+pip install "vera-cli>=0.3.0"
 vera convert manual.pdf manual.vera
 vera search manual.vera "when is stormwater detention required?" --json
 ```
@@ -432,10 +432,11 @@ filters, corpus search, and embedding configuration.
 
 ## Desktop app
 
-VERA also includes a desktop application for Windows: PDF conversion from the
-Explorer context menu, library search with highlighted citations, and an
-optional LLM provider connection for grounded question answering over
-documents. Configure chat providers and a Hugging Face token under
+VERA also includes a desktop application. The packaged installer currently
+targets Windows: PDF conversion from the Explorer context menu, library search
+with highlighted citations, and an optional LLM provider connection for
+grounded question answering over documents. From a repository checkout,
+`npm run app:dev` also runs on Linux and macOS. Configure chat providers and a Hugging Face token under
 **File > Settings**. Packaged conversions use one sidecar with PyMuPDF
 (default) and Advanced layout / Docling. Extra ingest and embedding plugins
 are pip packages in that same environment. It is built on the

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -14,7 +14,8 @@ Electron fits the product shape VERA is moving toward:
 - PDF/document workspace UI
 - sidebars, tabs, command palette, settings, and keyboard-driven interaction
 - mature PDF.js and web rendering ecosystem
-- normal desktop packaging path for Windows/macOS/Linux
+- a desktop packaging path (the current installer target is Windows;
+  `npm run app:dev` works on Linux, macOS, and Windows)
 
 Tauri remains a possible future optimization if app size becomes the dominant concern. PySide/PyQt would keep more code in Python but would make a polished document workstation UI more expensive to build.
 

--- a/docs/desktop-app-getting-started.md
+++ b/docs/desktop-app-getting-started.md
@@ -17,7 +17,8 @@ and then open VERA from the Start menu.
 - Python 3.10 or newer
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Node.js and npm
-- Windows (the current root development script and packaged build target Windows)
+- Source-run (`npm run app:dev`) works on Linux, macOS, and Windows. The
+  packaged installer currently targets Windows only.
 
 ## Clone the repository
 

--- a/docs/validation-and-export.md
+++ b/docs/validation-and-export.md
@@ -33,13 +33,14 @@ vera validate "manual.vera"
 Validation checks:
 
 - SQLite integrity;
-- required tables and metadata;
-- document, page, chunk, embedding, FTS, and asset counts;
-- one embedding and one FTS row per chunk;
-- embedding blob dimensions;
+- required tables and metadata (`vera_metadata`, `chunks`, `embeddings`,
+  `attachments`, `chunk_attachments`, `chunks_fts`);
+- matching chunk, embedding, and FTS row counts;
+- embedding blob dimensions and `float32_le` vector format;
 - finite vectors and compliance with a declared L2 normalization policy;
-- page references;
-- presence of the original source document.
+- JSON object shape for chunk, attachment, and archive metadata;
+- attachment SHA-256 checksums;
+- presence of the original source document (warning when it is omitted).
 
 JSON mode returns the full report:
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -68,8 +68,9 @@ retrieval implementation.
 ## `vera-app`
 
 Owns the Electron/React desktop app and Python sidecar. Depends directly on
-`vera-doc`, `vera-ingest`, `vera-ingest-pymupdf`, and `vera-ingest-docling`;
-it does not use the CLI as a backend.
+`vera-doc`, `vera-ingest`, `vera-ingest-pymupdf`, `vera-ingest-docling`, and
+`sentence-transformers`; it does not use the CLI as a backend. The packaged
+Windows installer freezes those converters plus MiniLM weights.
 
 ## `vera-lab`
 

--- a/packages/vera-cli/src/vera_cli/commands.py
+++ b/packages/vera-cli/src/vera_cli/commands.py
@@ -360,8 +360,15 @@ def cmd_export(args) -> int:
 
 
 def cmd_mcp(args) -> int:
-    from vera_mcp import main as mcp_main
-
+    try:
+        from vera_mcp import main as mcp_main
+    except ImportError:
+        print(
+            "vera mcp requires the optional MCP extra. "
+            "Install with: python -m pip install 'vera-cli[mcp]>=0.3.0'",
+            file=sys.stderr,
+        )
+        return 2
     return mcp_main()
 
 

--- a/packages/vera-cli/tests/test_cli.py
+++ b/packages/vera-cli/tests/test_cli.py
@@ -392,6 +392,15 @@ def test_cli_convert_unknown_provider_emits_json(tmp_path, monkeypatch, capsys):
     assert payload == {"ok": False, "error": message}
 
 
+def test_cli_mcp_explains_missing_extra(monkeypatch, capsys):
+    monkeypatch.setitem(sys.modules, "vera_mcp", None)
+    args = build_parser().parse_args(["mcp"])
+    assert args.func(args) == 2
+    err = capsys.readouterr().err
+    assert "vera mcp requires" in err
+    assert "vera-cli[mcp]" in err
+
+
 def test_cli_ocr_languages_list_json(capsys):
     args = build_parser().parse_args(["ocr-languages", "list", "eng+zzz", "--json"])
     assert args.func(args) == 0

--- a/packages/vera-ingest-docling/tests/test_docling_descriptor.py
+++ b/packages/vera-ingest-docling/tests/test_docling_descriptor.py
@@ -36,8 +36,9 @@ def test_create_descriptor_entry_point_does_not_need_runtime(monkeypatch):
 
 
 def test_create_pipeline_explains_missing_runtime(monkeypatch):
+    # create_pipeline() binds this helper at import time in __init__.py.
     monkeypatch.setattr(
-        "vera_ingest_docling.options._docling_runtime_available",
+        "vera_ingest_docling._docling_runtime_available",
         lambda: False,
     )
     with pytest.raises(UnknownIngestPipelineError, match="vera-ingest-docling"):

--- a/packages/vera-ingest-pymupdf/src/vera_ingest_pymupdf/parser.py
+++ b/packages/vera-ingest-pymupdf/src/vera_ingest_pymupdf/parser.py
@@ -34,7 +34,7 @@ _OCR_IMAGE_COVERAGE_THRESHOLD = 0.5
 
 def _open_fitz():
     try:
-        import fitz  # PyMuPDF
+        import pymupdf as fitz
     except Exception as exc:  # pragma: no cover
         raise RuntimeError(
             "PyMuPDF is required for PDF parsing: install vera-ingest-pymupdf"

--- a/packages/vera-lab/src/vera_lab/render.py
+++ b/packages/vera-lab/src/vera_lab/render.py
@@ -58,7 +58,7 @@ def rasterize_pages(
 
     Returns a mapping of page_number -> {data_url, width, height}.
     """
-    import fitz
+    import pymupdf as fitz
 
     if dpi < 36 or dpi > 300:
         raise ValueError("dpi must be between 36 and 300")

--- a/packages/vera-lab/src/vera_lab/report.py
+++ b/packages/vera-lab/src/vera_lab/report.py
@@ -116,7 +116,7 @@ def _load_runs(
 
 
 def _pdf_page_count(source_bytes: bytes) -> int:
-    import fitz
+    import pymupdf as fitz
 
     document = fitz.open(stream=source_bytes, filetype="pdf")
     try:

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -358,16 +358,16 @@ def test_hardening_json_contracts_are_documented():
     assert "VERA_SENTENCE_TRANSFORMERS_HOME" in main_ts
     assert not (ROOT / "packages" / "vera-app" / "src" / "vera_app" / "runtime.py").is_file()
     assert "Docling" in desktop
-    sidecar_build = (
-        ROOT / "packages" / "vera-app" / "scripts" / "build-sidecar.cjs"
-    ).read_text(encoding="utf-8")
+    sidecar_build = (ROOT / "packages" / "vera-app" / "scripts" / "build-sidecar.cjs").read_text(
+        encoding="utf-8"
+    )
     assert "copy-metadata" in sidecar_build
     assert "vendor_minilm.py" in sidecar_build
     assert "sentence_transformers" in sidecar_build
     assert "--exclude-module" not in sidecar_build
-    assert "sentence-transformers" in (
-        ROOT / "packages" / "vera-app" / "pyproject.toml"
-    ).read_text(encoding="utf-8")
+    assert "sentence-transformers" in (ROOT / "packages" / "vera-app" / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
     assert "ensure_registered" in (
         ROOT / "packages" / "vera-ingest-pymupdf" / "src" / "vera_ingest_pymupdf" / "__init__.py"
     ).read_text(encoding="utf-8")
@@ -605,3 +605,35 @@ def test_operational_docs_cover_recent_public_interfaces():
     assert "vera-lab (dev only)" in packages_index
     assert "ocr-languages list" in agents
     assert "ocr-languages download" in skill
+
+
+def test_release_docs_match_packaged_sidecar_and_validate_behavior():
+    """Guard 0.3 packaging and validate docs against the current implementation."""
+    packages_overview = (ROOT / "packages" / "README.md").read_text(encoding="utf-8")
+    docling_pkg = (DOCS / "packages" / "vera-ingest-docling.md").read_text(encoding="utf-8")
+    app_pkg = (DOCS / "packages" / "vera-app.md").read_text(encoding="utf-8")
+    desktop = (DOCS / "desktop-app-getting-started.md").read_text(encoding="utf-8")
+    architecture = (DOCS / "desktop-app-architecture.md").read_text(encoding="utf-8")
+    validate_docs = (DOCS / "validation-and-export.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    intro = readme.split("```bash", 1)[1].split("```", 1)[0]
+
+    assert "not bundled into packaged desktop releases" not in packages_overview
+    assert "packaged Windows sidecar freezes it" in packages_overview
+    assert "Advanced layout (slower)" in packages_overview
+    assert "vera-ingest-docling" in packages_overview.split("## `vera-app`", 1)[1]
+    assert "sentence-transformers" in packages_overview.split("## `vera-app`", 1)[1]
+    assert "vera-ingest-docling" in app_pkg
+    assert "not bundled in the installer" not in docling_pkg
+    assert "all-MiniLM-L6-v2" in docling_pkg
+    assert "Linux, macOS, and Windows" in desktop
+    assert "packaged installer currently targets Windows" in desktop
+    assert "Windows/macOS/Linux" not in architecture
+    assert "current installer target is Windows" in architecture
+    assert "document, page, chunk, embedding, FTS, and asset counts" not in validate_docs
+    assert "page references" not in validate_docs
+    assert "`chunks_fts`" in validate_docs
+    assert "vera ocr-languages list" in changelog
+    assert "vera-lab" in changelog
+    assert "vera-cli>=0.3.0" in intro


### PR DESCRIPTION
* fix: close 0.3 release-readiness test and CLI gaps

Patch the Docling missing-runtime test at the imported helper so it still fails closed when Docling is installed. Run unmarked vera-ingest-docling tests in the Docling CI job. Silence the deprecated fitz import on convert, and tell users to install vera-cli[mcp] when vera mcp cannot import.



* docs: correct 0.3 packaging claims and changelog gaps

Document that Docling and MiniLM ship in the Windows sidecar, that source-run works on Linux and macOS, and that validate checks format 0.2 tables rather than 0.1 page documents. Record ocr-languages, vera-lab, and the convert warning/mcp extra fixes in the changelog, and lock those claims in documentation-contract tests.



---------

## Summary

- 

## Test plan

- [ ] Relevant automated tests pass.
- [ ] Retrieval baselines were checked when search behavior changed.

## Documentation

- [ ] User-visible behavior is documented in the README or relevant `docs/`
      guide.
- [ ] CLI/API/MCP references and examples reflect public contract changes.
- [ ] `skills/vera/` reflects agent-facing behavior changes.
- [ ] Documentation-contract tests were updated when commands, options, JSON,
      exit codes, links, or documented workflows changed.
- [ ] Not applicable: this change has no user-visible or agent-facing behavior.
