### PR TITLE
Add official OpenAI embeddings plugin

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,6 +22,7 @@ jobs:
           - package: vera-ingest
           - package: vera-ingest-pymupdf
           - package: vera-ingest-docling
+          - package: vera-embed-openai
           - package: vera-mcp
           - package: vera-cli
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,9 @@ vera convert manual.pdf manual.vera --json
 vera convert scan.pdf scan.vera --parser docling --json
 vera convert scan.pdf scan.vera --parser docling --pipeline-option pdf_backend=pypdfium2 --json
 
-# Provider-owned embedder options (hashing dimension, future hosted providers)
+# Provider-owned embedder options (hashing dimension; OpenAI batch_size)
 vera convert manual.pdf --model hashing --embedder-option dimension=256 --json
+vera convert manual.pdf --model openai:text-embedding-3-small --json
 
 # Batch-convert a nested PDF library beside its source files
 vera convert ./proposals --recursive --json
@@ -209,7 +210,11 @@ non-obvious caveats for this environment; standard commands live in the sections
   (OpenAI/OpenRouter/Ollama/LM Studio) — there is no offline/extractive answer mode, so Ask is
   blocked without a provider/API key. For fully offline testing use the left-sidebar **Search**
   view (pure hybrid/semantic/keyword retrieval with grounded citations and highlights) or the
-  **Convert PDF** view. Convert lists PyMuPDF only. Docling is a CLI extra
+  **Convert PDF** view. Convert lists PyMuPDF only. OpenAI embeddings are
+  bundled (`openai:text-embedding-3-small` / `-large`); hashing remains the
+  default. Save `OPENAI_API_KEY` under **File > Settings → Embeddings** (or
+  export it for CLI convert). Archives converted with OpenAI are not portable
+  for semantic search. Docling is a CLI extra
   (`uv sync --extra docling`; `vera convert --parser docling`), not a desktop
   pipeline in 0.3.0. The packaged
   Windows sidecar freezes ONNX Runtime and vendors a VERA-exported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
 
 ## [Unreleased]
 
+### Added
+
+- Official `vera-embed-openai` plugin: stdlib HTTPS client for
+  `text-embedding-3-small`, `text-embedding-3-large`, and
+  `text-embedding-ada-002`. `vera-cli` and `vera-app` depend on it the same
+  way they depend on PyMuPDF; the frozen sidecar registers it via
+  `ensure_registered()`. See [docs/packages/vera-embed-openai.md](docs/packages/vera-embed-openai.md).
+- Desktop **Settings → Embeddings** stores `OPENAI_API_KEY` through the
+  existing encrypted env-secret IPC. Convert presets include the two
+  `text-embedding-3-*` models; hashing remains the default.
+- Archives converted with a hosted embedder are not portable for semantic
+  search: the recipient needs their own `OPENAI_API_KEY`. Keyword search
+  still works.
+
 ### Changed
 
 - Packaged MiniLM uses ONNX Runtime instead of PyTorch / Sentence Transformers.
@@ -66,8 +80,8 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
   plugins page and no `vera_plugin_host`. Convert drives `EmbedderConfigForm`
   from descriptors, persists `embedder_configs`, and gates conversion on
   `preflight_embedder`. Search reports `skipped_semantic_model_groups` when a
-  query embedder is unavailable. Hosted embedding providers (OpenAI, Voyage,
-  Ollama) follow in 0.3.1.
+  query embedder is unavailable. Hosted embedding providers were not part of
+  0.3.0; OpenAI now ships as `vera-embed-openai` (see Unreleased).
 - Desktop convert timing log: sidecar stderr (including `elapsed_ms` convert
   steps) is teed to `userData/logs/sidecar.log` in both `app:dev`
   and packaged VERA. **File > Open convert log...**, Convert **Open log**, and
@@ -192,5 +206,5 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
 - Clamp chunk overlap below `chunk_size` so carry never overruns.
 - Consume the skip flag; do not leak it into pipeline options.
 
