### PR TITLE
Stop app:dev MiniLM from silently using Sentence Transformers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,9 @@ non-obvious caveats for this environment; standard commands live in the sections
   `/workspace/.venv`.
 - Standard checks: `uv run --extra dev python -m pytest -q` (or `npm test`) for Python,
   `npm run app:typecheck` and `npm --prefix packages/vera-app run test:unit` for the app.
-- Desktop app: `npm run app:dev` works on Linux, macOS, and Windows. Electron
+- Desktop app: `npm run app:dev` works on Linux, macOS, and Windows. It vendors
+  the MiniLM ONNX graph into `packages/vera-app/build/minilm` before Electron
+  starts. Electron
   spawns the Python sidecar as `python -m vera_app.sidecar`, so set
   `VERA_APP_PYTHON=/workspace/.venv/bin/python` (the venv Python has numpy/pymupdf/pdfplumber);
   otherwise the sidecar fails to import its deps. In the cloud VM also set `DISPLAY=:1` and
@@ -214,8 +216,7 @@ non-obvious caveats for this environment; standard commands live in the sections
   `all-MiniLM-L6-v2` graph (`VERA_ONNX_MINILM_HOME` /
   `VERA_SENTENCE_TRANSFORMERS_HOME`);
   packaged `HF_HOME` stays under userData. `app:dev` leaves `HF_HOME` unset
-  and points MiniLM at `packages/vera-app/build/minilm` when that snapshot
-  exists. Convert
+  and vendors MiniLM into `packages/vera-app/build/minilm` before launch. Convert
   timing lines (`elapsed_ms`) go to
   sidecar stderr and are teed to `userData/logs/sidecar.log`; open it from
   **File > Open convert log...**. Ask is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
   Archive identity stays `sentence-transformers/all-MiniLM-L6-v2`. The installer
   vendors a VERA-exported fp32 graph (SHA256-pinned via `export_minilm_onnx.py`
   and `compare_minilm_onnx.py`). CLI MiniLM is `vera-doc[onnx]`; other Hub