-Hosted embedding providers (OpenAI, Voyage, Ollama) follow in 0.3.1. See
-[ROADMAP.md](ROADMAP.md).
+Voyage and Ollama embeddings remain pending (they need a query-versus-document
+hint). OpenAI ships as `vera-embed-openai`. See [ROADMAP.md](ROADMAP.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ point inward at the storage engine:
 ```text
 vera-ingest-pymupdf ─┐
 vera-ingest-docling ─┤
+vera-embed-openai ───┤
 vera-ingest ─────────┼──> vera-doc
 vera-cli ────────────┤
 vera-app ────────────┤
@@ -94,6 +95,7 @@ vera-lab (dev only) ─┘
 - Ingest core: `packages/vera-ingest/src/vera_ingest`
 - Default PDF pipeline: `packages/vera-ingest-pymupdf/src/vera_ingest_pymupdf`
 - Optional Docling pipeline: `packages/vera-ingest-docling/src/vera_ingest_docling`
+- Official OpenAI embedder: `packages/vera-embed-openai/src/vera_embed_openai`
 - MCP: `packages/vera-mcp/src/vera_mcp`
 - CLI: `packages/vera-cli/src/vera_cli`
 - Ingest layout lab (dev): `packages/vera-lab/src/vera_lab`

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ registry pattern:
 ```bash
 vera convert manual.pdf --model hashing                                     # default: offline, deterministic
 vera convert manual.pdf --model sentence-transformers:all-MiniLM-L6-v2     # local neural model
+vera convert manual.pdf --model openai:text-embedding-3-small              # bundled hosted API; set OPENAI_API_KEY
 vera convert manual.pdf --model hashing --embedder-option dimension=256    # provider-owned options
 ```
 
@@ -344,7 +345,11 @@ dependencies or network access) and `sentence-transformers` (MiniLM via the
 `onnx` extra / ONNX Runtime in the Windows installer; other Hub models via
 the `ml` extra). The installer vendors a VERA-exported `all-MiniLM-L6-v2`
 graph; archive identity stays `sentence-transformers/all-MiniLM-L6-v2`.
-Third-party providers register through the
+OpenAI embeddings ship as the official `vera-embed-openai` plugin (bundled
+with `vera-cli` and the desktop sidecar). Archives converted with it are
+**not portable for semantic search** — the recipient needs their own
+`OPENAI_API_KEY`. Voyage and Ollama are not bundled. Third-party providers
+register through the
 `vera.embedders` entry-point group or `register_embedder()`, and can advertise
 option schemas, model presets, and required credential environment variables
 so hosts can preflight them without storing secrets in configuration. Unknown
@@ -361,6 +366,7 @@ dependencies pointing at the storage engine:
 ```text
 vera-ingest-pymupdf ──> vera-ingest ─┐
 vera-ingest-docling ──> vera-ingest ─┤
+vera-embed-openai ───────────────────┤
 vera-cli ────────────────────────────┼──> vera-doc
 vera-app ────────────────────────────┤
 vera-mcp ────────────────────────────┘
@@ -372,6 +378,7 @@ vera-mcp ───────────────────────�
 | [`vera-ingest`](https://pypi.org/project/vera-ingest/) | `import vera_ingest` | Provider-neutral conversion: the pipeline registry, shared block/chunk types, chunking helpers, atomic archive writing, and viewer helpers for pages, figures, and regions |
 | [`vera-ingest-pymupdf`](https://pypi.org/project/vera-ingest-pymupdf/) | plugin | Default PDF pipeline: PyMuPDF/pdfplumber parsing, table extraction, selective OCR |
 | [`vera-ingest-docling`](https://pypi.org/project/vera-ingest-docling/) | plugin | Optional Docling pipeline with layout models and hybrid chunking |
+| [`vera-embed-openai`](https://pypi.org/project/vera-embed-openai/) | plugin | Official OpenAI embeddings (stdlib HTTPS; bundled with CLI and desktop) |
 | [`vera-cli`](https://pypi.org/project/vera-cli/) | `vera` | The command line: argument parsing, text/JSON output contracts, exit codes, and retrieval evaluation |
 | [`vera-mcp`](https://pypi.org/project/vera-mcp/) | `vera mcp` | Thin MCP adapter exposing search, inspection, figures, pages, and regions as agent tools |
 | `vera-app` | — | Electron/React desktop application with a Python sidecar, built on the same packages |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,7 +51,8 @@ current on-disk format. Do not expect further 0.2.x package releases from
 - [x] Persist the selected conversion embedding model.
 - [x] Use the selected model for single-file and batch conversion.
 - [x] Show installed embedding providers as model-spec suggestions.
-- [x] Offer Convert-view presets for hashing and Sentence Transformers MiniLM.
+- [x] Offer Convert-view presets for hashing, Sentence Transformers MiniLM,
+      and OpenAI `text-embedding-3-*`.
 - [x] Advertise provider-owned options through `EmbedderOptions` dataclass
   metadata and `vera.embedder_descriptors` (parallel to ingest pipelines).
 - [x] Accept `embedder_options` / `--embedder-option KEY=VALUE` and expose
@@ -66,24 +67,34 @@ current on-disk format. Do not expect further 0.2.x package releases from
   (`list_embedding_models`).
 - [x] Drive Convert UI embedding forms from descriptors
   (`EmbedderConfigForm` over `PipelineConfigForm`).
-- [ ] Store hosted embedding-provider credentials securely in the desktop
-  app (`credential_env` via encrypted env secrets) — 0.3.1.
+- [x] Store hosted embedding-provider credentials securely in the desktop
+      app (`credential_env` via encrypted env secrets). Settings → Embeddings
+      stores `OPENAI_API_KEY`.
 
 ### Official embedding providers
 
-Hosted providers below are follow-ups after 0.3.0 (0.3.1 or later), not
-0.3.0 blockers. The descriptor/`credential_env` pattern they will use is
-already in 0.3.0.
+OpenAI ships as the official `vera-embed-openai` plugin (stdlib HTTP, frozen
+into the Windows sidecar). Voyage and Ollama wait on an optional
+query-versus-document hint on `EmbeddingFunction`: convert and search share
+one `embed(texts)` today, and those providers need `input_type` or
+`search_document:` / `search_query:` prefixes.
 
-- [ ] Add a lightweight OpenAI-compatible embeddings provider.
+- [x] Add a lightweight OpenAI embeddings provider (`vera-embed-openai`).
 - [ ] Add Voyage AI embeddings for applications that use Claude for answers.
-- [ ] Add an Ollama embeddings provider for local models.
+      Blocked until `EmbeddingFunction` can hint query vs document.
+- [ ] Add an Ollama embeddings provider for local models. Same protocol
+      prerequisite as Voyage. A generic `openai-compatible` provider with a
+      required explicit endpoint is cleaner than overloading `OPENAI_BASE_URL`.
 - [x] Define supported configuration for endpoints, timeouts, and batch sizes
   via provider `Options` + descriptors (built-ins advertise dimension /
   device / batch_size; hosted plugins follow the same pattern; secrets use
   `credential_env`).
 - [x] Document which providers are bundled with each desktop release
-  (hashing + MiniLM in the Windows sidecar; hosted embedders in 0.3.1).
+      (hashing + MiniLM + OpenAI in the Windows sidecar).
+- [ ] Cancellation and progress during embed. Convert currently passes every
+      chunk to `embedder.embed(...)` in one call; Cancel is ignored until that
+      returns, and there is no per-batch progress. A protocol hook is a
+      follow-up, not a plugin-local fix.
 
 ### Packaging and local models
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@ inward toward the storage and search engine:
 ```text
 vera-ingest-pymupdf ─┐
 vera-ingest-docling ─┤
+vera-embed-openai ───┤
 vera-ingest ─────────┼──> vera-doc
 vera-cli ────────────┤
 vera-app ────────────┤
@@ -78,6 +79,14 @@ and do not change the 0.2 archive schema.
 ingest plugins are ordinary pip packages in the same environment. See
 [vera-ingest-docling](packages/vera-ingest-docling.md).
 
+### `vera-embed-openai`
+
+`vera-embed-openai` is the official OpenAI embeddings plugin. It registers
+`openai` under `vera.embedders` with stdlib `urllib` (no OpenAI SDK).
+`vera-cli` and `vera-app` depend on it, and the packaged sidecar freezes it
+beside PyMuPDF. Secrets stay in `OPENAI_API_KEY`. See
+[vera-embed-openai](packages/vera-embed-openai.md).
+
 ### `vera-cli`
 
 `vera-cli` publishes the `vera` console script and `vera_cli` module. It owns
@@ -94,10 +103,10 @@ helpers. The optional `vera-cli[mcp]` extra installs it for `vera mcp`.
 
 `vera-app` owns the Electron/React desktop application, Python sidecar, LLM
 providers, sessions, and application state. It depends on `vera-doc`,
-`vera-ingest`, and `vera-ingest-pymupdf`
+`vera-ingest`, `vera-ingest-pymupdf`, and `vera-embed-openai`
 (including
 viewer helpers), not on `vera-cli`. Packaged conversions keep one frozen
-sidecar for search, Ask, and PyMuPDF. MiniLM (`all-MiniLM-L6-v2`) runs on
+sidecar for search, Ask, PyMuPDF, and OpenAI embeddings. MiniLM (`all-MiniLM-L6-v2`) runs on
 ONNX Runtime; `npm run app:dev` vendors that graph before launch. When the
 `onnx` extra is installed, a missing MiniLM snapshot does not fall back to Sentence Transformers.
 Extra ingest and embedding plugins are pip packages in that same environment.
@@ -187,6 +196,10 @@ packages/
       recovery.py
       pipeline.py
       options.py
+  vera-embed-openai/
+    src/vera_embed_openai/
+      options.py
+      provider.py
   vera-cli/
     src/vera_cli/
       commands.py

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -31,11 +31,14 @@ Convert one PDF or a directory of PDFs.
 Options:
 
 - `--model MODEL` (`hashing`; accepts `provider:model-id` specs such as
-  `sentence-transformers:all-MiniLM-L6-v2`; unknown providers exit with an
+  `sentence-transformers:all-MiniLM-L6-v2` or `openai:text-embedding-3-small`;
+  unknown providers exit with an
   error; MiniLM needs the `onnx` extra and an ONNX snapshot, other Sentence
   Transformers models need the `ml` extra, and the Windows installer vendors a
   VERA-exported MiniLM graph. When the `onnx` extra is installed, MiniLM does
-  not fall back to Sentence Transformers)
+  not fall back to Sentence Transformers. OpenAI embeddings ship with
+  `vera-cli` as `vera-embed-openai`; set `OPENAI_API_KEY`. Archives converted
+  with OpenAI are not portable for semantic search)
 - `--parser PARSER` (`pymupdf`; accepts `provider[:variant]` specs such as
   `docling` / `docling:hybrid` when `vera-cli[docling]` is installed; unknown
   providers exit with an error; the 0.3.0 Windows installer does not include

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -67,6 +67,7 @@ rebuildable; the `.vera` files remain the source of truth.
 vera-doc              Storage, search, corpus, library indexes
 vera-ingest           Registry, convert orchestration, shared types
 vera-ingest-pymupdf   Default PDF parsing / OCR pipeline
+vera-embed-openai     Official OpenAI embeddings plugin
 vera-cli              Command-line interface (vera convert, search, index, …)
 vera-mcp              Model Context Protocol server for AI agents
 vera-app              Desktop app Python sidecar (Electron)

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -207,10 +207,11 @@ the factory runs. Convert-time knobs such
 as `batch_size` use `scope: convert` so search can resolve
 `get_embedder(stored_model_name)` with defaults.
 
-### Hosted provider plugins
+### Official OpenAI embeddings
 
-VERA does not bundle hosted embedding providers. Install a plugin that
-registers the desired provider, then use its `provider:model-id` spec:
+`vera-cli` and the desktop app bundle [`vera-embed-openai`](packages/vera-embed-openai.md).
+Hashing remains the default. Set `OPENAI_API_KEY` (desktop: **File > Settings
+→ Embeddings**):
 
 ```bash
 set OPENAI_API_KEY=...
@@ -218,13 +219,31 @@ vera convert "input.pdf" --model openai:text-embedding-3-small \
   --embedder-option batch_size=64
 ```
 
-The plugin's embedder must record the full spec (for example,
+The plugin records the full spec (for example
 `openai:text-embedding-3-small`) as `model_name`, so later semantic searches
-load the matching provider. See
+load the matching provider.
+
+**Archives converted with a hosted embedder are not portable for semantic or
+hybrid search.** Search resolves `get_embedder(stored_model_name)`, so a
+recipient needs their own `OPENAI_API_KEY` and a reachable API. Keyword search
+still works. Corpus search reports `skipped_semantic_model_groups` when the
+query embedder cannot load.
+
+OpenAI conversion bills per request. Desktop Convert Cancel does not interrupt
+an in-flight embeddings HTTP batch; conversion checks cancellation after
+`embed()` returns.
+
+Optional `OPENAI_BASE_URL` (default `https://api.openai.com/v1`) points at
+Azure, OpenRouter, or a local OpenAI-compatible server. Two archives can then
+record the same `openai:<model-id>` while holding vectors from different
+models; search cannot detect that. A separate `openai-compatible` provider
+with a required explicit endpoint is out of scope.
+
+Voyage and Ollama are not bundled. They need a query-versus-document hint on
+`EmbeddingFunction` (`input_type` / `search_document:` prefixes); convert and
+search share one `embed(texts)` today. See
 [Creating an embedding provider plugin](creating-an-embedding-provider.md)
-for the Options + descriptor authoring model and the
-[OpenAI plugin example](https://github.com/dkylewillis/vera/blob/main/packages/vera-doc/README.md#openai-embedding-plugin-example)
-for a complete entry-point sketch.
+for the Options + descriptor authoring model.
 
 Claude is an LLM rather than an embedding provider: Anthropic's Claude API has
 no embeddings endpoint. A Claude application can use a separate provider such
@@ -321,14 +340,16 @@ vera convert "input.pdf" --parser docling:hybrid
 
 Unknown pipeline names fail before parsing with an install-the-plugin message;
 VERA never silently falls back to PyMuPDF. The packaged desktop app bundles
-PyMuPDF and Docling in one sidecar. Extra pip plugins install into the same
-environment (`python -m pip install` or `python -m pip install -e <clone>`).
+PyMuPDF and OpenAI embeddings in one sidecar; Docling is a CLI extra. Extra
+pip plugins install into the same environment (`python -m pip install` or
+`python -m pip install -e <clone>`).
 The desktop Convert view persists `embedder_options` / `embedder_configs` and
 gates conversion on `preflight_embedder` so an archive is never written with a
 model Search cannot resolve. CLI convert still rejects unknown `--model` /
 `--parser` values before parsing, but it does not call `preflight_embedder`.
 Embedder `credential_env` secrets stay in the environment, not
-Options. Hosted embedding providers follow in 0.3.1.
+Options. OpenAI embeddings ship as `vera-embed-openai`; Voyage and Ollama
+do not.
 On Docling memory errors
 (`bad_alloc`), VERA retries failed pages with a fresh converter and falls back
 to the `pypdfium2` PDF backend when needed (whole document, then page batches

--- a/docs/creating-an-embedding-provider.md
+++ b/docs/creating-an-embedding-provider.md
@@ -7,9 +7,10 @@ special-cases a hosted OpenAI or Voyage package. Write your own to add a new
 API, a local runtime, or an experimental embedder.
 
 Registry and descriptor APIs (`register_embedder`, descriptor/model listing
-helpers) are experimental and may change before 1.0. Hosted providers
-(OpenAI, Voyage, Ollama) are examples you can implement yourself; they are
-not bundled with VERA.
+helpers) are experimental and may change before 1.0. The official OpenAI
+plugin is [`vera-embed-openai`](packages/vera-embed-openai.md), bundled with
+`vera-cli` and the desktop sidecar. Voyage and Ollama are not bundled with
+VERA; they need a query-versus-document hint on `EmbeddingFunction` first.
 
 This guide mirrors [Creating an ingest pipeline plugin](creating-an-ingest-pipeline.md):
 a plain factory, one Options dataclass whose field `metadata` drives both
@@ -49,14 +50,21 @@ Archives store `model_name`, dimension, and normalization — not your
   encode them in `model_name` (hashing does this as `vera-hashing-<N>`).
 - **Do not put API keys in Options.** Advertise
   `capabilities.credential_env` (for example `OPENAI_API_KEY`) and read the
-  environment inside the factory. The desktop app will store secrets
-  separately; Options fields must stay non-secret.
+  environment inside the factory. The desktop app stores those secrets under
+  **File > Settings → Embeddings**; Options fields must stay non-secret.
 
 Use `preflight_embedder("openai:text-embedding-3-small")` to check that a
 required credential env var is present without loading model weights. Desktop
 Convert calls this automatically; CLI `vera convert` and `vera_ingest.convert()`
-do not. Official hosted embedding packages (OpenAI, Voyage, Ollama) and their
-Settings UI are 0.3.1 follow-ups. Options fields must stay non-secret.
+do not. Options fields must stay non-secret.
+
+**Do not call the network from `__init__`.** `VeraDocument.open(..., mode="write")`
+resolves `get_embedder(stored_model_name)` only to validate dimension, and
+`preflight_embedder` is deliberately network-free. A constructor that embeds a
+dummy string on every write-mode open bills an API call and can fail offline.
+Ship a static dimension table for known ids and probe unrecognized ids lazily
+(on first `embed()` or a `dimension` property). The official OpenAI package
+does both.
 
 If a `vera.embedders` entry point fails to import, the provider is absent from
 `list_embedding_providers()`. Inspect `vera_doc.embeddings.list_embedder_load_errors()`
@@ -72,21 +80,42 @@ not fall back to Sentence Transformers. The Windows installer freezes ONNX
 Runtime and vendors a VERA-exported `all-MiniLM-L6-v2` graph. Archive identity
 stays `sentence-transformers/all-MiniLM-L6-v2`.
 
+## Official OpenAI package
+
+Use [`vera-embed-openai`](packages/vera-embed-openai.md) as the reference
+implementation for a hosted API: stdlib `urllib` (no SDK), `credential_env =
+"OPENAI_API_KEY"`, convert-time `batch_size` / `timeout`, token-aware request
+splitting, L2 normalization, and a constructor that never touches the network.
+`vera-cli` and `vera-app` depend on it; the frozen sidecar calls
+`ensure_registered()`.
+
+```bash
+set OPENAI_API_KEY=...
+vera convert manual.pdf --model openai:text-embedding-3-small \
+  --embedder-option batch_size=64
+```
+
+Archives converted with it are **not portable for semantic or hybrid search**:
+a recipient needs their own `OPENAI_API_KEY`. Keyword search still works.
+
 ## Minimal example (DIY hosted provider)
 
-The OpenAI sketch below is an example you can implement yourself. OpenAI,
-Voyage, and Ollama are not bundled with VERA.
+The sketch below is a third-party pattern. Copy
+[`packages/vera-embed-openai`](https://github.com/dkylewillis/vera/tree/main/packages/vera-embed-openai)
+when you want the official OpenAI client; use this skeleton for another API.
+Voyage and Ollama are not bundled with VERA.
 
 ```text
-vera-openai-embeddings/
+vera-myhost-embeddings/
   pyproject.toml
-  src/vera_openai_embeddings/
+  src/vera_myhost_embeddings/
     __init__.py
     options.py
     provider.py
 ```
 
-`provider.py`:
+`provider.py` — factory reads the env secret; the constructor does **not**
+probe dimension over the network:
 
 ```python
 from __future__ import annotations
@@ -94,40 +123,33 @@ from __future__ import annotations
 import os
 
 import numpy as np
-from openai import OpenAI
 
-from .options import OpenAIOptions
+from .options import KNOWN_DIMENSIONS, MyHostOptions
 
 
-class OpenAIEmbedder:
+class MyHostEmbedder:
     normalization = "l2"
 
     def __init__(self, model_id: str, *, batch_size: int):
-        self.model_name = f"openai:{model_id}"
-        self._client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+        self.model_name = f"myhost:{model_id}"
+        self._api_key = os.environ["MYHOST_API_KEY"]
         self._model = model_id
         self._batch_size = batch_size
-        self.dimension = len(self.embed(["dimension probe"])[0])
+        self.dimension = KNOWN_DIMENSIONS[model_id]
 
     def embed(self, texts: list[str]) -> list[np.ndarray]:
         vectors = []
         for start in range(0, len(texts), self._batch_size):
-            response = self._client.embeddings.create(
-                model=self._model,
-                input=texts[start : start + self._batch_size],
-            )
-            vectors.extend(item.embedding for item in response.data)
-        normalized = []
-        for vector in vectors:
-            array = np.asarray(vector, dtype=np.float32)
-            norm = np.linalg.norm(array)
-            normalized.append(array / norm if norm else array)
-        return normalized
+            vectors.extend(self._embed_batch(texts[start : start + self._batch_size]))
+        return vectors
+
+    def _embed_batch(self, texts: list[str]) -> list[np.ndarray]:
+        raise NotImplementedError("POST the provider embeddings API here")
 
 
 def create_embedder(model_id: str, **config):
-    options = OpenAIOptions.from_mapping(config)
-    return OpenAIEmbedder(model_id, batch_size=options.batch_size)
+    options = MyHostOptions.from_mapping(config)
+    return MyHostEmbedder(model_id, batch_size=options.batch_size)
 ```
 
 `options.py` validates convert-time knobs and describes them for CLI/GUI
@@ -146,14 +168,16 @@ from vera_doc import (
 )
 from vera_doc.embedder_descriptors import fields_from_dataclass
 
+KNOWN_DIMENSIONS = {"alpha-small": 1536}
+
 
 @dataclass(frozen=True)
-class OpenAIOptions(EmbedderOptions):
+class MyHostOptions(EmbedderOptions):
     batch_size: int = field(
         default=128,
         metadata={
             "label": "Batch size",
-            "description": "Texts embedded per OpenAI request (convert-time).",
+            "description": "Texts embedded per request (convert-time).",
             "minimum": 1,
             "maximum": 2048,
             "scope": "convert",
@@ -163,37 +187,29 @@ class OpenAIOptions(EmbedderOptions):
 
 def describe_provider() -> EmbedderDescriptor:
     return EmbedderDescriptor(
-        provider="openai",
-        label="openai — hosted embeddings",
-        description="OpenAI embeddings API (text-embedding-3-* and similar).",
-        default_model_id="text-embedding-3-small",
-        example_specs=(
-            "openai:text-embedding-3-small",
-            "openai:text-embedding-3-large",
-        ),
+        provider="myhost",
+        label="myhost — hosted embeddings",
+        description="Example hosted embeddings API.",
+        default_model_id="alpha-small",
+        example_specs=("myhost:alpha-small",),
         capabilities=EmbedderCapabilities(
             requires_network=True,
             requires_api_key=True,
-            credential_env="OPENAI_API_KEY",
+            credential_env="MYHOST_API_KEY",
             local_model=False,
             configurable_dimension=False,
             supports_model_listing=True,
         ),
-        fields=fields_from_dataclass(OpenAIOptions),
+        fields=fields_from_dataclass(MyHostOptions),
     )
 
 
 def list_models() -> tuple[EmbeddingModelInfo, ...]:
     return (
         EmbeddingModelInfo(
-            model_id="text-embedding-3-small",
-            label="text-embedding-3-small",
-            spec="openai:text-embedding-3-small",
-        ),
-        EmbeddingModelInfo(
-            model_id="text-embedding-3-large",
-            label="text-embedding-3-large",
-            spec="openai:text-embedding-3-large",
+            model_id="alpha-small",
+            label="alpha-small",
+            spec="myhost:alpha-small",
         ),
     )
 ```
@@ -220,13 +236,13 @@ def create_descriptor():
 
 ```toml
 [project.entry-points."vera.embedders"]
-openai = "vera_openai_embeddings:create_embedder"
+myhost = "vera_myhost_embeddings:create_embedder"
 
 [project.entry-points."vera.embedder_descriptors"]
-openai = "vera_openai_embeddings:create_descriptor"
+myhost = "vera_myhost_embeddings:create_descriptor"
 
 [project.entry-points."vera.embedder_models"]
-openai = "vera_openai_embeddings:list_models"
+myhost = "vera_myhost_embeddings:list_models"
 ```
 
 After `pip install`, resolve and convert:
@@ -294,8 +310,8 @@ cross-field checks, or normalizing values. Use
 - Built-in hashing and Sentence Transformers providers in
   `packages/vera-doc/src/vera_doc/embeddings.py` — Options + descriptors +
   model lists live beside the factories.
-- This guide's OpenAI sketch — hosted API with env credentials and
-  convert-time `batch_size`.
+- Official OpenAI plugin in `packages/vera-embed-openai` — stdlib HTTPS,
+  static dimensions, token-aware batching, no network in the constructor.
 
 See also [Convert documents](conversion.md#embedding-models) and the
 [vera-doc package overview](packages/vera-doc.md).

--- a/docs/desktop-app-architecture.md
+++ b/docs/desktop-app-architecture.md
@@ -27,6 +27,7 @@ packages/
   vera-ingest/            # conversion registry and archive writer
   vera-ingest-pymupdf/    # default PDF pipeline
   vera-ingest-docling/    # optional CLI Docling pipeline
+  vera-embed-openai/      # official OpenAI embeddings plugin
   vera-cli/               # terminal interface
   vera-app/               # Electron desktop app plus Python sidecar
 ```
@@ -34,7 +35,9 @@ packages/
 Dependency direction stays one-way:
 
 ```text
+vera-cli -> vera-embed-openai -> vera-doc
 vera-cli -> vera-ingest-pymupdf -> vera-ingest -> vera-doc
+vera-app -> vera-embed-openai -> vera-doc
 vera-app -> vera-ingest-pymupdf -> vera-ingest -> vera-doc
 ```
 
@@ -106,10 +109,12 @@ flowchart LR
   sidecar --> pymupdf
   sidecar --> hashing
   sidecar --> minilm["MiniLM"]
+  sidecar --> openai["OpenAI"]
 ```
 
-The sidecar registers the default `pymupdf` pipeline. Packaged Windows builds
-freeze PyMuPDF, `onnxruntime`, and `tokenizers` into one sidecar, and vendor a
+The sidecar registers the default `pymupdf` pipeline and the bundled `openai`
+embedder. Packaged Windows builds
+freeze PyMuPDF, `onnxruntime`, `tokenizers`, and `vera-embed-openai` into one sidecar, and vendor a
 VERA-exported `all-MiniLM-L6-v2` ONNX graph in the installer. Archive identity
 stays `sentence-transformers/all-MiniLM-L6-v2`. Hugging Face tokens,
 packaged `HF_HOME` (a writable cache under `userData` unless already set),
@@ -126,8 +131,9 @@ into `userData/logs/sidecar.log`, rotated to
 `sidecar.log.1` at about 2 MB. **File > Open convert log...**, Convert
 **Open log**, and **Settings → Diagnostics** open that file. Search
 reports `skipped_semantic_model_groups` when a query embedder is unavailable.
-`list_embedding_models` and `credential_env` remain part of the descriptor
-contract so hosted providers can land in 0.3.1 without a protocol change.
+`list_embedding_models` and `credential_env` drive Convert presets and
+**File > Settings → Embeddings**. OpenAI is bundled; Voyage and Ollama still
+need a query-versus-document hint on `EmbeddingFunction` before they can ship.
 
 ## Active Libraries and Collection Indexes
 
@@ -356,12 +362,13 @@ PyInstaller with the project virtualenv when it is available (honoring
 English data is passed as an absolute path so the build works from any
 directory. PyInstaller `--exclude-module` drops `torch` and
 `sentence_transformers` so a freeze venv that also has the `ml` extra still
-ships ONNX MiniLM only. The build copies `vera-ingest-pymupdf`
-package metadata and the sidecar registers the default
-`pymupdf` pipeline on import so Convert works in frozen builds
-where `importlib.metadata` entry points are otherwise empty. After a freeze,
-`node packages/vera-app/scripts/verify-packaged-sidecar.cjs` asserts
-`describe_ingest_pipelines` reports `pymupdf` (and not Docling), that MiniLM
+ships ONNX MiniLM only. The build copies `vera-ingest-pymupdf` and
+`vera-embed-openai` package metadata. The sidecar registers the default
+`pymupdf` pipeline and the `openai` embedder on import so Convert works in
+frozen builds where `importlib.metadata` entry points are otherwise empty.
+After a freeze, `node packages/vera-app/scripts/verify-packaged-sidecar.cjs`
+asserts `describe_ingest_pipelines` reports `pymupdf` (and not Docling), that
+`describe_embedding_providers` includes `openai`, that MiniLM
 weights are present, and that Torch is absent.
 
 From the repo root:
@@ -416,5 +423,6 @@ export controls alongside the PDF.
 
 ## Near-Term App Work
 
-- Hosted embedding providers (OpenAI, Voyage, Ollama) and their credentials UI.
+- Voyage and Ollama embeddings after an optional query/document hint on
+  `EmbeddingFunction`.
 - Add recent document shortcuts.

--- a/docs/desktop-app-getting-started.md
+++ b/docs/desktop-app-getting-started.md
@@ -55,7 +55,8 @@ native File menu to open an existing archive or document library.
 Desktop conversions default to the PyMuPDF ingest pipeline and the
 offline `hashing` embedder. The Convert view exposes dropdowns for
 `ingest_pipeline` (PyMuPDF in 0.3.0) and
-embedding model presets such as `sentence-transformers:all-MiniLM-L6-v2`, plus
+embedding model presets such as `sentence-transformers:all-MiniLM-L6-v2` and
+`openai:text-embedding-3-small`, plus
 a custom `provider:model-id` field. Chunking and OCR controls are schema-driven:
 the sidecar `describe_ingest_pipelines` action supplies descriptors, and
 `PipelineConfigForm` renders only advertised fields under a collapsed
@@ -65,7 +66,8 @@ for combinations such as `eng+spa`). These settings are independent of the Chat
 model and are persisted in app settings. `npm run app:dev` installs the `app`
 extra into the workspace environment. The source-run
 sidecar matches packaged releases: one Python process with PyMuPDF,
-hashing, and ONNX MiniLM. Plugins are ordinary pip packages in **the same environment**
+hashing, ONNX MiniLM, and OpenAI embeddings. Save `OPENAI_API_KEY` under
+**File > Settings → Embeddings**. Plugins are ordinary pip packages in **the same environment**
 (`vera.ingest_pipelines` / `vera.embedders`); CLI users can
 `pip install "vera-cli[docling]>=0.3.0"` or `pip install -e <clone>` after
 `vera-ingest` 0.3.x. An unavailable selection is disabled or fails with the
@@ -232,14 +234,14 @@ Search, Ask, indexing, and PyMuPDF conversion all run in
 the sidecar. Extra converters are pip packages in that environment, not a
 second interpreter. The 0.3.0 sidecar does not run Docling conversion.
 
-The packaged Windows installer freezes PyMuPDF, hashing, and ONNX Runtime
-into `vera-sidecar.exe`. MiniLM
+The packaged Windows installer freezes PyMuPDF, hashing, ONNX Runtime, and
+`vera-embed-openai` into `vera-sidecar.exe`. MiniLM
 (`all-MiniLM-L6-v2`) ONNX weights ship inside Setup.exe, so **Local semantic
 (MiniLM)** does not download those files on
 first use. Docling / **Advanced layout (slower)** is not part of the 0.3.0
-desktop app; install `vera-cli[docling]` and convert from the CLI. Hosted
-embedding providers
-(OpenAI, Voyage, Ollama) are a 0.3.1 follow-up.
+desktop app; install `vera-cli[docling]` and convert from the CLI. OpenAI
+embeddings are bundled; save `OPENAI_API_KEY` under **File > Settings →
+Embeddings**. Voyage and Ollama are not bundled.
 
 CLI users who want Docling install it into the VERA environment:
 
@@ -301,7 +303,8 @@ Convert and embed always run in-process in the sidecar; see
   `python -m pip install -e <clone>`), then restart the app. Raw `PYTHONPATH`
   folders are not discovered. If Search warns that semantic groups were
   skipped, the embedder used at convert time is not available in this
-  sidecar. Hosted embedders are not included until 0.3.1.
+  sidecar. OpenAI embeddings are bundled (`OPENAI_API_KEY` under **File >
+  Settings → Embeddings**); Voyage and Ollama are not.
 
 ## Provider request errors
 

--- a/docs/desktop-app-overview.md
+++ b/docs/desktop-app-overview.md
@@ -115,7 +115,8 @@ This lets the app deliver faster, more consistent, and more explainable answers 
 Libraries (folder-scoped Search/Ask with persistent collection indexes) and
 LLM Ask are already shipped. Remaining product follow-ups:
 
-- Hosted embedding providers (OpenAI, Voyage, Ollama) in 0.3.1
+- Voyage and Ollama embeddings after an optional query/document hint on
+  `EmbeddingFunction`. OpenAI already ships as `vera-embed-openai`.
 - Advanced reranking and confidence scoring
 - Evaluation dashboard for groundedness and retrieval quality
 - Role-based governance and audit trails

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,8 @@ Install the CLI and its dependencies:
 python -m pip install "vera-cli>=0.3.0"
 ```
 
-That installs `vera-doc`, `vera-ingest`, and `vera-ingest-pymupdf` as well.
+That installs `vera-doc`, `vera-ingest`, `vera-ingest-pymupdf`, and
+`vera-embed-openai` as well.
 Add MCP support with:
 
 ```bash
@@ -61,7 +62,7 @@ Contributors can clone the repository and install workspace packages:
 ```bash
 git clone https://github.com/dkylewillis/vera.git
 cd vera
-python -m pip install ./packages/vera-doc ./packages/vera-ingest ./packages/vera-ingest-pymupdf ./packages/vera-cli
+python -m pip install ./packages/vera-doc ./packages/vera-ingest ./packages/vera-ingest-pymupdf ./packages/vera-embed-openai ./packages/vera-cli
 ```
 
 Or with `uv`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,8 @@ Install the CLI from PyPI:
 python -m pip install "vera-cli>=0.3.0"
 ```
 
-That pulls in `vera-doc`, `vera-ingest`, and `vera-ingest-pymupdf`. Library-only
+That pulls in `vera-doc`, `vera-ingest`, `vera-ingest-pymupdf`, and
+`vera-embed-openai`. Library-only
 installs (include the pymupdf plugin for a working default PDF convert path):
 
 ```bash
@@ -91,6 +92,8 @@ with VeraDocument.open("knowledge.vera") as document:
   writing.
 - [**vera-ingest-pymupdf**](packages/vera-ingest-pymupdf.md) — default PDF
   parsing and selective OCR.
+- [**vera-embed-openai**](packages/vera-embed-openai.md) — official OpenAI
+  embeddings plugin.
 - [**vera-cli**](packages/vera-cli.md) — run complete workflows from the
   `vera` command.
 - [**vera-mcp**](packages/vera-mcp.md) — expose retrieval to MCP-capable

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -9,6 +9,7 @@ the package that owns the capability you need.
 | [vera-ingest](vera-ingest.md) | `vera-ingest` | `import vera_ingest` | Conversion registry, shared types, and archive writing |
 | [vera-ingest-pymupdf](vera-ingest-pymupdf.md) | `vera-ingest-pymupdf` | `import vera_ingest_pymupdf` | Default PyMuPDF PDF parsing and Tesseract OCR |
 | [vera-ingest-docling](vera-ingest-docling.md) | `vera-ingest-docling` | `import vera_ingest_docling` | Optional Docling HybridChunker ingest (CLI extra; not bundled in the installer) |
+| [vera-embed-openai](vera-embed-openai.md) | `vera-embed-openai` | `import vera_embed_openai` | Official OpenAI embeddings plugin (bundled in CLI and the desktop sidecar) |
 | [vera-cli](vera-cli.md) | `vera-cli` | `vera` / `import vera_cli` | Shell workflows and retrieval evaluation |
 | [vera-mcp](vera-mcp.md) | `vera-mcp` | `vera mcp` / `import vera_mcp` | Exposing VERA retrieval to MCP clients |
 | [vera-app](vera-app.md) | `vera-app` | Desktop application | Interactive conversion, search, and grounded answers |
@@ -19,6 +20,7 @@ the package that owns the capability you need.
 ```text
 vera-ingest-pymupdf ──> vera-ingest ─┐
 vera-ingest-docling ──> vera-ingest ─┤
+vera-embed-openai ───────────────────┤
 vera-cli ─────────────────────────────┼──> vera-doc
 vera-app ─────────────────────────────┤
 vera-mcp ─────────────────────────────┤

--- a/docs/packages/vera-app.md
+++ b/docs/packages/vera-app.md
@@ -1,10 +1,10 @@
 # vera-app
 
 `vera-app` is the VERA desktop product: an Electron and React interface backed
-by a local Python sidecar. It composes `vera-doc` for retrieval and
-`vera-ingest` / `vera-ingest-pymupdf` for conversion;
-it does not use the CLI as its backend. `vera-ingest-docling` is an optional
-CLI extra, not bundled in the installer.
+by a local Python sidecar. It composes `vera-doc` for retrieval,
+`vera-ingest` / `vera-ingest-pymupdf` for conversion, and `vera-embed-openai`
+for hosted OpenAI embeddings; it does not use the CLI as its backend.
+`vera-ingest-docling` is an optional CLI extra, not bundled in the installer.
 
 See the [product overview](../desktop-app-overview.md) for the intended
 workflow and audience.
@@ -26,11 +26,12 @@ Download `VERA Setup <version>.exe` from the
    **Advanced pipeline options** for schema-driven settings from
    `describe_ingest_pipelines` / `PipelineConfigForm`. Convert lists PyMuPDF
    as the 0.3.0 ingest pipeline. Convert embedding presets are hashing
-   (default) and **Local semantic
-   (MiniLM)**; MiniLM is ONNX Runtime under the same
+   (default), **Local semantic
+   (MiniLM)**, and OpenAI `text-embedding-3-*`. MiniLM is ONNX Runtime under the same
    `sentence-transformers/all-MiniLM-L6-v2` identity, and the installer
-   vendors a VERA-exported, SHA256-pinned graph. Hosted embedders
-   are a 0.3.1 follow-up. Right-click a `.vera`
+   vendors a VERA-exported, SHA256-pinned graph. Save `OPENAI_API_KEY` under
+   **File > Settings → Embeddings**. Archives converted with OpenAI are not
+   portable for semantic search. Right-click a `.vera`
    archive and choose **Reconvert…** to replace it with a different ingest
    pipeline or embedding model.
 2. Use **File > Open Folder** to activate a document library.
@@ -43,11 +44,12 @@ Download `VERA Setup <version>.exe` from the
    convert steps.
 6. Select a citation in an answer to inspect the highlighted source passage.
 
-Search and conversion do not require a model-provider account. A provider is
-only required for generated Ask responses.
+Search and conversion do not require a model-provider account unless you
+choose a hosted embedder such as OpenAI. A Chat provider is only required
+for generated Ask responses.
 
 Source-run and packaged conversions use one sidecar interpreter with PyMuPDF,
-hashing, and ONNX MiniLM. Extra ingest and embedding
+hashing, ONNX MiniLM, and OpenAI embeddings. Extra ingest and embedding
 plugins are pip packages in that
 same environment (`python -m pip install` or `python -m pip install -e
 <clone>`). See

--- a/docs/packages/vera-cli.md
+++ b/docs/packages/vera-cli.md
@@ -1,10 +1,10 @@
 # vera-cli
 
 `vera-cli` publishes the `vera` console command and the `vera_cli` Python
-package. It depends on `vera-doc`, `vera-ingest`, and `vera-ingest-pymupdf`,
-and owns argument parsing, human and JSON output, exit codes, and retrieval
-evaluation. The optional `docling` extra installs `vera-ingest-docling` for
-`--parser docling`.
+package. It depends on `vera-doc`, `vera-ingest`, `vera-ingest-pymupdf`, and
+`vera-embed-openai`, and owns argument parsing, human and JSON output, exit
+codes, and retrieval evaluation. The optional `docling` extra installs
+`vera-ingest-docling` for `--parser docling`.
 
 Use the CLI for complete document workflows rather than assembling the Python
 packages directly.
@@ -25,6 +25,7 @@ python -m pip install \
   ./packages/vera-doc \
   ./packages/vera-ingest \
   ./packages/vera-ingest-pymupdf \
+  ./packages/vera-embed-openai \
   ./packages/vera-cli
 ```
 

--- a/docs/packages/vera-embed-openai.md
+++ b/docs/packages/vera-embed-openai.md
@@ -1,0 +1,86 @@
+# vera-embed-openai
+
+Official OpenAI embeddings plugin for VERA. It registers the `openai`
+provider under the `vera.embedders` entry-point group. `vera-cli` and
+`vera-app` depend on this package so hosted OpenAI conversion works out of
+the box. The client uses stdlib `urllib`; there is no `openai` SDK
+dependency.
+
+`vera-doc` does not special-case OpenAI. This package is an ordinary plugin
+on the same contract as a third-party embedder.
+
+## Install
+
+```bash
+python -m pip install "vera-embed-openai>=0.3.0"
+```
+
+From a repository checkout with uv, the workspace installs it by default:
+
+```bash
+uv sync
+```
+
+## Usage
+
+```bash
+set OPENAI_API_KEY=...
+vera convert "manual.pdf" --model openai:text-embedding-3-small
+vera convert "manual.pdf" --model openai:text-embedding-3-large \
+  --embedder-option batch_size=64
+```
+
+```python
+import os
+from vera_ingest import convert
+
+os.environ["OPENAI_API_KEY"] = "..."
+convert("manual.pdf", "manual.vera", model="openai:text-embedding-3-small")
+```
+
+Keep the API key in `OPENAI_API_KEY`. The desktop app stores it under
+**File > Settings → Embeddings** using the same encrypted env-secret store
+as other sidecar credentials. Optional `OPENAI_BASE_URL` (default
+`https://api.openai.com/v1`) points at Azure, OpenRouter, or a local
+OpenAI-compatible server. Archives still record `openai:<model-id>`, so two
+endpoints that embed different models under the same id are indistinguishable
+at search time.
+
+## Behavior
+
+- Known dimensions (constructor does not touch the network):
+  `text-embedding-3-small` 1536, `text-embedding-3-large` 3072,
+  `text-embedding-ada-002` 1536. Unrecognized model ids probe once on first
+  use.
+- Convert-time options: `batch_size` (1–2048 texts, also split on an
+  estimated token budget) and `timeout` seconds. Search resolves
+  `get_embedder(stored_model_name)` with defaults.
+- Responses are L2-normalized. `model_name` is the full spec
+  (`openai:text-embedding-3-small`).
+- A single chunk over the per-input token limit raises instead of truncating.
+- HTTP 429 and 5xx responses retry with backoff, honoring `Retry-After`.
+
+## Portability
+
+Archives converted with this provider are **not portable for semantic or
+hybrid search**. A recipient needs their own `OPENAI_API_KEY` (and a
+reachable API) because search resolves `get_embedder(stored_model_name)`.
+Keyword search still works without a key. Corpus search reports
+`skipped_semantic_model_groups` when the query embedder cannot load.
+
+Conversion bills per request. Desktop Convert Cancel does not interrupt an
+in-flight embeddings HTTP batch; conversion checks cancellation after
+`embed()` returns.
+
+## Desktop app
+
+The packaged sidecar freezes this plugin, copies its package metadata, and
+calls `ensure_registered()` so PyInstaller builds still resolve `openai`
+when dist-info is missing. Convert lists OpenAI presets beside hashing and
+MiniLM. Hashing remains the default.
+
+## See also
+
+- [Convert documents](../conversion.md)
+- [Creating an embedding provider plugin](../creating-an-embedding-provider.md)
+- [vera-doc](vera-doc.md)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -13,6 +13,7 @@ Install source ingestion separately when needed:
 ```bash
 python -m pip install "vera-ingest>=0.3.0"
 python -m pip install "vera-ingest-pymupdf>=0.3.0"
+python -m pip install "vera-embed-openai>=0.3.0"
 ```
 
 ## Create and search a database
@@ -282,8 +283,9 @@ creates `ChunkRecord` objects and optional attachments, then writes them through
 
 Registry and descriptor APIs (`register_ingest_pipeline`, `register_embedder`,
 and their describe/list helpers) are experimental and may change before 1.0.
-Hosted embedding providers (OpenAI, Voyage, Ollama) are examples you can
-implement yourself; they are not bundled with VERA. See
+OpenAI embeddings ship as the bundled `vera-embed-openai` plugin. Voyage and
+Ollama are examples you can implement yourself; they are not bundled with
+VERA (they need a query-versus-document hint on `EmbeddingFunction`). See
 [Creating an ingest pipeline plugin](creating-an-ingest-pipeline.md) and
 [Creating an embedding provider plugin](creating-an-embedding-provider.md).
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,6 +10,7 @@ generated from source docstrings using [mkdocstrings](https://mkdocstrings.githu
 | [vera-doc](vera.md) | `import vera_doc` | Storage, CRUD, search, corpus, library indexes |
 | [vera-ingest](vera-ingest.md) | `import vera_ingest` | Conversion registry, shared types, archive writing |
 | [vera-ingest-pymupdf](../packages/vera-ingest-pymupdf.md) | `import vera_ingest_pymupdf` | Default PyMuPDF PDF parsing and OCR |
+| [vera-embed-openai](../packages/vera-embed-openai.md) | `import vera_embed_openai` | Official OpenAI embeddings plugin |
 | [vera-cli](vera-cli.md) | `import vera_cli` | Command-line interface |
 | [vera-mcp](vera-mcp.md) | `import vera_mcp` | MCP server for AI agents |
 
@@ -19,6 +20,7 @@ Install packages from PyPI:
 python -m pip install "vera-doc>=0.3.0"
 python -m pip install "vera-ingest>=0.3.0"
 python -m pip install "vera-ingest-pymupdf>=0.3.0"
+python -m pip install "vera-embed-openai>=0.3.0"
 python -m pip install "vera-cli>=0.3.0"
 python -m pip install "vera-mcp>=0.3.0"
 ```
@@ -29,6 +31,7 @@ Or from a repository checkout:
 python -m pip install ./packages/vera-doc
 python -m pip install ./packages/vera-ingest
 python -m pip install ./packages/vera-ingest-pymupdf
+python -m pip install ./packages/vera-embed-openai
 python -m pip install ./packages/vera-cli
 python -m pip install ./packages/vera-mcp
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -289,7 +289,8 @@ The desktop app uses one sidecar interpreter. Install extra pip plugins into
 the same environment (`python -m pip install` or `python -m pip install -e
 <clone>`), then restart the app. Raw `PYTHONPATH` folders are not discovered.
 If Search reports skipped semantic model groups, the convert-time embedder is
-not available in this sidecar. Hosted embedders are a 0.3.1 follow-up. A
+not available in this sidecar. OpenAI embeddings are bundled (`OPENAI_API_KEY`
+under **File > Settings → Embeddings**); Voyage and Ollama are not. A
 source-run or CLI convert that fails with
 `No module named 'onnxruntime'` needs `uv sync --extra onnx` in the
 environment that runs VERA. Other Sentence Transformers models still need
@@ -360,8 +361,9 @@ entry names the model, indexed dimension, and load or dimension error.
 
 Install the missing provider in the process that embeds the query (CLI
 environment or desktop sidecar). Keyword results from
-the same search remain usable. Hosted embedding providers are not included
-until 0.3.1.
+the same search remain usable. OpenAI archives need `OPENAI_API_KEY` at search
+time as well; keyword hits still work without it. Voyage and Ollama are not
+bundled.
 
 ## vera-lab cannot open an archive
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ plugins:
             - packages/vera-ingest/src
             - packages/vera-ingest-pymupdf/src
             - packages/vera-ingest-docling/src
+            - packages/vera-embed-openai/src
             - packages/vera-cli/src
             - packages/vera-mcp/src
             - packages/vera-app/src
@@ -141,6 +142,8 @@ nav:
       - Overview: packages/vera-ingest-pymupdf.md
   - vera-ingest-docling:
       - Overview: packages/vera-ingest-docling.md
+  - vera-embed-openai:
+      - Overview: packages/vera-embed-openai.md
   - vera-lab:
       - Overview: packages/vera-lab.md
   - vera-cli:

--- a/packages/README.md
+++ b/packages/README.md
@@ -14,6 +14,7 @@ Published on PyPI:
 | [`vera-ingest`](https://pypi.org/project/vera-ingest/) | `import vera_ingest` | Conversion registry and shared ingest types |
 | [`vera-ingest-pymupdf`](https://pypi.org/project/vera-ingest-pymupdf/) | `import vera_ingest_pymupdf` | Default PyMuPDF PDF ingest pipeline |
 | [`vera-ingest-docling`](https://pypi.org/project/vera-ingest-docling/) | `import vera_ingest_docling` | Optional Docling ingest pipeline |
+| [`vera-embed-openai`](https://pypi.org/project/vera-embed-openai/) | `import vera_embed_openai` | Official OpenAI embeddings plugin |
 | [`vera-cli`](https://pypi.org/project/vera-cli/) | `vera` | CLI and evaluation |
 | [`vera-mcp`](https://pypi.org/project/vera-mcp/) | `vera mcp` | MCP adapter |
 
@@ -51,10 +52,17 @@ Optional CLI/library plugin that depends on `vera-ingest` and Docling.
 Registers the `docling` / `docling:hybrid` ingest pipeline. `vera-cli`
 installs it through the `docling` extra. It is not bundled into packaged desktop releases. The 0.3.0 Convert view does not list **Advanced layout (slower)**.
 
+## `vera-embed-openai`
+
+Official OpenAI embeddings plugin. Registers the `openai` provider with
+stdlib HTTPS (no OpenAI SDK). Pulled in by `vera-cli` and `vera-app` so
+hosted conversion works out of the box. Archives converted with it are not
+portable for semantic search.
+
 ## `vera-cli`
 
 Publishes `vera_cli` and the `vera` command. Depends on `vera-doc`,
-`vera-ingest`, and `vera-ingest-pymupdf`. Owns argument parsing, output
+`vera-ingest`, `vera-ingest-pymupdf`, and `vera-embed-openai`. Owns argument parsing, output
 contracts, exit codes, and retrieval evaluation. The optional `mcp` extra
 adds `vera-mcp`.
 
@@ -67,9 +75,9 @@ retrieval implementation.
 ## `vera-app`
 
 Owns the Electron/React desktop app and Python sidecar. Depends directly on
-`vera-doc`, `vera-ingest`, `vera-ingest-pymupdf`, ONNX Runtime, and
-`tokenizers`; it does not use the CLI as a backend. The packaged
-Windows installer freezes PyMuPDF plus a VERA-exported MiniLM ONNX graph
+`vera-doc`, `vera-ingest`, `vera-ingest-pymupdf`, ONNX Runtime,
+`tokenizers`, and `vera-embed-openai`; it does not use the CLI as a backend. The packaged
+Windows installer freezes PyMuPDF, OpenAI embeddings, plus a VERA-exported MiniLM ONNX graph
 (not Torch). The Docling CLI extra is
 not bundled in the installer.
 
@@ -85,6 +93,7 @@ pipeline provider.
 ```text
 vera-ingest-pymupdf ──> vera-ingest ─┐
 vera-ingest-docling ──> vera-ingest ─┤
+vera-embed-openai ───────────────────┤
 vera-cli ─────────────────────────────┼──> vera-doc
 vera-app ─────────────────────────────┤
 vera-mcp ─────────────────────────────┘

--- a/packages/vera-app/README.md
+++ b/packages/vera-app/README.md
@@ -2,13 +2,14 @@
 
 `vera-app` contains the Electron/React desktop application and its Python
 sidecar. It composes `vera-doc` for storage/search with `vera-ingest` and
-`vera-ingest-pymupdf` for conversion.
+`vera-ingest-pymupdf` for conversion, and `vera-embed-openai` for hosted
+OpenAI embeddings.
 
 The Convert view is schema-driven: the sidecar `describe_ingest_pipelines`
 action returns pipeline descriptors, and `PipelineConfigForm` renders only the
 fields each pipeline advertises. Source-run and packaged builds use one sidecar
-interpreter with PyMuPDF, hashing, and Local semantic (MiniLM) via ONNX
-Runtime. The Windows installer vendors a VERA-exported MiniLM graph (no
+interpreter with PyMuPDF, hashing, Local semantic (MiniLM) via ONNX
+Runtime, and OpenAI embeddings. The Windows installer vendors a VERA-exported MiniLM graph (no
 PyTorch). Docling remains
 a CLI extra (`vera-cli[docling]`) and is not listed in Convert.
 

--- a/packages/vera-app/electron/main.ts
+++ b/packages/vera-app/electron/main.ts
@@ -359,6 +359,7 @@ class PythonSidecar {
         join(process.cwd(), '..', 'vera-doc', 'src'),
         join(process.cwd(), '..', 'vera-ingest', 'src'),
         join(process.cwd(), '..', 'vera-ingest-pymupdf', 'src'),
+        join(process.cwd(), '..', 'vera-embed-openai', 'src'),
       ];
       env.PYTHONPATH = [sourcePaths.join(delimiter), env.PYTHONPATH || ''].filter(Boolean).join(delimiter);
     }
@@ -550,6 +551,12 @@ function storedEnvSecrets(): Record<string, string> {
   return secrets;
 }
 
+const KNOWN_EMBEDDER_ENV = ['OPENAI_API_KEY'];
+
+function envSecretPresent(name: string): boolean {
+  return Boolean(storedEnvSecrets()[name] || (process.env[name] || '').trim());
+}
+
 function applyEmbedderSecretEnv(env: NodeJS.ProcessEnv): void {
   for (const [name, value] of Object.entries(storedEnvSecrets())) {
     env[name] = value;
@@ -584,7 +591,7 @@ function clearEnvSecret(name: string): CredentialResult {
     writeApiKeys(keys);
   }
   sidecar.restart();
-  return { ok: true, has_api_key: Boolean(storedEnvSecrets()[envName] || process.env[envName]) };
+  return { ok: true, has_api_key: envSecretPresent(envName) };
 }
 
 function withRuntime(settings: AppSettings): AppSettings {
@@ -597,7 +604,9 @@ function withRuntime(settings: AppSettings): AppSettings {
     })),
     has_hf_token: Boolean(resolveHfToken()),
     has_env_secrets: Object.fromEntries(
-      Object.keys(storedEnvSecrets()).map((name) => [name, true]),
+      [...new Set([...Object.keys(storedEnvSecrets()), ...KNOWN_EMBEDDER_ENV])]
+        .filter((name) => envSecretPresent(name))
+        .map((name) => [name, true]),
     ),
   };
 }

--- a/packages/vera-app/pyproject.toml
+++ b/packages/vera-app/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "vera-doc[onnx]>=0.3.0",
   "vera-ingest>=0.3.0",
   "vera-ingest-pymupdf>=0.3.0",
+  "vera-embed-openai>=0.3.0",
 ]
 authors = [{name = "Kyle Willis"}]
 license = {text = "Apache-2.0"}

--- a/packages/vera-app/scripts/build-sidecar.cjs
+++ b/packages/vera-app/scripts/build-sidecar.cjs
@@ -39,11 +39,15 @@ const pyinstallerArgs = [
   "--copy-metadata",
   "vera-ingest-pymupdf",
   "--copy-metadata",
+  "vera-embed-openai",
+  "--copy-metadata",
   "vera-ingest",
   "--copy-metadata",
   "onnxruntime",
   "--hidden-import",
   "vera_ingest_pymupdf",
+  "--hidden-import",
+  "vera_embed_openai",
   "--hidden-import",
   "onnxruntime",
   "--hidden-import",
@@ -70,6 +74,7 @@ const sourcePaths = [
   path.join(repoRoot, "packages", "vera-doc", "src"),
   path.join(repoRoot, "packages", "vera-ingest", "src"),
   path.join(repoRoot, "packages", "vera-ingest-pymupdf", "src"),
+  path.join(repoRoot, "packages", "vera-embed-openai", "src"),
 ];
 const env = {
   ...process.env,
@@ -78,6 +83,7 @@ const env = {
 
 const CRITICAL_MISSING_PREFIXES = [
   "vera_ingest_pymupdf",
+  "vera_embed_openai",
   "onnxruntime",
   "tokenizers",
 ];

--- a/packages/vera-app/scripts/verify-packaged-sidecar.cjs
+++ b/packages/vera-app/scripts/verify-packaged-sidecar.cjs
@@ -156,6 +156,10 @@ function runDescribeChecks(sidecarPath) {
       finish(1, `Sidecar omitted sentence-transformers (got ${embedderNames.join(", ") || "none"})`);
       return;
     }
+    if (!embedderNames.includes("openai")) {
+      finish(1, `Sidecar omitted openai embedder (got ${embedderNames.join(", ") || "none"})`);
+      return;
+    }
 
     console.log(JSON.stringify({
       sidecar: sidecarPath,

--- a/packages/vera-app/src/renderer/components/ConvertPanel.tsx
+++ b/packages/vera-app/src/renderer/components/ConvertPanel.tsx
@@ -275,7 +275,12 @@ export function ConvertPanel({
             );
           })}
           {embeddingDescriptors
-            .filter((item) => item.provider !== 'hashing' && item.provider !== 'sentence-transformers')
+            .filter((item) => {
+              const covered = new Set(
+                EMBEDDING_MODEL_PRESETS.map((preset) => preset.requiresProvider || embeddingProviderFromSpec(preset.value)),
+              );
+              return !covered.has(item.provider);
+            })
             .map((item) => {
               const spec = item.default_model_id
                 ? `${item.provider}:${item.default_model_id}`
@@ -318,8 +323,8 @@ export function ConvertPanel({
       ) : null}
       <p className="sideMuted">
         {embeddingProviders.includes('sentence-transformers')
-          ? 'Local semantic (MiniLM) is bundled in the desktop app. The installer vendors a VERA-exported ONNX MiniLM graph, so first use does not download and does not need PyTorch. Hashing stays the default. The conversion embedding model is independent of Chat.'
-          : <>MiniLM is not available in this sidecar. From the repo root run <code>uv sync --extra app</code> (or <code>uv sync --extra onnx</code> for the CLI) and restart the app. Other Sentence Transformers models need <code>uv sync --extra ml</code>. Hosted embedders ship in a later 0.3.1 release.</>}
+          ? 'Local semantic (MiniLM) is bundled in the desktop app. The installer vendors a VERA-exported ONNX MiniLM graph, so first use does not download and does not need PyTorch. Hashing stays the default. OpenAI embeddings are bundled too: they bill per conversion and need OPENAI_API_KEY under File > Settings → Embeddings for convert and later semantic search. Those archives are not portable for semantic search: a recipient needs their own key. Keyword search still works without a key. The conversion embedding model is independent of Chat.'
+          : <>MiniLM is not available in this sidecar. From the repo root run <code>uv sync --extra app</code> (or <code>uv sync --extra onnx</code> for the CLI) and restart the app. Other Sentence Transformers models need <code>uv sync --extra ml</code>.</>}
         {' '}Custom specs are saved when the field loses focus.
       </p>
       <label className="miniCheck">

--- a/packages/vera-app/src/renderer/components/ProviderManagers.tsx
+++ b/packages/vera-app/src/renderer/components/ProviderManagers.tsx
@@ -13,9 +13,10 @@ import {
   Search,
   Settings,
   Trash2,
+  Sparkles,
   X,
 } from 'lucide-react';
-import type { AppSettings, ProviderProfile } from '../types';
+import type { AppSettings, EmbedderDescriptor, ProviderProfile } from '../types';
 import {
   defaultEnabledModels,
   emptyProvider,
@@ -115,7 +116,7 @@ type ProviderRowInfo = {
   profile: ProviderProfile | null;
 };
 
-export type SettingsSectionId = 'providers' | 'huggingface' | 'diagnostics';
+export type SettingsSectionId = 'providers' | 'embeddings' | 'huggingface' | 'diagnostics';
 
 const SETTINGS_SECTIONS: {
   id: SettingsSectionId;
@@ -128,6 +129,12 @@ const SETTINGS_SECTIONS: {
     label: 'LLM Providers',
     description: 'Hosted, local, and custom models used by Chat and Ask.',
     icon: MessageSquareText,
+  },
+  {
+    id: 'embeddings',
+    label: 'Embeddings',
+    description: 'API keys for hosted embedding providers used by Convert and Search.',
+    icon: Sparkles,
   },
   {
     id: 'huggingface',
@@ -152,7 +159,9 @@ export function SettingsModal({
   ingestPipeline,
   ingestPipelineConfigs,
   embedderConfigs,
+  embeddingDescriptors = [],
   hasHfToken = false,
+  hasEnvSecrets = {},
   convertLogPath = '',
   initialSection = 'providers',
   onPersist,
@@ -167,7 +176,9 @@ export function SettingsModal({
   ingestPipeline: string;
   ingestPipelineConfigs: AppSettings['ingest_pipeline_configs'];
   embedderConfigs: AppSettings['embedder_configs'];
+  embeddingDescriptors?: EmbedderDescriptor[];
   hasHfToken?: boolean;
+  hasEnvSecrets?: Record<string, boolean>;
   convertLogPath?: string;
   initialSection?: SettingsSectionId;
   onPersist: (next: AppSettings) => Promise<AppSettings>;
@@ -182,6 +193,8 @@ export function SettingsModal({
   const [keyInputs, setKeyInputs] = useState<Record<string, string>>({});
   const [hfTokenInput, setHfTokenInput] = useState('');
   const [hfTokenStored, setHfTokenStored] = useState(hasHfToken);
+  const [envSecretInputs, setEnvSecretInputs] = useState<Record<string, string>>({});
+  const [envSecretsStored, setEnvSecretsStored] = useState<Record<string, boolean>>(hasEnvSecrets);
   const [modelInput, setModelInput] = useState('');
   const [modelFilter, setModelFilter] = useState('');
   const [message, setMessage] = useState('');
@@ -387,6 +400,51 @@ export function SettingsModal({
       setMessage(result.has_api_key
         ? 'App token cleared; process environment still provides HF_TOKEN'
         : 'Hugging Face token cleared');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const embeddingCredentialProviders = embeddingDescriptors.filter(
+    (item) => item.capabilities?.requires_api_key && item.capabilities.credential_env,
+  );
+
+  async function saveEmbeddingSecret(envName: string) {
+    const value = (envSecretInputs[envName] || '').trim();
+    if (!value) {
+      setMessage(`Enter a value for ${envName} first`);
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await window.vera.saveEnvSecret(envName, value);
+      if (!result.ok) {
+        setMessage(result.error || `Unable to save ${envName}`);
+        return;
+      }
+      setEnvSecretInputs((current) => ({ ...current, [envName]: '' }));
+      const refreshed = await onRefresh();
+      setEnvSecretsStored(refreshed.has_env_secrets || {});
+      setMessage(`${envName} saved`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function clearEmbeddingSecret(envName: string) {
+    setBusy(true);
+    try {
+      const result = await window.vera.clearEnvSecret(envName);
+      if (!result.ok) {
+        setMessage(result.error || `Unable to clear ${envName}`);
+        return;
+      }
+      setEnvSecretInputs((current) => ({ ...current, [envName]: '' }));
+      const refreshed = await onRefresh();
+      setEnvSecretsStored(refreshed.has_env_secrets || {});
+      setMessage(result.has_api_key
+        ? `${envName} cleared from the app; the process environment still provides it`
+        : `${envName} cleared`);
     } finally {
       setBusy(false);
     }
@@ -730,6 +788,59 @@ export function SettingsModal({
                   <Plus size={14} />Local / custom endpoint
                   <small>Point VERA at any OpenAI-compatible endpoint (vLLM, llama.cpp, etc.)</small>
                 </button>
+              </div>
+            ) : null}
+
+            {section === 'embeddings' ? (
+              <div className="settingsForm">
+                <p className="providerItemDescription">
+                  Hosted embedders such as OpenAI bill per conversion and need an API key
+                  for later semantic or hybrid search of those archives. Keyword search
+                  still works without a key. Secrets are stored like LLM API keys and
+                  injected as environment variables when the sidecar starts.
+                </p>
+                {embeddingCredentialProviders.length === 0 ? (
+                  <p className="mutedText">No hosted embedding providers that require an API key are installed in this sidecar.</p>
+                ) : embeddingCredentialProviders.map((descriptor) => {
+                  const envName = descriptor.capabilities?.credential_env?.trim() || '';
+                  const stored = Boolean(envSecretsStored[envName]);
+                  const input = envSecretInputs[envName] || '';
+                  return (
+                    <label className="field" key={descriptor.provider}>
+                      <span>{descriptor.label || descriptor.provider} ({envName})</span>
+                      {stored && !input ? (
+                        <div className="editorActions">
+                          <span className="connectedTag"><CheckCircle2 size={13} />Key saved</span>
+                          <button className="secondaryAction compactAction" onClick={() => void clearEmbeddingSecret(envName)} disabled={busy}>
+                            <Trash2 size={13} />Clear key
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="pathInput">
+                          <input
+                            type="password"
+                            value={input}
+                            onChange={(event) => setEnvSecretInputs((current) => ({ ...current, [envName]: event.target.value }))}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter') {
+                                event.preventDefault();
+                                void saveEmbeddingSecret(envName);
+                              }
+                            }}
+                            placeholder={`Paste ${envName}`}
+                            autoComplete="off"
+                            disabled={busy}
+                          />
+                          {input.trim() ? (
+                            <button type="button" className="secondaryAction compactAction" onClick={() => void saveEmbeddingSecret(envName)} disabled={busy}>
+                              <KeyRound size={13} />Save
+                            </button>
+                          ) : null}
+                        </div>
+                      )}
+                    </label>
+                  );
+                })}
               </div>
             ) : null}
 

--- a/packages/vera-app/src/renderer/components/SettingsModal.test.tsx
+++ b/packages/vera-app/src/renderer/components/SettingsModal.test.tsx
@@ -38,6 +38,7 @@ describe('SettingsModal', () => {
     expect(html).toContain('id="settings-title"');
     expect(html).toContain('Settings');
     expect(html).toContain('LLM Providers');
+    expect(html).toContain('Embeddings');
     expect(html).toContain('Hugging Face');
     expect(html).toContain('Diagnostics');
     expect(html).not.toContain('Python plugins');
@@ -71,5 +72,37 @@ describe('SettingsModal', () => {
     expect(html).toContain('Show convert log in folder');
     expect(html).toContain('app:dev');
     expect(html).not.toContain('Paste OpenAI key');
+  });
+
+  it('opens the Embeddings section with hosted credential fields', () => {
+    const html = renderToStaticMarkup(
+      <SettingsModal
+        providers={[]}
+        activeProviderId=""
+        activeModel=""
+        activeModeId=""
+        embeddingModel="hashing"
+        ingestPipeline="pymupdf"
+        ingestPipelineConfigs={{}}
+        embedderConfigs={{}}
+        embeddingDescriptors={[
+          {
+            provider: 'openai',
+            label: 'openai — hosted embeddings',
+            description: 'OpenAI embeddings API',
+            installed: true,
+            fields: [],
+            capabilities: { requires_api_key: true, credential_env: 'OPENAI_API_KEY' },
+          },
+        ]}
+        initialSection="embeddings"
+        onPersist={async () => settings}
+        onRefresh={async () => settings}
+        onClose={() => undefined}
+      />,
+    );
+    expect(html).toContain('OPENAI_API_KEY');
+    expect(html).toContain('Paste OPENAI_API_KEY');
+    expect(html).toContain('bill per conversion');
   });
 });

--- a/packages/vera-app/src/renderer/hooks/useConversion.test.ts
+++ b/packages/vera-app/src/renderer/hooks/useConversion.test.ts
@@ -109,7 +109,7 @@ describe('createConversionController', () => {
       'Checking embedder',
     );
     expect(setConversionError).toHaveBeenCalledWith(
-      'Embedding provider is not ready. This build does not include hosted embedders; OPENAI_API_KEY cannot be configured here yet.',
+      'Embedding provider is not ready. Set OPENAI_API_KEY under File > Settings → Embeddings, then convert again.',
     );
     expect(dispatchBackgroundTask).not.toHaveBeenCalled();
   });

--- a/packages/vera-app/src/renderer/hooks/useConversion.ts
+++ b/packages/vera-app/src/renderer/hooks/useConversion.ts
@@ -406,7 +406,7 @@ export function createConversionController(getHost: () => ConversionHost) {
       const missing = preflight.missing_credential_env?.trim();
       host.setConversionError(
         missing
-          ? `Embedding provider is not ready. This build does not include hosted embedders; ${missing} cannot be configured here yet.`
+          ? `Embedding provider is not ready. Set ${missing} under File > Settings → Embeddings, then convert again.`
           : (preflight.detail || 'Embedding provider is not ready.'),
       );
       return;

--- a/packages/vera-app/src/renderer/lib/convertPresets.test.ts
+++ b/packages/vera-app/src/renderer/lib/convertPresets.test.ts
@@ -55,7 +55,8 @@ describe('convertPresets', () => {
     expect(isKnownEmbeddingPreset('sentence-transformers:all-MiniLM-L6-v2')).toBe(true);
     expect(EMBEDDING_MODEL_PRESETS.find((item) => item.value === 'sentence-transformers:all-MiniLM-L6-v2')?.label)
       .toBe('Local semantic (MiniLM)');
-    expect(isKnownEmbeddingPreset('openai:text-embedding-3-small')).toBe(false);
+    expect(isKnownEmbeddingPreset('openai:text-embedding-3-small')).toBe(true);
+    expect(isKnownEmbeddingPreset('openai:text-embedding-3-large')).toBe(true);
   });
 
   it('parses provider names from embedding specs', () => {
@@ -84,12 +85,14 @@ describe('convertPresets', () => {
         source: 'external',
       },
     ]);
-    expect(options.some((item) => item.value === 'openai:text-embedding-3-small' && item.source === 'external')).toBe(true);
+    expect(options.some((item) => item.value === 'openai:text-embedding-3-small')).toBe(true);
+    expect(options.some((item) => item.value === 'openai:text-embedding-3-large')).toBe(true);
   });
 
   it('maps unknown models to the custom select value', () => {
     expect(embeddingSelectValue('hashing')).toBe('hashing');
-    expect(embeddingSelectValue('openai:text-embedding-3-small')).toBe(CUSTOM_EMBEDDING_VALUE);
+    expect(embeddingSelectValue('openai:text-embedding-3-small')).toBe('openai:text-embedding-3-small');
+    expect(embeddingSelectValue('voyage:voyage-3')).toBe(CUSTOM_EMBEDDING_VALUE);
   });
 
   it('gates optional providers on sidecar availability', () => {

--- a/packages/vera-app/src/renderer/lib/convertPresets.ts
+++ b/packages/vera-app/src/renderer/lib/convertPresets.ts
@@ -20,6 +20,16 @@ export const EMBEDDING_MODEL_PRESETS: ConvertPresetOption[] = [
     label: 'Local semantic (MiniLM)',
     requiresProvider: 'sentence-transformers',
   },
+  {
+    value: 'openai:text-embedding-3-small',
+    label: 'OpenAI text-embedding-3-small',
+    requiresProvider: 'openai',
+  },
+  {
+    value: 'openai:text-embedding-3-large',
+    label: 'OpenAI text-embedding-3-large',
+    requiresProvider: 'openai',
+  },
 ];
 
 /** Optional pipelines that should appear disabled with an install hint when missing. */
@@ -60,11 +70,11 @@ export function embeddingSelectOptions(
   const known = new Set(descriptors.map((item) => item.provider));
   const presets = EMBEDDING_MODEL_PRESETS.filter((preset) => {
     const provider = preset.requiresProvider || embeddingProviderFromSpec(preset.value);
-    return !known.has(provider) || preset.value === 'hashing';
+    return !known.has(provider) || preset.value === 'hashing' || provider === 'openai';
   });
   const extra = installed.filter((option) => {
     const provider = option.requiresProvider || embeddingProviderFromSpec(option.value);
-    return provider !== 'hashing' && provider !== 'sentence-transformers';
+    return provider !== 'hashing' && provider !== 'sentence-transformers' && provider !== 'openai';
   });
   return [...presets, ...extra];
 }

--- a/packages/vera-app/src/renderer/main.tsx
+++ b/packages/vera-app/src/renderer/main.tsx
@@ -125,6 +125,7 @@ function App() {
   const [pipelineOptions, setPipelineOptions] = useState<PipelineOptions>({});
   const [embedderOptions, setEmbedderOptions] = useState<PipelineOptions>({});
   const [hasHfToken, setHasHfToken] = useState(false);
+  const [hasEnvSecrets, setHasEnvSecrets] = useState<Record<string, boolean>>({});
   const [convertLogPath, setConvertLogPath] = useState('');
   const [modePickerOpen, setModePickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -1393,6 +1394,7 @@ function App() {
     setIngestPipelineConfigs(saved.ingest_pipeline_configs || {});
     setEmbedderConfigs(saved.embedder_configs || {});
     setHasHfToken(Boolean(saved.has_hf_token));
+    setHasEnvSecrets(saved.has_env_secrets || {});
     return saved;
   }
 
@@ -1407,6 +1409,7 @@ function App() {
     setIngestPipelineConfigs(saved.ingest_pipeline_configs || {});
     setEmbedderConfigs(saved.embedder_configs || {});
     setHasHfToken(Boolean(saved.has_hf_token));
+    setHasEnvSecrets(saved.has_env_secrets || {});
     return saved;
   }
 
@@ -1638,6 +1641,7 @@ function App() {
       setIngestPipelineConfigs(saved.ingest_pipeline_configs || {});
       setEmbedderConfigs(saved.embedder_configs || {});
       setHasHfToken(Boolean(saved.has_hf_token));
+      setHasEnvSecrets(saved.has_env_secrets || {});
     },
     setEmbeddingProviders,
     setEmbeddingDescriptors,
@@ -2350,7 +2354,9 @@ function App() {
           ingestPipeline={ingestPipeline}
           ingestPipelineConfigs={ingestPipelineConfigs}
           embedderConfigs={embedderConfigs}
+          embeddingDescriptors={embeddingDescriptors}
           hasHfToken={hasHfToken}
+          hasEnvSecrets={hasEnvSecrets}
           convertLogPath={convertLogPath}
           onPersist={persistSettings}
           onRefresh={refreshSettings}

--- a/packages/vera-app/src/vera_app/sidecar.py
+++ b/packages/vera-app/src/vera_app/sidecar.py
@@ -9,13 +9,18 @@ import threading
 import traceback
 from typing import Any
 
+from vera_embed_openai import (
+    ensure_registered as ensure_openai_embedder_registered,
+)
 from vera_ingest_pymupdf import (
     ensure_registered as ensure_pymupdf_pipeline_registered,
 )
 
 # PyInstaller freezes and PYTHONPATH-only app runs often omit entry-point
-# metadata; the sidecar hard-depends on the default PDF pipeline.
+# metadata; the sidecar hard-depends on the default PDF pipeline and the
+# bundled OpenAI embedder.
 ensure_pymupdf_pipeline_registered()
+ensure_openai_embedder_registered()
 
 from vera_app import convert as convert_handlers
 from vera_app import library as library_handlers

--- a/packages/vera-app/tests/test_app_sidecar.py
+++ b/packages/vera-app/tests/test_app_sidecar.py
@@ -913,9 +913,11 @@ def test_sidecar_forwards_embedding_model_and_lists_providers(monkeypatch):
     assert captured["model"] == "openai:text-embedding-3-small"
     assert providers["ok"] is True
     assert "hashing" in providers["result"]["providers"]
+    assert "openai" in providers["result"]["providers"]
     assert described["ok"] is True
     assert "providers" in described["result"]
     assert isinstance(described["result"]["providers"], list)
+    assert any(item.get("provider") == "openai" for item in described["result"]["providers"])
     assert models["ok"] is True
     assert models["result"]["provider"] == "hashing"
     assert models["result"]["models"][0]["model_id"] == "vera-hashing-384"

--- a/packages/vera-cli/README.md
+++ b/packages/vera-cli/README.md
@@ -1,7 +1,7 @@
 # vera-cli
 
 `vera-cli` provides the `vera` command-line interface over `vera-doc`,
-`vera-ingest`, and `vera-ingest-pymupdf`. It owns command parsing, text and
+`vera-ingest`, `vera-ingest-pymupdf`, and `vera-embed-openai`. It owns command parsing, text and
 JSON output, exit codes, and retrieval evaluation.
 
 `vera convert` accepts repeatable `--pipeline-option KEY=VALUE` flags for

--- a/packages/vera-cli/src/vera_cli/commands.py
+++ b/packages/vera-cli/src/vera_cli/commands.py
@@ -8,6 +8,7 @@ from vera_doc import UnknownEmbeddingModelError
 from vera_doc.collection import build_library_index, library_index_status, update_library_index
 from vera_doc.corpus import VeraCorpus
 from vera_doc.document import VeraDocument
+from vera_embed_openai import ensure_registered as ensure_openai_embedder_registered
 from vera_ingest import (
     UnknownIngestPipelineError,
     batch_convert,
@@ -18,7 +19,6 @@ from vera_ingest.viewer import (
     get_source_document,
     result_payload,
 )
-from vera_embed_openai import ensure_registered as ensure_openai_embedder_registered
 from vera_ingest_pymupdf import (
     OCRLanguageDownloadError,
     UnknownOCRLanguageError,

--- a/packages/vera-cli/src/vera_cli/commands.py
+++ b/packages/vera-cli/src/vera_cli/commands.py
@@ -18,12 +18,15 @@ from vera_ingest.viewer import (
     get_source_document,
     result_payload,
 )
+from vera_embed_openai import ensure_registered as ensure_openai_embedder_registered
 from vera_ingest_pymupdf import (
     OCRLanguageDownloadError,
     UnknownOCRLanguageError,
     describe_ocr_languages,
     download_ocr_language_data,
 )
+
+ensure_openai_embedder_registered()
 
 _TRUE_TOKENS = {"1", "true", "yes", "y", "on"}
 _FALSE_TOKENS = {"0", "false", "no", "n", "off", ""}

--- a/packages/vera-doc/README.md
+++ b/packages/vera-doc/README.md
@@ -473,127 +473,22 @@ them as `embedder_options={...}`, `get_embedder(..., batch_size=64)`, or CLI
 `--embedder-option KEY=VALUE`. See
 [Creating an embedding provider plugin](../../docs/creating-an-embedding-provider.md).
 
-### OpenAI embedding plugin example
+### Official OpenAI plugin
 
-VERA does not bundle hosted providers. Prefer the Options + descriptor
-authoring model in
+OpenAI embeddings ship as the `vera-embed-openai` package — a
+`vera.embedders` plugin, not a `vera-doc` builtin. `vera-cli` and the desktop
+sidecar depend on it. Keep secrets in `OPENAI_API_KEY`, not in Options fields.
+The constructor does not probe the API; known models use a static dimension
+table. See
+[vera-embed-openai](https://dkylewillis.github.io/vera/packages/vera-embed-openai/)
+and
 [Creating an embedding provider plugin](../../docs/creating-an-embedding-provider.md).
-Keep secrets in the environment (`OPENAI_API_KEY`), not in Options fields.
-This minimal sketch shows the factory + entry points:
-
-```toml
-# pyproject.toml
-[project]
-name = "vera-openai-embeddings"
-dependencies = ["openai>=1", "vera-doc"]
-
-[project.entry-points."vera.embedders"]
-openai = "vera_openai_embeddings:create_embedder"
-
-[project.entry-points."vera.embedder_descriptors"]
-openai = "vera_openai_embeddings:create_descriptor"
-
-[project.entry-points."vera.embedder_models"]
-openai = "vera_openai_embeddings:list_models"
-```
-
-```python
-# vera_openai_embeddings.py
-import os
-from dataclasses import dataclass, field
-
-import numpy as np
-from openai import OpenAI
-
-from vera_doc import (
-    EmbedderCapabilities,
-    EmbedderDescriptor,
-    EmbedderOptions,
-    EmbeddingModelInfo,
-)
-from vera_doc.embedder_descriptors import fields_from_dataclass
-
-
-@dataclass(frozen=True)
-class OpenAIOptions(EmbedderOptions):
-    batch_size: int = field(
-        default=128,
-        metadata={
-            "label": "Batch size",
-            "minimum": 1,
-            "maximum": 2048,
-            "scope": "convert",
-        },
-    )
-
-
-class OpenAIEmbedder:
-    normalization = "l2"
-
-    def __init__(self, model_id: str, *, batch_size: int):
-        self.model_name = f"openai:{model_id}"
-        self._client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
-        self._model = model_id
-        self._batch_size = batch_size
-        self.dimension = len(self.embed(["dimension probe"])[0])
-
-    def embed(self, texts: list[str]) -> list[np.ndarray]:
-        vectors = []
-        for start in range(0, len(texts), self._batch_size):
-            response = self._client.embeddings.create(
-                model=self._model,
-                input=texts[start : start + self._batch_size],
-            )
-            vectors.extend(item.embedding for item in response.data)
-        normalized = []
-        for vector in vectors:
-            array = np.asarray(vector, dtype=np.float32)
-            norm = np.linalg.norm(array)
-            normalized.append(array / norm if norm else array)
-        return normalized
-
-
-def create_embedder(model_id: str, **config):
-    options = OpenAIOptions.from_mapping(config)
-    return OpenAIEmbedder(model_id, batch_size=options.batch_size)
-
-
-def create_descriptor() -> EmbedderDescriptor:
-    return EmbedderDescriptor(
-        provider="openai",
-        label="openai — hosted embeddings",
-        description="OpenAI embeddings API.",
-        default_model_id="text-embedding-3-small",
-        example_specs=("openai:text-embedding-3-small",),
-        capabilities=EmbedderCapabilities(
-            requires_network=True,
-            requires_api_key=True,
-            credential_env="OPENAI_API_KEY",
-            local_model=False,
-            supports_model_listing=True,
-        ),
-        fields=fields_from_dataclass(OpenAIOptions),
-    )
-
-
-def list_models():
-    return (
-        EmbeddingModelInfo(
-            model_id="text-embedding-3-small",
-            label="text-embedding-3-small",
-            spec="openai:text-embedding-3-small",
-        ),
-    )
-```
-
-After installing the plugin and setting `OPENAI_API_KEY`, use it from the CLI:
 
 ```bash
+set OPENAI_API_KEY=...
 vera convert "manual.pdf" --model openai:text-embedding-3-small \
   --embedder-option batch_size=64
 ```
-
-Or pass provider-specific settings from Python:
 
 ```python
 from vera_doc import get_embedder, preflight_embedder
@@ -606,6 +501,9 @@ embedder = get_embedder(
 )
 convert("manual.pdf", "manual.vera", embedding_function=embedder)
 ```
+
+Voyage and Ollama are not bundled; they need a query-versus-document hint on
+`EmbeddingFunction` first.
 
 ### Claude applications
 

--- a/packages/vera-embed-openai/README.md
+++ b/packages/vera-embed-openai/README.md
@@ -1,0 +1,58 @@
+# vera-embed-openai
+
+Official OpenAI embeddings plugin for VERA. Registers the `openai` provider
+under the `vera.embedders` entry-point group.
+
+`vera-cli` and `vera-app` depend on this package so hosted OpenAI conversion
+works out of the box. The client uses stdlib `urllib` — there is no `openai`
+SDK dependency.
+
+## Install
+
+```bash
+python -m pip install "vera-embed-openai>=0.3.0"
+```
+
+From a repository checkout with uv, the workspace installs it by default
+(via `vera-cli` / `vera-app`):
+
+```bash
+uv sync
+```
+
+## Usage
+
+```bash
+set OPENAI_API_KEY=...
+vera convert "manual.pdf" --model openai:text-embedding-3-small
+```
+
+```python
+import os
+
+from vera_ingest import convert
+
+os.environ["OPENAI_API_KEY"] = "..."
+convert("manual.pdf", "manual.vera", model="openai:text-embedding-3-small")
+```
+
+Keep the API key in `OPENAI_API_KEY`. Optional `OPENAI_BASE_URL` (default
+`https://api.openai.com/v1`) points at Azure, OpenRouter, or a local
+OpenAI-compatible server. Archives still record `openai:<model-id>`, so two
+endpoints that embed different models under the same id are indistinguishable
+at search time.
+
+## Notes
+
+- Known dimensions (no network in the constructor): `text-embedding-3-small`
+  1536, `text-embedding-3-large` 3072, `text-embedding-ada-002` 1536.
+  Unrecognized model ids probe once on first use.
+- Convert-time options: `batch_size` (1–2048) and `timeout` seconds.
+  Search resolves `get_embedder(stored_model_name)` with defaults.
+- Semantic search of a hosted archive needs the same provider and credentials
+  on the searching machine. Keyword search still works without a key.
+- Desktop Convert Cancel does not interrupt an in-flight embeddings HTTP
+  batch; conversion checks cancellation after `embed()` returns.
+
+See the [vera-embed-openai documentation](https://dkylewillis.github.io/vera/packages/vera-embed-openai/)
+and [conversion guide](https://github.com/dkylewillis/vera/blob/main/docs/conversion.md).

--- a/packages/vera-embed-openai/pyproject.toml
+++ b/packages/vera-embed-openai/pyproject.toml
@@ -1,18 +1,16 @@
 [project]
-name = "vera-cli"
+name = "vera-embed-openai"
 version = "0.3.0"
-description = "Command-line interface for VERA documents"
+description = "Official OpenAI embeddings provider for VERA"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "vera-doc>=0.3.0",
-  "vera-ingest>=0.3.0",
-  "vera-ingest-pymupdf>=0.3.0",
-  "vera-embed-openai>=0.3.0",
+  "numpy>=1.24",
 ]
 authors = [{name = "Kyle Willis"}]
 license = {text = "Apache-2.0"}
-keywords = ["semantic-search", "document", "sqlite", "cli"]
+keywords = ["openai", "embeddings", "semantic-search", "vera"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: Apache Software License",
@@ -23,18 +21,20 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/dkylewillis/vera"
 Repository = "https://github.com/dkylewillis/vera"
-Documentation = "https://dkylewillis.github.io/vera/packages/vera-cli/"
+Documentation = "https://dkylewillis.github.io/vera/packages/vera-embed-openai/"
 
-[project.optional-dependencies]
-mcp = ["vera-mcp>=0.3.0"]
-docling = ["vera-ingest-docling>=0.3.0"]
+[project.entry-points."vera.embedders"]
+openai = "vera_embed_openai:create_embedder"
 
-[project.scripts]
-vera = "vera_cli:main"
+[project.entry-points."vera.embedder_descriptors"]
+openai = "vera_embed_openai:create_descriptor"
+
+[project.entry-points."vera.embedder_models"]
+openai = "vera_embed_openai:list_models"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/vera_cli"]
+packages = ["src/vera_embed_openai"]

--- a/packages/vera-embed-openai/src/vera_embed_openai/__init__.py
+++ b/packages/vera-embed-openai/src/vera_embed_openai/__init__.py
@@ -1,0 +1,81 @@
+"""Official OpenAI embeddings provider for VERA."""
+
+from __future__ import annotations
+
+from vera_doc import (
+    EmbedderDescriptor,
+    EmbeddingModelInfo,
+    register_embedder,
+    register_embedder_descriptor,
+    register_embedder_models,
+)
+
+from .options import (
+    BASE_URL_ENV,
+    CREDENTIAL_ENV,
+    DEFAULT_BASE_URL,
+    DEFAULT_MODEL_ID,
+    MODEL_DIMENSIONS,
+    PROVIDER,
+    OpenAIOptions,
+    describe_provider,
+    list_models as _list_models,
+)
+from .provider import (
+    MAX_INPUT_TOKENS,
+    MAX_REQUEST_TOKENS,
+    OpenAIEmbedder,
+    OpenAIEmbedderError,
+    create_embedder,
+    embeddings_url,
+    estimate_tokens,
+    iter_embed_batches,
+)
+
+__all__ = [
+    "BASE_URL_ENV",
+    "CREDENTIAL_ENV",
+    "DEFAULT_BASE_URL",
+    "DEFAULT_MODEL_ID",
+    "MAX_INPUT_TOKENS",
+    "MAX_REQUEST_TOKENS",
+    "MODEL_DIMENSIONS",
+    "OpenAIEmbedder",
+    "OpenAIEmbedderError",
+    "OpenAIOptions",
+    "PROVIDER",
+    "create_descriptor",
+    "create_embedder",
+    "describe_provider",
+    "embeddings_url",
+    "ensure_registered",
+    "estimate_tokens",
+    "iter_embed_batches",
+    "list_models",
+]
+
+
+def create_descriptor() -> EmbedderDescriptor:
+    """Entry-point factory for ``vera.embedder_descriptors``."""
+    return describe_provider()
+
+
+def list_models() -> tuple[EmbeddingModelInfo, ...]:
+    """Entry-point factory for ``vera.embedder_models``."""
+    return _list_models()
+
+
+def ensure_registered(*, replace: bool = True) -> None:
+    """Register the ``openai`` embedder without relying on package metadata.
+
+    Entry-point discovery fails in PyInstaller freezes and PYTHONPATH-only
+    source runs that never install ``vera-embed-openai`` dist-info. Callers
+    that already import this package (CLI, the desktop sidecar) should invoke
+    this so Convert and search still resolve the provider.
+    """
+    register_embedder(PROVIDER, create_embedder, replace=replace)
+    register_embedder_descriptor(PROVIDER, create_descriptor, replace=replace)
+    register_embedder_models(PROVIDER, list_models, replace=replace)
+
+
+ensure_registered()

--- a/packages/vera-embed-openai/src/vera_embed_openai/__init__.py
+++ b/packages/vera-embed-openai/src/vera_embed_openai/__init__.py
@@ -19,8 +19,8 @@ from .options import (
     PROVIDER,
     OpenAIOptions,
     describe_provider,
-    list_models as _list_models,
 )
+from .options import list_models as _list_models
 from .provider import (
     MAX_INPUT_TOKENS,
     MAX_REQUEST_TOKENS,

--- a/packages/vera-embed-openai/src/vera_embed_openai/options.py
+++ b/packages/vera-embed-openai/src/vera_embed_openai/options.py
@@ -1,0 +1,124 @@
+"""Typed options, descriptor, and model list for the OpenAI embedder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from vera_doc import (
+    EmbedderCapabilities,
+    EmbedderDescriptor,
+    EmbedderOptions,
+    EmbeddingModelInfo,
+)
+from vera_doc.embedder_descriptors import fields_from_dataclass
+
+PROVIDER = "openai"
+DEFAULT_MODEL_ID = "text-embedding-3-small"
+CREDENTIAL_ENV = "OPENAI_API_KEY"
+BASE_URL_ENV = "OPENAI_BASE_URL"
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+MODEL_DIMENSIONS: dict[str, int] = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+}
+
+
+@dataclass(frozen=True)
+class OpenAIOptions(EmbedderOptions):
+    """OpenAI-owned convert-time embedding settings.
+
+    Credentials and the API root stay in the environment
+    (``OPENAI_API_KEY``, optional ``OPENAI_BASE_URL``), not in this dataclass.
+    """
+
+    batch_size: int = field(
+        default=128,
+        metadata={
+            "label": "Batch size",
+            "description": (
+                "Maximum texts per OpenAI request. Requests also split when "
+                "the estimated token budget would be exceeded. Convert-time "
+                "only — search uses the default."
+            ),
+            "minimum": 1,
+            "maximum": 2048,
+            "step": 1,
+            "scope": "convert",
+        },
+    )
+    timeout: int = field(
+        default=60,
+        metadata={
+            "label": "Timeout",
+            "description": (
+                "Seconds to wait for each embeddings HTTP response. "
+                "Convert-time only — search uses the default."
+            ),
+            "unit": "seconds",
+            "minimum": 1,
+            "maximum": 600,
+            "step": 1,
+            "scope": "convert",
+        },
+    )
+
+
+def describe_provider() -> EmbedderDescriptor:
+    return EmbedderDescriptor(
+        provider=PROVIDER,
+        label="openai — hosted embeddings",
+        description=(
+            "OpenAI embeddings API (text-embedding-3-* and similar). "
+            "Requires OPENAI_API_KEY. Archives converted with this provider "
+            "need the same key for later semantic or hybrid search; keyword "
+            "search still works offline. Conversion bills per request."
+        ),
+        default_model_id=DEFAULT_MODEL_ID,
+        example_specs=(
+            "openai:text-embedding-3-small",
+            "openai:text-embedding-3-large",
+        ),
+        capabilities=EmbedderCapabilities(
+            requires_network=True,
+            requires_api_key=True,
+            credential_env=CREDENTIAL_ENV,
+            local_model=False,
+            configurable_dimension=False,
+            supports_model_listing=True,
+        ),
+        fields=fields_from_dataclass(OpenAIOptions),
+        notes=(
+            "Set OPENAI_API_KEY (desktop: File > Settings → Embeddings). "
+            "Optional OPENAI_BASE_URL overrides the API root "
+            f"(default {DEFAULT_BASE_URL}); archives still record "
+            "openai:<model-id>, so a custom endpoint that serves a different "
+            "model is not detectable at search time. "
+            "batch_size and timeout are convert-time options; search uses defaults. "
+            "Cancel does not interrupt an in-flight embeddings request.",
+        ),
+    )
+
+
+def list_models() -> tuple[EmbeddingModelInfo, ...]:
+    return (
+        EmbeddingModelInfo(
+            model_id="text-embedding-3-small",
+            label="text-embedding-3-small",
+            spec="openai:text-embedding-3-small",
+            description="OpenAI text-embedding-3-small (1536-d).",
+        ),
+        EmbeddingModelInfo(
+            model_id="text-embedding-3-large",
+            label="text-embedding-3-large",
+            spec="openai:text-embedding-3-large",
+            description="OpenAI text-embedding-3-large (3072-d).",
+        ),
+        EmbeddingModelInfo(
+            model_id="text-embedding-ada-002",
+            label="text-embedding-ada-002",
+            spec="openai:text-embedding-ada-002",
+            description="Legacy OpenAI ada embedding model (1536-d).",
+        ),
+    )

--- a/packages/vera-embed-openai/src/vera_embed_openai/provider.py
+++ b/packages/vera-embed-openai/src/vera_embed_openai/provider.py
@@ -1,0 +1,288 @@
+"""Stdlib HTTP OpenAI embeddings client.
+
+Batch splitting, retries, and URL construction stay in this module. The
+``EmbeddingFunction`` contract is ``embed(texts)``, so convert and search
+never see request boundaries.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+import numpy as np
+
+from .options import (
+    BASE_URL_ENV,
+    CREDENTIAL_ENV,
+    DEFAULT_BASE_URL,
+    DEFAULT_MODEL_ID,
+    MODEL_DIMENSIONS,
+    PROVIDER,
+    OpenAIOptions,
+)
+
+# OpenAI embeddings caps (re-check against current docs if these start failing).
+# Per-input limit for text-embedding-3-* and ada-002.
+MAX_INPUT_TOKENS = 8192
+# Published per-request cap is ~300k tokens; stay under it to absorb the
+# character heuristic's estimation error.
+MAX_REQUEST_TOKENS = 250_000
+MAX_BATCH_ITEMS = 2048
+MAX_RETRIES = 4
+_RETRY_STATUS = frozenset({429, 500, 502, 503, 504})
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+class OpenAIEmbedderError(RuntimeError):
+    """Raised when the OpenAI embeddings API rejects or cannot complete a request."""
+
+
+def estimate_tokens(text: str) -> int:
+    """Conservative character heuristic (~3 chars/token). Over-estimates on purpose."""
+    if not text:
+        return 1
+    return max(1, (len(text) + 2) // 3)
+
+
+def iter_embed_batches(
+    texts: Sequence[str],
+    *,
+    batch_size: int,
+    max_request_tokens: int = MAX_REQUEST_TOKENS,
+    max_input_tokens: int = MAX_INPUT_TOKENS,
+) -> Iterator[list[str]]:
+    """Yield text batches that fit both the item cap and the token budget.
+
+    A single text over ``max_input_tokens`` raises rather than truncating.
+    """
+    max_items = max(1, min(int(batch_size), MAX_BATCH_ITEMS))
+    budget = max(1, int(max_request_tokens))
+    batch: list[str] = []
+    batch_tokens = 0
+    for index, text in enumerate(texts):
+        value = text if isinstance(text, str) else ("" if text is None else str(text))
+        tokens = estimate_tokens(value)
+        if tokens > max_input_tokens:
+            raise OpenAIEmbedderError(
+                f"chunk {index} is ~{tokens} tokens, over the {max_input_tokens} "
+                "per-input OpenAI embeddings limit; lower the pipeline chunk_size"
+            )
+        if batch and (len(batch) >= max_items or batch_tokens + tokens > budget):
+            yield batch
+            batch = []
+            batch_tokens = 0
+        batch.append(value)
+        batch_tokens += tokens
+    if batch:
+        yield batch
+
+
+def embeddings_url(base_url: str) -> str:
+    """Join ``base_url`` with ``/embeddings``, inserting ``/v1`` when missing."""
+    root = (base_url or DEFAULT_BASE_URL).strip() or DEFAULT_BASE_URL
+    root = root.rstrip("/")
+    if root.endswith("/embeddings"):
+        return root
+    if not root.endswith("/v1") and "/v1/" not in root + "/":
+        root = f"{root}/v1"
+    return f"{root}/embeddings"
+
+
+def _sanitize_unicode(value: Any) -> Any:
+    if isinstance(value, str):
+        return _SURROGATE_RE.sub("\ufffd", value)
+    if isinstance(value, list):
+        return [_sanitize_unicode(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            _sanitize_unicode(key) if isinstance(key, str) else key: _sanitize_unicode(item)
+            for key, item in value.items()
+        }
+    return value
+
+
+def _l2_normalize(vector: np.ndarray) -> np.ndarray:
+    array = np.asarray(vector, dtype=np.float32)
+    norm = float(np.linalg.norm(array))
+    if norm:
+        array = array / norm
+    return array.astype(np.float32)
+
+
+def _retry_delay_seconds(headers: Any, attempt: int) -> float:
+    raw = ""
+    if headers is not None:
+        raw = str(headers.get("Retry-After") or headers.get("retry-after") or "")
+    if raw:
+        try:
+            return min(60.0, max(0.5, float(raw.strip())))
+        except ValueError:
+            pass
+    return min(32.0, 0.5 * (2**attempt))
+
+
+def _error_detail(exc: urllib.error.HTTPError) -> str:
+    try:
+        body = exc.read().decode("utf-8", errors="replace")
+    except Exception:  # noqa: BLE001 - error path must not hide the status
+        body = ""
+    snippet = " ".join(body.split())
+    if len(snippet) > 500:
+        snippet = snippet[:497] + "..."
+    return snippet
+
+
+def _post_embeddings(
+    *,
+    url: str,
+    api_key: str,
+    model: str,
+    inputs: list[str],
+    timeout: float,
+) -> list[np.ndarray]:
+    payload = json.dumps(
+        _sanitize_unicode({"model": model, "input": inputs}),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    last_error: Exception | None = None
+    for attempt in range(MAX_RETRIES):
+        request = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = json.loads(response.read().decode("utf-8"))
+            return _vectors_from_payload(raw, expected=len(inputs))
+        except urllib.error.HTTPError as exc:
+            detail = _error_detail(exc)
+            if exc.code in _RETRY_STATUS and attempt + 1 < MAX_RETRIES:
+                time.sleep(_retry_delay_seconds(exc.headers, attempt))
+                last_error = OpenAIEmbedderError(
+                    f"OpenAI embeddings HTTP {exc.code}: {detail or exc.reason}"
+                )
+                continue
+            raise OpenAIEmbedderError(
+                f"OpenAI embeddings HTTP {exc.code}: {detail or exc.reason}"
+            ) from exc
+        except urllib.error.URLError as exc:
+            reason = getattr(exc, "reason", exc)
+            last_error = OpenAIEmbedderError(f"Unable to reach OpenAI embeddings API: {reason}")
+            if attempt + 1 < MAX_RETRIES:
+                time.sleep(_retry_delay_seconds(None, attempt))
+                continue
+            raise last_error from exc
+        except (json.JSONDecodeError, TypeError, ValueError, KeyError) as exc:
+            raise OpenAIEmbedderError(f"OpenAI embeddings returned an invalid payload: {exc}") from exc
+    raise last_error or OpenAIEmbedderError("OpenAI embeddings request failed")
+
+
+def _vectors_from_payload(payload: Any, *, expected: int) -> list[np.ndarray]:
+    if not isinstance(payload, dict):
+        raise OpenAIEmbedderError("OpenAI embeddings response is not a JSON object")
+    rows = payload.get("data")
+    if not isinstance(rows, list) or len(rows) != expected:
+        raise OpenAIEmbedderError(
+            f"OpenAI embeddings returned {0 if not isinstance(rows, list) else len(rows)} "
+            f"vectors; expected {expected}"
+        )
+    indexed: list[tuple[int, np.ndarray]] = []
+    for position, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise OpenAIEmbedderError("OpenAI embeddings data entry is not an object")
+        embedding = row.get("embedding")
+        if not isinstance(embedding, list) or not embedding:
+            raise OpenAIEmbedderError("OpenAI embeddings data entry is missing embedding")
+        index = row.get("index", position)
+        try:
+            order = int(index)
+        except (TypeError, ValueError) as exc:
+            raise OpenAIEmbedderError("OpenAI embeddings data entry has an invalid index") from exc
+        indexed.append((order, _l2_normalize(np.asarray(embedding, dtype=np.float32))))
+    indexed.sort(key=lambda item: item[0])
+    return [vector for _index, vector in indexed]
+
+
+class OpenAIEmbedder:
+    """Hosted OpenAI embeddings. Constructor does not touch the network."""
+
+    normalization = "l2"
+
+    def __init__(
+        self,
+        model_id: str,
+        *,
+        api_key: str,
+        base_url: str,
+        batch_size: int,
+        timeout: int,
+    ) -> None:
+        model = (model_id or "").strip() or DEFAULT_MODEL_ID
+        self.model_name = f"{PROVIDER}:{model}"
+        self._model = model
+        self._api_key = api_key
+        self._url = embeddings_url(base_url)
+        self._batch_size = max(1, min(int(batch_size), MAX_BATCH_ITEMS))
+        self._timeout = float(timeout)
+        self._lock = threading.Lock()
+        self._dimension = MODEL_DIMENSIONS.get(model)
+
+    @property
+    def dimension(self) -> int:
+        if self._dimension is None:
+            self._dimension = int(len(self._embed_one_batch(["ping"])[0]))
+        return self._dimension
+
+    def embed(self, texts: list[str]) -> list[np.ndarray]:
+        if not texts:
+            return []
+        vectors: list[np.ndarray] = []
+        for batch in iter_embed_batches(texts, batch_size=self._batch_size):
+            vectors.extend(self._embed_one_batch(batch))
+        if self._dimension is None and vectors:
+            self._dimension = int(vectors[0].shape[0])
+        return vectors
+
+    def _embed_one_batch(self, batch: list[str]) -> list[np.ndarray]:
+        with self._lock:
+            return _post_embeddings(
+                url=self._url,
+                api_key=self._api_key,
+                model=self._model,
+                inputs=batch,
+                timeout=self._timeout,
+            )
+
+
+def _require_api_key() -> str:
+    api_key = os.environ.get(CREDENTIAL_ENV, "").strip()
+    if not api_key:
+        raise OpenAIEmbedderError(
+            f"Set the {CREDENTIAL_ENV} environment variable before converting or searching "
+            "with an OpenAI embedding model. In the desktop app, save it under "
+            "File > Settings → Embeddings."
+        )
+    return api_key
+
+
+def create_embedder(model_id: str, **config: Any) -> OpenAIEmbedder:
+    """Entry-point factory for ``vera.embedders`` provider ``openai``."""
+    options = OpenAIOptions.from_mapping(config)
+    model = (model_id or "").strip() or DEFAULT_MODEL_ID
+    base_url = os.environ.get(BASE_URL_ENV, "").strip() or DEFAULT_BASE_URL
+    return OpenAIEmbedder(
+        model,
+        api_key=_require_api_key(),
+        base_url=base_url,
+        batch_size=options.batch_size,
+        timeout=options.timeout,
+    )

--- a/packages/vera-embed-openai/tests/test_openai_embedder.py
+++ b/packages/vera-embed-openai/tests/test_openai_embedder.py
@@ -1,0 +1,276 @@
+"""Unit tests for the official OpenAI embeddings plugin."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from vera_doc import (
+    clear_embedder_cache,
+    describe_embedder,
+    get_embedder,
+    list_embedding_models,
+    preflight_embedder,
+)
+from vera_embed_openai import (
+    CREDENTIAL_ENV,
+    DEFAULT_MODEL_ID,
+    MAX_INPUT_TOKENS,
+    OpenAIEmbedder,
+    OpenAIEmbedderError,
+    OpenAIOptions,
+    create_embedder,
+    embeddings_url,
+    ensure_registered,
+    estimate_tokens,
+    iter_embed_batches,
+)
+
+
+def _response(vectors: list[list[float]], *, indexes: list[int] | None = None):
+    payload = {
+        "data": [
+            {"index": (indexes[i] if indexes else i), "embedding": vector}
+            for i, vector in enumerate(vectors)
+        ]
+    }
+    raw = json.dumps(payload).encode("utf-8")
+
+    class _Handle:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self) -> bytes:
+            return raw
+
+    return _Handle()
+
+
+@pytest.fixture
+def openai_key(monkeypatch):
+    monkeypatch.setenv(CREDENTIAL_ENV, "sk-test")
+    return "sk-test"
+
+
+def test_estimate_tokens_is_conservative():
+    assert estimate_tokens("") == 1
+    assert estimate_tokens("abcd") == 2
+    assert estimate_tokens("a" * 30) == 10
+
+
+def test_iter_embed_batches_splits_on_item_cap_and_token_budget():
+    texts = ["aa", "bb", "cc", "dd"]
+    batches = list(iter_embed_batches(texts, batch_size=2, max_request_tokens=1000))
+    assert batches == [["aa", "bb"], ["cc", "dd"]]
+
+    # Each "aaaaaa" is 2 tokens with the heuristic; budget 3 forces size 1.
+    longish = ["aaaaaa", "aaaaaa", "aaaaaa"]
+    token_batches = list(iter_embed_batches(longish, batch_size=10, max_request_tokens=3))
+    assert token_batches == [["aaaaaa"], ["aaaaaa"], ["aaaaaa"]]
+
+
+def test_iter_embed_batches_rejects_oversized_chunk():
+    huge = "a" * (MAX_INPUT_TOKENS * 3 + 3)
+    with pytest.raises(OpenAIEmbedderError, match="chunk 0"):
+        list(iter_embed_batches([huge], batch_size=8))
+
+
+def test_embeddings_url_joins_v1_and_embeddings():
+    assert embeddings_url("https://api.openai.com/v1") == "https://api.openai.com/v1/embeddings"
+    assert embeddings_url("https://api.openai.com") == "https://api.openai.com/v1/embeddings"
+    assert (
+        embeddings_url("https://example.test/v1/embeddings")
+        == "https://example.test/v1/embeddings"
+    )
+
+
+def test_constructor_does_not_touch_the_network(openai_key):
+    calls: list[object] = []
+
+    def boom(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("constructor must not call urlopen")
+
+    with patch("vera_embed_openai.provider.urllib.request.urlopen", boom):
+        embedder = create_embedder("text-embedding-3-small")
+    assert embedder.model_name == "openai:text-embedding-3-small"
+    assert embedder.dimension == 1536
+    assert embedder.normalization == "l2"
+    assert calls == []
+
+
+def test_known_model_dimensions_need_no_probe(openai_key):
+    small = OpenAIEmbedder(
+        "text-embedding-3-small",
+        api_key=openai_key,
+        base_url="https://api.openai.com/v1",
+        batch_size=8,
+        timeout=5,
+    )
+    large = OpenAIEmbedder(
+        "text-embedding-3-large",
+        api_key=openai_key,
+        base_url="https://api.openai.com/v1",
+        batch_size=8,
+        timeout=5,
+    )
+    ada = OpenAIEmbedder(
+        "text-embedding-ada-002",
+        api_key=openai_key,
+        base_url="https://api.openai.com/v1",
+        batch_size=8,
+        timeout=5,
+    )
+    assert small.dimension == 1536
+    assert large.dimension == 3072
+    assert ada.dimension == 1536
+
+
+def test_embed_normalizes_and_preserves_order(openai_key):
+    embedder = create_embedder("text-embedding-3-small", batch_size=8)
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(request, timeout=None):
+        captured["url"] = request.full_url
+        captured["timeout"] = timeout
+        body = json.loads(request.data.decode("utf-8"))
+        captured["payload"] = body
+        auth = request.headers.get("Authorization") or request.get_header("Authorization")
+        captured["authorization"] = auth
+        # Unnormalized, reversed indexes — client must L2-normalize and reorder.
+        return _response(
+            [[0.0, 3.0], [4.0, 0.0]],
+            indexes=[1, 0],
+        )
+
+    with patch("vera_embed_openai.provider.urllib.request.urlopen", fake_urlopen):
+        vectors = embedder.embed(["one", "two"])
+
+    assert captured["url"] == "https://api.openai.com/v1/embeddings"
+    assert captured["payload"] == {"model": "text-embedding-3-small", "input": ["one", "two"]}
+    assert str(captured["authorization"]).endswith("sk-test")
+    assert pytest.approx(float(np.linalg.norm(vectors[0])), abs=1e-5) == 1.0
+    assert pytest.approx(float(np.linalg.norm(vectors[1])), abs=1e-5) == 1.0
+    # After reorder, index 0 is [4,0] -> [1,0]; index 1 is [0,3] -> [0,1].
+    assert pytest.approx(float(vectors[0][0]), abs=1e-5) == 1.0
+    assert pytest.approx(float(vectors[1][1]), abs=1e-5) == 1.0
+
+
+def test_embed_splits_http_requests_on_batch_size(openai_key):
+    embedder = create_embedder("text-embedding-3-small", batch_size=2)
+    payloads: list[list[str]] = []
+
+    def fake_urlopen(request, timeout=None):
+        body = json.loads(request.data.decode("utf-8"))
+        payloads.append(list(body["input"]))
+        unit = [[1.0, 0.0] for _ in body["input"]]
+        return _response(unit)
+
+    with patch("vera_embed_openai.provider.urllib.request.urlopen", fake_urlopen):
+        vectors = embedder.embed(["a", "b", "c"])
+    assert payloads == [["a", "b"], ["c"]]
+    assert len(vectors) == 3
+
+
+def test_retries_on_429_then_succeeds(openai_key, monkeypatch):
+    embedder = create_embedder("text-embedding-3-small")
+    attempts = {"n": 0}
+
+    def fake_urlopen(request, timeout=None):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            import vera_embed_openai.provider as provider_mod
+
+            raise provider_mod.urllib.error.HTTPError(
+                request.full_url,
+                429,
+                "rate limited",
+                hdrs={"Retry-After": "0"},
+                fp=io.BytesIO(b'{"error":"slow down"}'),
+            )
+        return _response([[1.0, 0.0]])
+
+    monkeypatch.setattr("vera_embed_openai.provider.time.sleep", lambda _seconds: None)
+    with patch("vera_embed_openai.provider.urllib.request.urlopen", fake_urlopen):
+        vectors = embedder.embed(["hello"])
+    assert attempts["n"] == 2
+    assert vectors[0].shape == (2,)
+
+
+def test_http_error_includes_status_and_body(openai_key):
+    embedder = create_embedder("text-embedding-3-small")
+
+    def fake_urlopen(request, timeout=None):
+        import vera_embed_openai.provider as provider_mod
+
+        raise provider_mod.urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "bad request",
+            hdrs={},
+            fp=io.BytesIO(b'{"error":{"message":"max tokens"}}'),
+        )
+
+    with patch("vera_embed_openai.provider.urllib.request.urlopen", fake_urlopen):
+        with pytest.raises(OpenAIEmbedderError, match="HTTP 400") as exc:
+            embedder.embed(["hello"])
+    assert "max tokens" in str(exc.value)
+
+
+def test_missing_api_key_fails_in_factory(monkeypatch):
+    monkeypatch.delenv(CREDENTIAL_ENV, raising=False)
+    with pytest.raises(OpenAIEmbedderError, match="OPENAI_API_KEY"):
+        create_embedder("text-embedding-3-small")
+
+
+def test_options_validate_bounds():
+    options = OpenAIOptions.from_mapping({"batch_size": 16, "timeout": 30})
+    assert options.batch_size == 16
+    assert options.timeout == 30
+    with pytest.raises(ValueError, match="batch_size"):
+        OpenAIOptions.from_mapping({"batch_size": 0})
+    with pytest.raises(ValueError, match="timeout"):
+        OpenAIOptions.from_mapping({"timeout": 0})
+
+
+def test_ensure_registered_descriptor_and_preflight(monkeypatch, openai_key):
+    ensure_registered()
+    try:
+        descriptor = describe_embedder("openai")
+        assert descriptor.provider == "openai"
+        assert descriptor.capabilities.credential_env == CREDENTIAL_ENV
+        assert descriptor.capabilities.requires_api_key is True
+        models = list_embedding_models("openai")
+        assert any(item.model_id == DEFAULT_MODEL_ID for item in models)
+        assert preflight_embedder("openai:text-embedding-3-small").ok is True
+        monkeypatch.delenv(CREDENTIAL_ENV, raising=False)
+        failed = preflight_embedder("openai:text-embedding-3-large")
+        assert failed.ok is False
+        assert failed.missing_credential_env == CREDENTIAL_ENV
+        monkeypatch.setenv(CREDENTIAL_ENV, openai_key)
+        embedder = get_embedder("openai:text-embedding-3-small")
+        assert embedder.model_name == "openai:text-embedding-3-small"
+        assert embedder.dimension == 1536
+    finally:
+        clear_embedder_cache()
+
+
+def test_unknown_model_probes_dimension_lazily(openai_key):
+    calls = {"n": 0}
+
+    def fake_urlopen(request, timeout=None):
+        calls["n"] += 1
+        return _response([[0.6, 0.8]])
+
+    embedder = create_embedder("text-embedding-custom")
+    assert calls["n"] == 0
+    with patch("vera_embed_openai.provider.urllib.request.urlopen", fake_urlopen):
+        assert embedder.dimension == 2
+    assert calls["n"] == 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "vera-ingest",
   "vera-ingest-pymupdf",
   "vera-cli",
+  "vera-embed-openai",
 ]
 authors = [{name = "Kyle Willis"}]
 license = {text = "Apache-2.0"}
@@ -45,6 +46,7 @@ members = [
   "packages/vera-ingest-docling",
   "packages/vera-mcp",
   "packages/vera-cli",
+  "packages/vera-embed-openai",
   "packages/vera-app",
   "packages/vera-lab",
 ]
@@ -56,6 +58,7 @@ vera-ingest-pymupdf = { workspace = true }
 vera-ingest-docling = { workspace = true }
 vera-mcp = { workspace = true }
 vera-cli = { workspace = true }
+vera-embed-openai = { workspace = true }
 vera-app = { workspace = true }
 vera-lab = { workspace = true }
 
@@ -90,6 +93,7 @@ known-first-party = [
   "vera_ingest_pymupdf",
   "vera_ingest_docling",
   "vera_cli",
+  "vera_embed_openai",
   "vera_mcp",
   "vera_app",
   "vera_lab",
@@ -115,6 +119,7 @@ pythonpath = [
   "packages/vera-ingest-docling/src",
   "packages/vera-mcp/src",
   "packages/vera-cli/src",
+  "packages/vera-embed-openai/src",
   "packages/vera-app/src",
   "packages/vera-lab/src",
   "tests",
@@ -126,6 +131,7 @@ testpaths = [
   "packages/vera-ingest-pymupdf/tests",
   "packages/vera-ingest-docling/tests",
   "packages/vera-cli/tests",
+  "packages/vera-embed-openai/tests",
   "packages/vera-mcp/tests",
   "packages/vera-app/tests",
   "packages/vera-lab/tests",

--- a/skills/vera/SKILL.md
+++ b/skills/vera/SKILL.md
@@ -152,7 +152,10 @@ commands write or replace local files and require normal user authorization:
   Sentence Transformers. Use `vera-doc[ml]` for other Sentence Transformers
   models (or for MiniLM only when the `onnx` extra is absent). The
   0.3.0 packaged desktop app converts with PyMuPDF only; Docling is the
-  `vera-cli[docling]` extra, not Advanced layout in Convert.
+  `vera-cli[docling]` extra, not Advanced layout in Convert. OpenAI embeddings
+  ship with `vera-cli` as `vera-embed-openai`; set `OPENAI_API_KEY`. Hashing
+  remains the default. Archives converted with OpenAI are not portable for
+  semantic search.
 - `convert --overwrite` replaces existing batch outputs.
 - `index build` and `index update` write `.vera-index/` and delete previous
   generation directories after a successful publish.

--- a/skills/vera/references/cli-reference.md
+++ b/skills/vera/references/cli-reference.md
@@ -40,6 +40,10 @@ Options:
   Transformers. Other Sentence Transformers models need the `ml` extra. The
   Windows desktop installer vendors a VERA-exported `all-MiniLM-L6-v2` ONNX
   graph. Archive identity stays `sentence-transformers/all-MiniLM-L6-v2`.
+  OpenAI embeddings ship with `vera-cli` as `vera-embed-openai`
+  (`openai:text-embedding-3-small` / `-large`); set `OPENAI_API_KEY`. Archives
+  converted with OpenAI are not portable for semantic search. Voyage and
+  Ollama are not bundled.
 - `--parser PARSER` defaults to `pymupdf`. Accepts ingest pipeline specs
   `provider[:variant]` (requires `vera-ingest-pymupdf` for the default; for
   example `docling` or `docling:hybrid` when `vera-ingest-docling` is

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -408,6 +408,15 @@ def test_hardening_json_contracts_are_documented():
         encoding="utf-8"
     )
     assert "_warmup_sentence_transformers" not in sidecar_py
+    assert "vera-embed-openai" in main_ts
+    assert "OPENAI_API_KEY" in main_ts
+    assert "vera-embed-openai" in sidecar_build
+    assert "vera_embed_openai" in sidecar_build
+    assert 'embedderNames.includes("openai")' in verify_sidecar
+    assert "ensure_openai_embedder_registered" in sidecar_py
+    assert "ensure_registered" in (
+        ROOT / "packages" / "vera-embed-openai" / "src" / "vera_embed_openai" / "__init__.py"
+    ).read_text(encoding="utf-8")
     export_src = (ROOT / "packages" / "vera-app" / "scripts" / "export_minilm_onnx.py").read_text(
         encoding="utf-8"
     )
@@ -442,6 +451,8 @@ def test_hardening_json_contracts_are_documented():
     assert "ensure_registered" in (
         ROOT / "packages" / "vera-ingest-pymupdf" / "src" / "vera_ingest_pymupdf" / "__init__.py"
     ).read_text(encoding="utf-8")
+    publish_pypi = (ROOT / ".github" / "workflows" / "publish-pypi.yml").read_text(encoding="utf-8")
+    assert "vera-embed-openai" in publish_pypi
     assert "PyMuPDF ingest pipeline" in desktop
     assert "ingest_pipeline" in desktop
     assert "vera-ingest-docling" in conversion or "docling:hybrid" in conversion
@@ -451,6 +462,16 @@ def test_hardening_json_contracts_are_documented():
     assert "File > Settings" in desktop
     assert "Hugging Face" in (DOCS / "packages" / "vera-app.md").read_text(encoding="utf-8")
     assert "File > Settings" in (DOCS / "packages" / "vera-app.md").read_text(encoding="utf-8")
+    assert "Settings → Embeddings" in (DOCS / "packages" / "vera-app.md").read_text(encoding="utf-8")
+    assert "not portable" in conversion
+    assert "vera-embed-openai" in conversion
+    assert "OPENAI_API_KEY" in conversion
+    assert "Settings → Embeddings" in desktop
+    assert "vera-embed-openai" in (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "dimension probe" not in guide
+    assert "from openai import OpenAI" not in guide
+    assert "vera-embed-openai" in guide
+    assert "Do not call the network from `__init__`" in guide
     assert "Advanced pipeline options" in (DOCS / "packages" / "vera-app.md").read_text(
         encoding="utf-8"
     )
@@ -462,6 +483,7 @@ def test_hardening_json_contracts_are_documented():
     assert "IngestRequest" in python_api
     assert "may change before 1.0" in python_api
     assert "not bundled" in python_api
+    assert "vera-embed-openai" in python_api
     assert "register_ingest_pipeline" in python_api
     assert "register_embedder" in python_api
     assert "may change before 1.0" in ingest_guide
@@ -472,6 +494,7 @@ def test_hardening_json_contracts_are_documented():
     assert "clamp `overlap` to `chunk_size - 1`" in ingest_guide
     assert "may change before 1.0" in guide
     assert "not bundled" in guide
+    assert "vera-embed-openai" in guide
     assert "Plugin load errors:" in guide
     ingest_pkg = (DOCS / "packages" / "vera-ingest.md").read_text(encoding="utf-8")
     assert "register_ingest_pipeline" in ingest_pkg

--- a/tests/test_package_boundaries.py
+++ b/tests/test_package_boundaries.py
@@ -67,6 +67,7 @@ def test_sibling_packages_do_not_import_vera_doc_private_modules() -> None:
         ROOT / "packages" / "vera-ingest-pymupdf" / "src",
         ROOT / "packages" / "vera-ingest-docling" / "src",
         ROOT / "packages" / "vera-cli" / "src",
+        ROOT / "packages" / "vera-embed-openai" / "src",
         ROOT / "packages" / "vera-mcp" / "src",
         ROOT / "packages" / "vera-app" / "src",
         ROOT / "packages" / "vera-lab" / "src",

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ members = [
     "vera-app",
     "vera-cli",
     "vera-doc",
+    "vera-embed-openai",
     "vera-ingest",
     "vera-ingest-docling",
     "vera-ingest-pymupdf",
@@ -4787,6 +4788,7 @@ version = "0.3.0"
 source = { editable = "packages/vera-app" }
 dependencies = [
     { name = "vera-doc", extra = ["onnx"] },
+    { name = "vera-embed-openai" },
     { name = "vera-ingest" },
     { name = "vera-ingest-pymupdf" },
 ]
@@ -4794,6 +4796,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "vera-doc", extras = ["onnx"], editable = "packages/vera-doc" },
+    { name = "vera-embed-openai", editable = "packages/vera-embed-openai" },
     { name = "vera-ingest", editable = "packages/vera-ingest" },
     { name = "vera-ingest-pymupdf", editable = "packages/vera-ingest-pymupdf" },
 ]
@@ -4804,6 +4807,7 @@ version = "0.3.0"
 source = { editable = "packages/vera-cli" }
 dependencies = [
     { name = "vera-doc" },
+    { name = "vera-embed-openai" },
     { name = "vera-ingest" },
     { name = "vera-ingest-pymupdf" },
 ]
@@ -4819,6 +4823,7 @@ mcp = [
 [package.metadata]
 requires-dist = [
     { name = "vera-doc", editable = "packages/vera-doc" },
+    { name = "vera-embed-openai", editable = "packages/vera-embed-openai" },
     { name = "vera-ingest", editable = "packages/vera-ingest" },
     { name = "vera-ingest-docling", marker = "extra == 'docling'", editable = "packages/vera-ingest-docling" },
     { name = "vera-ingest-pymupdf", editable = "packages/vera-ingest-pymupdf" },
@@ -4855,6 +4860,22 @@ requires-dist = [
     { name = "tokenizers", marker = "extra == 'onnx'", specifier = ">=0.15" },
 ]
 provides-extras = ["ml", "onnx"]
+
+[[package]]
+name = "vera-embed-openai"
+version = "0.3.0"
+source = { editable = "packages/vera-embed-openai" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "vera-doc" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = ">=1.24" },
+    { name = "vera-doc", editable = "packages/vera-doc" },
+]
 
 [[package]]
 name = "vera-ingest"
@@ -4938,6 +4959,7 @@ source = { editable = "." }
 dependencies = [
     { name = "vera-cli" },
     { name = "vera-doc" },
+    { name = "vera-embed-openai" },
     { name = "vera-ingest" },
     { name = "vera-ingest-pymupdf" },
 ]
@@ -4996,6 +5018,7 @@ requires-dist = [
     { name = "vera-cli", editable = "packages/vera-cli" },
     { name = "vera-doc", editable = "packages/vera-doc" },
     { name = "vera-doc", extras = ["onnx"], marker = "extra == 'onnx'", editable = "packages/vera-doc" },
+    { name = "vera-embed-openai", editable = "packages/vera-embed-openai" },
     { name = "vera-ingest", editable = "packages/vera-ingest" },
     { name = "vera-ingest-docling", marker = "extra == 'docling'", editable = "packages/vera-ingest-docling" },
     { name = "vera-ingest-pymupdf", editable = "packages/vera-ingest-pymupdf" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `vera-embed-openai`, an official `vera.embedders` plugin that talks to the OpenAI embeddings API with stdlib `urllib` (no OpenAI SDK).
- `vera-cli` and `vera-app` depend on it the same way they depend on PyMuPDF. The frozen sidecar registers it via `ensure_registered()`, copies package metadata, and `verify-packaged-sidecar` requires the `openai` provider.
- Desktop **File > Settings → Embeddings** stores `OPENAI_API_KEY` through the existing encrypted env-secret IPC. Convert presets include `openai:text-embedding-3-small` and `-large`. Hashing remains the default.
- Constructor does not touch the network (static dimension table). Batching is token-aware inside the plugin. Secrets stay in `OPENAI_API_KEY`.
- Archives converted with OpenAI are **not portable for semantic search**; keyword search still works. Voyage and Ollama stay on the roadmap until `EmbeddingFunction` can hint query vs document.

[Convert embedding presets including OpenAI](https://cursor.com/agents/bc-07aa35ac-4f41-4a3c-8970-7fc79c7d9591/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconvert_openai_presets_dropdown.webp)
[Settings Embeddings OPENAI_API_KEY](https://cursor.com/agents/bc-07aa35ac-4f41-4a3c-8970-7fc79c7d9591/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_embeddings_openai_key.webp)

## Test plan

- [x] Relevant automated tests pass (`uv run --extra dev python -m pytest -q`, `npm --prefix packages/vera-app run test:unit`, `npm run app:typecheck`).
- [x] Retrieval baselines were checked when search behavior changed. (Search still resolves `get_embedder(stored_model_name)`; no ranking change. Hosted archives skip semantic groups without a key.)
- [x] No live OpenAI API calls in CI (HTTP is mocked).
- [x] Desktop Convert presets and Settings → Embeddings exercised in `app:dev`.

## Documentation

- [x] User-visible behavior is documented in the README or relevant `docs/`
      guide.
- [x] CLI/API/MCP references and examples reflect public contract changes.
- [x] `skills/vera/` reflects agent-facing behavior changes.
- [x] Documentation-contract tests were updated when commands, options, JSON,
      exit codes, links, or documented workflows changed.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07aa35ac-4f41-4a3c-8970-7fc79c7d9591?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07aa35ac-4f41-4a3c-8970-7fc79c7d9591&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