-  Sentence Transformers models remain `vera-doc[ml]`.
+  Sentence Transformers models remain `vera-doc[ml]`. `app:dev` vendors the ONNX
+  snapshot before launch. MiniLM no longer falls back to Sentence Transformers
+  when the `onnx` extra is installed but the ONNX graph is missing.
 
 ## [0.3.0] — 2026-08
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,10 @@ The desktop app also needs Node.js 22+:
 npm --prefix packages/vera-app install
 ```
 
+`npm run app:dev` vendors the MiniLM ONNX graph into
+`packages/vera-app/build/minilm` before Electron starts (one-time export with
+`--extra ml` if that snapshot is missing).
+
 ## Checks
 
 Run these before opening a pull request:

--- a/README.md
+++ b/README.md
@@ -446,9 +446,10 @@ grounded question answering over documents. From a repository checkout,
 **File > Settings**. Packaged conversions use one sidecar with PyMuPDF.
 **File > Open convert log...** opens
 timed convert steps in `userData/logs/sidecar.log` (same file in
-`app:dev` and packaged VERA). `app:dev` loads MiniLM from
-`packages/vera-app/build/minilm` when that snapshot exists; packaged builds
-vendor it. Extra ingest and embedding plugins
+`app:dev` and packaged VERA). `app:dev` vendors MiniLM ONNX into
+`packages/vera-app/build/minilm` before launch; it does not load Sentence
+Transformers for MiniLM when the `onnx` extra is installed. Packaged builds
+vendor the same graph. Extra ingest and embedding plugins
 are pip packages in that same environment. It is built on the
 same packages described above. Download it from
 [GitHub Releases](https://github.com/dkylewillis/vera/releases/latest) and see

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,9 +99,8 @@ providers, sessions, and application state. It depends on `vera-doc`,
 viewer helpers), not on `vera-cli`. Packaged conversions keep one frozen
 sidecar for search, Ask, and PyMuPDF. MiniLM (`all-MiniLM-L6-v2`) runs on
 ONNX Runtime; `npm run app:dev` vendors that graph before launch. When the
-`onnx` extra is installed, a missing MiniLM snapshot does not fall back to
-Sentence Transformers. Extra ingest and embedding
-plugins are pip packages in that same environment.
+`onnx` extra is installed, a missing MiniLM snapshot does not fall back to Sentence Transformers.
+Extra ingest and embedding plugins are pip packages in that same environment.
 
 ### `vera-lab`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,7 +97,10 @@ providers, sessions, and application state. It depends on `vera-doc`,
 `vera-ingest`, and `vera-ingest-pymupdf`
 (including
 viewer helpers), not on `vera-cli`. Packaged conversions keep one frozen
-sidecar for search, Ask, and PyMuPDF. Extra ingest and embedding
+sidecar for search, Ask, and PyMuPDF. MiniLM (`all-MiniLM-L6-v2`) runs on
+ONNX Runtime; `npm run app:dev` vendors that graph before launch. When the
+`onnx` extra is installed, a missing MiniLM snapshot does not fall back to
+Sentence Transformers. Extra ingest and embedding
 plugins are pip packages in that same environment.
 
 ### `vera-lab`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -32,9 +32,10 @@ Options:
 
 - `--model MODEL` (`hashing`; accepts `provider:model-id` specs such as
   `sentence-transformers:all-MiniLM-L6-v2`; unknown providers exit with an
-  error; MiniLM needs the `onnx` extra, other Sentence Transformers models
-  need the `ml` extra, and the Windows installer vendors a VERA-exported
-  MiniLM graph)
+  error; MiniLM needs the `onnx` extra and an ONNX snapshot, other Sentence
+  Transformers models need the `ml` extra, and the Windows installer vendors a
+  VERA-exported MiniLM graph. When the `onnx` extra is installed, MiniLM does
+  not fall back to Sentence Transformers)
 - `--parser PARSER` (`pymupdf`; accepts `provider[:variant]` specs such as
   `docling` / `docling:hybrid` when `vera-cli[docling]` is installed; unknown
   providers exit with an error; the 0.3.0 Windows installer does not include

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -180,10 +180,12 @@ bare alias `all-MiniLM-L6-v2` still work.
 The model name, vector dimension, and stored-vector normalization policy are
 recorded in the archive. Both built-in embedders use L2 normalization. Search
 uses the recorded model, so CLI machines that search a MiniLM archive still
-need `vera-doc[onnx]` plus a MiniLM ONNX snapshot (`VERA_ONNX_MINILM_HOME`, or
-the graph the Windows installer vendors), or `vera-doc[ml]` so Sentence
-Transformers can load MiniLM from the Hub. The packaged desktop sidecar already
-includes ONNX Runtime and the pinned graph.
+need `vera-doc[onnx]` plus a MiniLM ONNX snapshot (`VERA_ONNX_MINILM_HOME`,
+`app:dev`'s vendored graph, or the graph the Windows installer vendors).
+When the `onnx` extra is installed, MiniLM does not fall back to Sentence
+Transformers. Install `vera-doc[ml]` without the `onnx` extra if you want
+MiniLM via Sentence Transformers from the Hub. The packaged desktop sidecar
+already includes ONNX Runtime and the pinned graph.
 
 Prefer `provider:model-id` specs. An unrecognized provider or model raises an
 error at convert time instead of silently falling back to hashing. Third-party

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -182,8 +182,8 @@ recorded in the archive. Both built-in embedders use L2 normalization. Search
 uses the recorded model, so CLI machines that search a MiniLM archive still
 need `vera-doc[onnx]` plus a MiniLM ONNX snapshot (`VERA_ONNX_MINILM_HOME`,
 `app:dev`'s vendored graph, or the graph the Windows installer vendors).
-When the `onnx` extra is installed, MiniLM does not fall back to Sentence
-Transformers. Install `vera-doc[ml]` without the `onnx` extra if you want
+When the `onnx` extra is installed, MiniLM does not fall back to Sentence Transformers.
+Install `vera-doc[ml]` without the `onnx` extra if you want
 MiniLM via Sentence Transformers from the Hub. The packaged desktop sidecar
 already includes ONNX Runtime and the pinned graph.
 

--- a/docs/creating-an-embedding-provider.md
+++ b/docs/creating-an-embedding-provider.md
@@ -67,9 +67,10 @@ Install the package in the same environment as VERA (`python -m pip install`
 or `python -m pip install -e <clone>`), then restart the app. Bundled
 `hashing` wins on duplicate names. MiniLM uses the workspace `onnx` extra
 (ONNX Runtime) for CLI and source-run installs. Other Sentence Transformers
-models use the `ml` extra. The Windows installer freezes ONNX Runtime and
-vendors a VERA-exported `all-MiniLM-L6-v2` graph. Archive identity stays
-`sentence-transformers/all-MiniLM-L6-v2`.
+models use the `ml` extra. When the `onnx` extra is installed, MiniLM does
+not fall back to Sentence Transformers. The Windows installer freezes ONNX
+Runtime and vendors a VERA-exported `all-MiniLM-L6-v2` graph. Archive identity
+stays `sentence-transformers/all-MiniLM-L6-v2`.
 
 ## Minimal example (DIY hosted provider)
 

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -114,8 +114,8 @@ VERA-exported `all-MiniLM-L6-v2` ONNX graph in the installer. Archive identity
 stays `sentence-transformers/all-MiniLM-L6-v2`. Hugging Face tokens,
 packaged `HF_HOME` (a writable cache under `userData` unless already set),
 `VERA_ONNX_MINILM_HOME`, and `VERA_SENTENCE_TRANSFORMERS_HOME` (alias for the
-bundled MiniLM snapshot, or `packages/vera-app/build/minilm` when that folder
-exists in `app:dev`) are forwarded on spawn. `app:dev` leaves `HF_HOME` unset.
+bundled MiniLM snapshot) are forwarded on spawn. `app:dev` vendors
+`packages/vera-app/build/minilm` before launch. `app:dev` leaves `HF_HOME` unset.
 Convert stays on **Discovering PDFs** until `resolve_embedder` finishes.
 Convert gates conversion on `preflight_embedder`.
 Docling is a CLI extra (`vera-cli[docling]`) and is not listed in Convert.
@@ -346,7 +346,8 @@ npm run app:dist
 ```
 
 `npm run app:dev` starts Electron against the workspace sidecar with the
-`app` extra (ONNX MiniLM). Convert uses PyMuPDF in that sidecar. `npm run app:dist`
+`app` extra (ONNX MiniLM) after vendoring `packages/vera-app/build/minilm`.
+Convert uses PyMuPDF in that sidecar. `npm run app:dist`
 packages the Python
 sidecar through `packages/vera-app/scripts/build-sidecar.cjs`, which runs
 PyInstaller with the project virtualenv when it is available (honoring

--- a/docs/desktop-app-getting-started.md
+++ b/docs/desktop-app-getting-started.md
@@ -254,12 +254,13 @@ pipeline is not listed in the 0.3.0 desktop Convert view.
 Ingest plugins register under `vera.ingest_pipelines`; embedders register
 under `vera.embedders`. Desktop Convert calls `preflight_embedder` before writing an
 archive. MiniLM runs on ONNX Runtime in the Windows sidecar with a
-VERA-exported, SHA256-pinned graph. Source-run `app:dev` installs MiniLM via
-`--extra app` / `--extra onnx` and, when present, loads
-`packages/vera-app/build/minilm`. Other Sentence Transformers models still
-need `uv sync --extra ml`. A missing `onnxruntime` module in a checkout means
-that extra is not installed — run `uv sync --extra onnx` (or `--extra app`)
-and restart the app. See
+VERA-exported, SHA256-pinned graph. `npm run app:dev` vendors that graph
+into `packages/vera-app/build/minilm` before Electron starts (exporting
+once with `--extra ml` if the snapshot is missing). It does not silently
+fall back to Sentence Transformers when the `onnx` extra is installed.
+Other Sentence Transformers models still need `uv sync --extra ml`. A missing
+`onnxruntime` module in a checkout means that extra is not installed —
+run `uv sync --extra onnx` (or `--extra app`) and restart the app. See
 [Creating an ingest pipeline plugin](creating-an-ingest-pipeline.md) and
 [Creating an embedding provider](creating-an-embedding-provider.md).
 Convert and embed always run in-process in the sidecar; see

--- a/docs/packages/vera-app.md
+++ b/docs/packages/vera-app.md
@@ -75,8 +75,8 @@ npm run app:dev
 The supported packaged target is currently Windows. Use the CLI
 `--pipeline-option` flags (or Convert-view pipeline settings) for
 provider-owned chunking and OCR controls. Packaged and `app:dev` Convert both
-report `pymupdf`, plus hashing and MiniLM embedders. `app:dev` loads MiniLM
-from `packages/vera-app/build/minilm` when that snapshot exists; packaged
+report `pymupdf`, plus hashing and MiniLM embedders. `app:dev` vendors MiniLM
+into `packages/vera-app/build/minilm` before launch; packaged
 builds vendor a VERA-exported ONNX graph. The sidecar does not import Torch.
 Docling is not listed;
 use `vera-cli[docling]` from the CLI.

--- a/docs/packages/vera-doc.md
+++ b/docs/packages/vera-doc.md
@@ -23,8 +23,10 @@ python -m pip install ./packages/vera-doc
 
 Python 3.10 or newer is required. The default hashing embedder works locally
 without a model download or API key. MiniLM neural embeddings use the
-optional `onnx` extra (ONNX Runtime). The Windows installer freezes
-ONNX Runtime and vendors a VERA-exported `all-MiniLM-L6-v2` graph. Other
+optional `onnx` extra (ONNX Runtime) plus a MiniLM ONNX snapshot. When that
+extra is installed, MiniLM does not fall back to Sentence Transformers. The
+Windows installer freezes ONNX Runtime and vendors a VERA-exported
+`all-MiniLM-L6-v2` graph. Other
 Hub Sentence Transformers models use the `ml` extra. Additional
 providers can be registered with
 `register_embedder` or discovered through the `vera.embedders` entry-point

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -322,7 +322,12 @@ visible while it is still running.
 
 Convert reports **Discovering PDFs** until MiniLM is resolved. Check
 `sidecar.log` for `resolve_embedder` timing. MiniLM no longer imports Torch
-at sidecar start.
+at sidecar start. Sidecar stderr `MiniLM runtime=onnx` means ONNX Runtime is
+in use. `Loading weights: 0/103` is Hugging Face safetensors via Sentence
+Transformers — that MiniLM path is used only when the `onnx` extra is not
+installed. `npm run app:dev` vendors the ONNX graph first; a missing graph
+with the `onnx` extra installed is an error, not a silent Sentence
+Transformers load.
 
 ## Figures are missing or have no caption
 

--- a/packages/vera-app/electron/main.ts
+++ b/packages/vera-app/electron/main.ts
@@ -190,26 +190,35 @@ function packagedSidecarExecutable(): string {
   return join(dir, fallback);
 }
 
+function looksLikeOnnxMinilmHome(home: string): boolean {
+  const nested = join(home, 'all-MiniLM-L6-v2');
+  return [nested, home].some(
+    (dir) => existsSync(join(dir, 'model.onnx')) && existsSync(join(dir, 'tokenizer.json')),
+  );
+}
+
 function minilmHome(): string | undefined {
   const onnxEnv = process.env.VERA_ONNX_MINILM_HOME?.trim();
-  if (onnxEnv && existsSync(onnxEnv)) return onnxEnv;
+  if (onnxEnv && looksLikeOnnxMinilmHome(onnxEnv)) return onnxEnv;
   const fromEnv = process.env.VERA_SENTENCE_TRANSFORMERS_HOME?.trim();
-  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  if (fromEnv && looksLikeOnnxMinilmHome(fromEnv)) return fromEnv;
   if (!app.isPackaged) {
     const devVendor = join(process.cwd(), 'build', 'minilm');
-    if (existsSync(join(devVendor, 'all-MiniLM-L6-v2', 'model.onnx'))) {
+    if (looksLikeOnnxMinilmHome(devVendor)) {
       return devVendor;
     }
-    return onnxEnv || fromEnv || undefined;
+    console.warn(
+      'MiniLM ONNX snapshot missing at packages/vera-app/build/minilm/all-MiniLM-L6-v2/model.onnx. ' +
+        'Ask/Convert MiniLM will not use ONNX. `npm run app:dev` vendors this graph before launch.',
+    );
+    return undefined;
   }
   const sidecarDir = dirname(packagedSidecarExecutable());
   const candidates = [
     join(sidecarDir, 'sentence_transformers_models'),
     join(sidecarDir, '_internal', 'sentence_transformers_models'),
   ];
-  return candidates.find((candidate) =>
-    existsSync(join(candidate, 'all-MiniLM-L6-v2', 'model.onnx')),
-  );
+  return candidates.find((candidate) => looksLikeOnnxMinilmHome(candidate));
 }
 
 function userDataHfHome(): string {

--- a/packages/vera-doc/README.md
+++ b/packages/vera-doc/README.md
@@ -22,6 +22,8 @@ Python 3.10 or newer is required. The default hashing embedder needs no model
 download or API key. MiniLM (`all-MiniLM-L6-v2`) uses the optional `onnx`
 extra (`onnxruntime` + `tokenizers`) plus a VERA-exported ONNX snapshot
 (`VERA_ONNX_MINILM_HOME`, or the graph vendored in the Windows installer).
+When the `onnx` extra is installed, MiniLM does not fall back to Sentence
+Transformers.
 Other Hub Sentence Transformers models use the `ml` extra.
 
 ## Quick start

--- a/packages/vera-doc/src/vera_doc/embeddings.py
+++ b/packages/vera-doc/src/vera_doc/embeddings.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import re
+import sys
 import threading
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -28,6 +29,7 @@ from .onnx_minilm import (
     MINILM_HUB_NAME,
     OnnxMiniLMEmbedder,
     minilm_bundle_home,
+    onnx_minilm_deps_available,
     resolve_onnx_minilm_source,
     sentence_transformers_available,
 )
@@ -286,23 +288,36 @@ def _sentence_transformers_factory(model_id: str, **config: Any) -> EmbeddingFun
         onnx_source = resolve_onnx_minilm_source(model_name)
         if onnx_source is not None:
             try:
-                return OnnxMiniLMEmbedder(
+                embedder = OnnxMiniLMEmbedder(
                     MINILM_HUB_NAME,
                     source=onnx_source,
                     device=options.device,
                     batch_size=options.batch_size,
                 )
+                print(f"MiniLM runtime=onnx snapshot={onnx_source}", file=sys.stderr)
+                return embedder
             except ImportError:
                 logger.info(
-                    "onnxruntime is not installed; falling back to Sentence Transformers for MiniLM"
+                    "ONNX MiniLM dependencies are not installed; "
+                    "falling back to Sentence Transformers for MiniLM"
                 )
+        elif onnx_minilm_deps_available():
+            raise UnknownEmbeddingModelError(
+                "all-MiniLM-L6-v2 uses ONNX Runtime, but no MiniLM graph was found "
+                "(need model.onnx and tokenizer.json). Set VERA_ONNX_MINILM_HOME or run "
+                "packages/vera-app/scripts/vendor_minilm.py (app:dev vendors this automatically). "
+                "Sentence Transformers is not used for MiniLM when the onnx extra is installed."
+            )
     try:
-        return SentenceTransformerEmbedder(
+        embedder = SentenceTransformerEmbedder(
             model_name,
             source=resolve_sentence_transformers_source(model_name),
             device=options.device,
             batch_size=options.batch_size,
         )
+        if short_id == BUNDLED_MINILM_MODEL_ID:
+            print("MiniLM runtime=sentence-transformers", file=sys.stderr)
+        return embedder
     except ImportError as exc:
         if short_id == BUNDLED_MINILM_MODEL_ID:
             raise UnknownEmbeddingModelError(

--- a/packages/vera-doc/src/vera_doc/embeddings.py
+++ b/packages/vera-doc/src/vera_doc/embeddings.py
@@ -288,14 +288,14 @@ def _sentence_transformers_factory(model_id: str, **config: Any) -> EmbeddingFun
         onnx_source = resolve_onnx_minilm_source(model_name)
         if onnx_source is not None:
             try:
-                embedder = OnnxMiniLMEmbedder(
+                onnx_embedder = OnnxMiniLMEmbedder(
                     MINILM_HUB_NAME,
                     source=onnx_source,
                     device=options.device,
                     batch_size=options.batch_size,
                 )
                 print(f"MiniLM runtime=onnx snapshot={onnx_source}", file=sys.stderr)
-                return embedder
+                return onnx_embedder
             except ImportError:
                 logger.info(
                     "ONNX MiniLM dependencies are not installed; "

--- a/packages/vera-doc/src/vera_doc/onnx_minilm.py
+++ b/packages/vera-doc/src/vera_doc/onnx_minilm.py
@@ -214,3 +214,28 @@ def sentence_transformers_available() -> bool:
     except ImportError:
         return False
     return True
+
+
+def onnxruntime_available() -> bool:
+    try:
+        import onnxruntime  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def tokenizers_available() -> bool:
+    try:
+        import tokenizers  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def onnx_minilm_deps_available() -> bool:
+    """True when MiniLM can run on ONNX Runtime (not merely that onnxruntime exists).
+
+    Docling's RapidOCR extra also installs ``onnxruntime``. Requiring tokenizers
+    keeps that from blocking the Sentence Transformers MiniLM path.
+    """
+    return onnxruntime_available() and tokenizers_available()

--- a/packages/vera-doc/tests/test_onnx_minilm.py
+++ b/packages/vera-doc/tests/test_onnx_minilm.py
@@ -15,6 +15,7 @@ from vera_doc import ChunkRecord, VeraDocument
 from vera_doc.embeddings import (
     BUNDLED_MINILM_MODEL_ID,
     SENTENCE_TRANSFORMERS_HOME_ENV,
+    UnknownEmbeddingModelError,
     bundled_minilm_available,
     clear_embedder_cache,
     cosine_similarity,
@@ -170,10 +171,50 @@ class TestModelListing:
         else:
             assert "all-MiniLM-L12-v2" not in ids
 
+    def test_minilm_does_not_fall_back_to_st_when_onnx_extra_installed(self, tmp_path, monkeypatch):
+        pytest.importorskip("onnxruntime")
+        pytest.importorskip("tokenizers")
+        monkeypatch.delenv(ONNX_MINILM_HOME_ENV, raising=False)
+        monkeypatch.setenv(SENTENCE_TRANSFORMERS_HOME_ENV, str(tmp_path))
+        monkeypatch.setattr(sys, "frozen", False, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path / "missing-meipass"), raising=False)
+        clear_embedder_cache()
+        with pytest.raises(UnknownEmbeddingModelError, match="ONNX Runtime"):
+            get_embedder("sentence-transformers:all-MiniLM-L6-v2")
+
+    def test_minilm_factory_uses_onnx_when_snapshot_exists(self, tmp_path, monkeypatch, capsys):
+        model_dir = tmp_path / BUNDLED_MINILM_MODEL_ID
+        model_dir.mkdir()
+        (model_dir / "model.onnx").write_bytes(b"stub")
+        (model_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+        monkeypatch.setenv(ONNX_MINILM_HOME_ENV, str(tmp_path))
+        monkeypatch.delenv(SENTENCE_TRANSFORMERS_HOME_ENV, raising=False)
+
+        class DummyOnnx:
+            model_name = MINILM_HUB_NAME
+
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            def embed(self, texts: list[str]) -> list[np.ndarray]:
+                return []
+
+        def boom(*args, **kwargs):
+            raise AssertionError(
+                "Sentence Transformers should not load MiniLM when an ONNX snapshot exists"
+            )
+
+        monkeypatch.setattr("vera_doc.embeddings.OnnxMiniLMEmbedder", DummyOnnx)
+        monkeypatch.setattr("vera_doc.embeddings.SentenceTransformerEmbedder", boom)
+        clear_embedder_cache()
+        embedder = get_embedder("sentence-transformers:all-MiniLM-L6-v2")
+        assert isinstance(embedder, DummyOnnx)
+        assert "MiniLM runtime=onnx" in capsys.readouterr().err
+
 
 @pytest.mark.skipif(_onnx_snapshot() is None, reason="vendored MiniLM ONNX snapshot is not present")
 class TestOnnxMiniLMGoldens:
-    def test_goldens_match_onnx_embedder(self, monkeypatch):
+    def test_goldens_match_onnx_embedder(self, monkeypatch, capsys):
         snapshot = _onnx_snapshot()
         assert snapshot is not None
         pytest.importorskip("onnxruntime")
@@ -183,6 +224,7 @@ class TestOnnxMiniLMGoldens:
         embedder = get_embedder("sentence-transformers:all-MiniLM-L6-v2")
         assert isinstance(embedder, OnnxMiniLMEmbedder)
         assert embedder.model_name == MINILM_HUB_NAME
+        assert "MiniLM runtime=onnx" in capsys.readouterr().err
         payload = json.loads(_GOLDENS.read_text(encoding="utf-8"))
         texts = [item["text"] for item in payload["items"]]
         vectors = embedder.embed(texts)

--- a/scripts/app-dev.js
+++ b/scripts/app-dev.js
@@ -1,4 +1,5 @@
 const { spawnSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 
 // `uv run` spawns its command via Rust's std::process::Command, which does
@@ -8,6 +9,61 @@ const path = require("path");
 const npmBin = process.platform === "win32" ? "npm.cmd" : "npm";
 
 const repoRoot = path.resolve(__dirname, "..");
+const minilmDest = path.join(
+  repoRoot,
+  "packages",
+  "vera-app",
+  "build",
+  "minilm",
+  "all-MiniLM-L6-v2",
+);
+const vendorScript = path.join(
+  repoRoot,
+  "packages",
+  "vera-app",
+  "scripts",
+  "vendor_minilm.py",
+);
+
+function runUv(args, extra) {
+  return spawnSync("uv", ["run", "--extra", extra, ...args], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: true,
+    env: process.env,
+  });
+}
+
+function snapshotReady() {
+  return (
+    fs.existsSync(path.join(minilmDest, "model.onnx")) &&
+    fs.existsSync(path.join(minilmDest, "tokenizer.json"))
+  );
+}
+
+function vendorMinilm(extra) {
+  console.log(`Vendoring MiniLM ONNX snapshot with --extra ${extra}`);
+  return runUv(["python", vendorScript, "--dest", minilmDest], extra);
+}
+
+if (!snapshotReady()) {
+  let vendor = vendorMinilm("onnx");
+  if ((vendor.status ?? 1) !== 0 || !snapshotReady()) {
+    console.warn(
+      "MiniLM ONNX snapshot missing; exporting once with --extra ml (Sentence Transformers is build-time only).",
+    );
+    vendor = vendorMinilm("ml");
+  }
+  if ((vendor.status ?? 1) !== 0 || !snapshotReady()) {
+    console.error(
+      "app:dev needs a MiniLM ONNX graph at packages/vera-app/build/minilm/all-MiniLM-L6-v2/model.onnx.\n" +
+        "Export once, then retry:\n" +
+        "  uv run --extra ml python packages/vera-app/scripts/export_minilm_onnx.py --dest packages/vera-app/build/minilm-export/all-MiniLM-L6-v2\n" +
+        "  uv run --extra onnx python packages/vera-app/scripts/vendor_minilm.py --dest packages/vera-app/build/minilm/all-MiniLM-L6-v2",
+    );
+    process.exit(vendor.status ?? 1);
+  }
+}
 
 const result = spawnSync(
   "uv",

--- a/skills/vera/SKILL.md
+++ b/skills/vera/SKILL.md
@@ -148,7 +148,9 @@ commands write or replace local files and require normal user authorization:
   Extra ingest plugins are pip packages in the same environment
   (`python -m pip install` or `python -m pip install -e <clone>`). MiniLM
   convert/search needs `vera-doc[onnx]` (ONNX Runtime) and a VERA-exported
-  snapshot, or `vera-doc[ml]` for other Sentence Transformers models. The
+  snapshot. When the `onnx` extra is installed, MiniLM does not fall back to
+  Sentence Transformers. Use `vera-doc[ml]` for other Sentence Transformers
+  models (or for MiniLM only when the `onnx` extra is absent). The
   0.3.0 packaged desktop app converts with PyMuPDF only; Docling is the
   `vera-cli[docling]` extra, not Advanced layout in Convert.
 - `convert --overwrite` replaces existing batch outputs.

--- a/skills/vera/references/cli-reference.md
+++ b/skills/vera/references/cli-reference.md
@@ -34,10 +34,12 @@ Options:
   (`hashing`, `vera-hashing-384`, `all-MiniLM-L6-v2`,
   `sentence-transformers/...`). Unknown providers raise and the command
   exits non-zero instead of silently falling back to hashing. CLI and
-  source-run installs need the `onnx` extra for MiniLM (ONNX Runtime). Other
-  Sentence Transformers models need the `ml` extra. The Windows desktop
-  installer vendors a VERA-exported `all-MiniLM-L6-v2` ONNX graph. Archive
-  identity stays `sentence-transformers/all-MiniLM-L6-v2`.
+  source-run installs need the `onnx` extra for MiniLM (ONNX Runtime) plus a
+  MiniLM ONNX snapshot (`VERA_ONNX_MINILM_HOME` or the `app:dev` vendor path).
+  When the `onnx` extra is installed, MiniLM does not fall back to Sentence
+  Transformers. Other Sentence Transformers models need the `ml` extra. The
+  Windows desktop installer vendors a VERA-exported `all-MiniLM-L6-v2` ONNX
+  graph. Archive identity stays `sentence-transformers/all-MiniLM-L6-v2`.
 - `--parser PARSER` defaults to `pymupdf`. Accepts ingest pipeline specs
   `provider[:variant]` (requires `vera-ingest-pymupdf` for the default; for
   example `docling` or `docling:hybrid` when `vera-ingest-docling` is

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -363,6 +363,9 @@ def test_hardening_json_contracts_are_documented():
     assert "registers the default" in desktop_architecture and "pymupdf" in desktop_architecture
     app_dev = (ROOT / "scripts" / "app-dev.js").read_text(encoding="utf-8")
     assert "--extra" in app_dev and '"app"' in app_dev
+    assert '"onnx"' in app_dev
+    assert "vendor_minilm.py" in app_dev
+    assert "snapshotReady" in app_dev
     assert '"docling"' not in app_dev
     main_ts = (ROOT / "packages" / "vera-app" / "electron" / "main.ts").read_text(encoding="utf-8")
     assert "vera-ingest-pymupdf" in main_ts
@@ -741,6 +744,15 @@ def test_release_docs_match_packaged_sidecar_and_validate_behavior():
     assert "Open convert log" in app_pkg
     assert "Open convert log" in readme
     assert "logs/sidecar.log" in readme
+    assert "vendors MiniLM ONNX" in readme
+    assert "does not silently" in desktop
+    assert "does not fall back to Sentence Transformers" in (DOCS / "architecture.md").read_text(
+        encoding="utf-8"
+    )
+    assert "MiniLM runtime=onnx" in (
+        ROOT / "packages" / "vera-doc" / "src" / "vera_doc" / "embeddings.py"
+    ).read_text(encoding="utf-8")
+    assert "Loading weights" in troubleshooting
 
 
 def test_index_ask_and_embedder_operational_docs():
@@ -778,6 +790,7 @@ def test_index_ask_and_embedder_operational_docs():
     assert "quality" in desktop and "permissive" in desktop
     assert "provider_error_detail" in architecture
     assert "does not call `preflight_embedder`" in conversion
+    assert "does not fall back to Sentence Transformers" in conversion
     assert "does not call `preflight_embedder`" in architecture
     assert "single `.vera` archive" in evaluation
     assert "list_embedder_load_errors" in python_api


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `#48` wired MiniLM to ONNX Runtime, but `app:dev` still silently used Sentence Transformers when `packages/vera-app/build/minilm` had no `model.onnx`. That is the Hugging Face `Loading weights: 0/103` progress the desktop sidecar printed during Ask.
- `npm run app:dev` now vendors that ONNX graph before Electron starts (one-time export with `--extra ml` if needed).
- When the `onnx` extra is installed (`onnxruntime` + `tokenizers`), a missing MiniLM snapshot raises instead of falling back to Sentence Transformers. Docling's RapidOCR `onnxruntime` install alone does not trigger that error.
- Sidecar stderr logs `MiniLM runtime=onnx snapshot=...` or `MiniLM runtime=sentence-transformers`.

## Test plan

- [x] Relevant automated tests pass.
- [x] Retrieval baselines were checked when search behavior changed.

Local evidence:

- `uv run --extra dev python -m pytest -q` (full suite)
- `uv run mypy packages/vera-doc/src`
- `npm run app:typecheck`
- `npm --prefix packages/vera-app run test:unit` (192 tests)
- With `VERA_ONNX_MINILM_HOME=packages/vera-app/build/minilm`: `get_embedder("sentence-transformers:all-MiniLM-L6-v2")` returns `OnnxMiniLMEmbedder`, logs `MiniLM runtime=onnx`, does not import `torch` or `sentence_transformers`, and does not print `Loading weights`
- With an empty MiniLM home and the `onnx` extra installed: `UnknownEmbeddingModelError` (no Sentence Transformers load)

## Documentation

- [x] User-visible behavior is documented in the README or relevant `docs/` guide.
- [x] CLI/API/MCP references and examples reflect public contract changes.
- [x] `skills/vera/` reflects agent-facing behavior changes.
- [x] Documentation-contract tests were updated when commands, options, JSON, exit codes, links, or documented workflows changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de7cd64b-d4c9-4779-a7ef-be0c7f63f0f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de7cd64b-d4c9-4779-a7ef-be0c7f63f0f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

