### PR TITLE
Add vera get to fetch a stored chunk by id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,9 @@ vera figures manual.vera --out-dir ./figures --json
 # What's in this file?
 vera inspect manual.vera --json
 
+# Fetch one stored chunk by id (citation-ready text, no score)
+vera get manual.vera chunk_0042 --json
+
 # Is this file well-formed? (exit code 0 = valid, 1 = invalid)
 vera validate manual.vera --json
 
@@ -140,12 +143,15 @@ dimension-incompatible. Result order is the rank; the CLI does not emit a
    origin top-left). Markdown hits use `{kind: "text_span", start, end}` line/column
    locators instead of page bounding boxes.
 6. **Check exit codes.** Parse stdout as JSON on exit 0. `validate`, `index status`,
-   `eval`, a failed `export`, a failed `figures`, and a failed `convert` can also print a structured JSON
+   `eval`, a failed `export`, a failed `figures`, a failed `get`, and a failed `convert` can also print a structured JSON
    report on exit 1; `convert --json` uses the same `{ok, error}` object on exit 2
    for an unknown `--parser` / `--model`. Most other missing-path/runtime errors
    instead write an unstructured traceback to stderr.
 7. **Don't read the SQLite file directly** unless the CLI is unavailable — the schema
    is documented in the spec, but the CLI/MCP tools are the stable interface.
+8. **Reload a known `chunk_id` with `vera get`** when you need the stored chunk body
+   or to verify that a quoted span is still in `text`. Searching again is not a
+   substitute: rank can change, and keyword search can miss a short quote.
 
 For the complete reusable workflow, load [skills/vera/SKILL.md](skills/vera/SKILL.md).
 Its [CLI reference](skills/vera/references/cli-reference.md) documents every flag,
@@ -166,6 +172,7 @@ VERA ships an MCP server (stdio) exposing the same capabilities as tools:
 | `vera_figures` | List figures/images with captions, optionally by page range |
 | `vera_get_figure` | Fetch one stored figure as native image content plus citation metadata |
 | `vera_get_page` | Full text of a specific page |
+| `vera_get_chunk` | Fetch one stored chunk by id as citation-ready JSON |
 | `vera_get_chunk_regions` | Page numbers + bounding boxes a chunk's text came from (visual grounding) |
 
 Requires the integration package: `pip install "vera-cli[mcp]"` or `pip install vera-mcp`. Example VS Code config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
 
 ### Added
 
+- `vera get FILE CHUNK_ID` fetches one stored chunk by id as citation-ready
+  JSON (`ok`, locator fields, `chunk_id`, `text`, and the same citation keys
+  as a search hit, without `score`). `--figures` and `--regions` match search
+  enrichment. An unknown or whitespace-only id exits 1 with
+  `{"ok": false, "error": "chunk not found: ..."}`. MCP `vera_get_chunk` returns
+  the same object. Shared `vera_ingest.viewer.chunk_payload()` flattens a
+  `ChunkRecord`; `result_payload()` layers retrieval scores on top.
+
 - Markdown ingest: `vera convert notes.md` (and directory discovery of `.md` /
   `.markdown`) uses a bundled `markdown` pipeline in `vera-ingest`. Convert
   selects a pipeline from the file extension when `--parser` is omitted.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ full command surface is scriptable by agents and applications:
 | `vera search` | Hybrid, semantic, or keyword search over a file or a folder-as-corpus |
 | `vera index` | Build, update, and check a persistent library index over many archives |
 | `vera inspect` | Report pages, chunks, embedding model, parser, and archive metadata |
+| `vera get` | Fetch one stored chunk by id as citation-ready JSON |
 | `vera validate` | Verify schema, hashes, embeddings, and index integrity |
 | `vera export` | Recover the original source document from the archive |
 | `vera figures` | List stored figures, or write their image files to a directory |
@@ -136,6 +137,9 @@ vera search manual.vera "pipe sizing chart" --json --context-chunks 1 --figures 
 # Keyword mode for exact phrases and section numbers; semantic for paraphrases
 vera search manual.vera "section 4.2" --mode keyword
 vera search manual.vera "how big should the pond be" --mode semantic
+
+# Reload a stored chunk by id (same citation fields as a search hit, no score)
+vera get manual.vera chunk_0042 --json
 
 # Batch-convert a nested PDF library, then measure retrieval quality
 vera convert ./proposals --recursive --json
@@ -165,12 +169,12 @@ real-world regulatory queries at MRR 0.900, tracked with
 Three integration surfaces share the same retrieval engine:
 
 - **CLI with `--json`** — any agent that can run shell commands can convert,
-  search, inspect, and validate archives. This repository's own
+  search, inspect, get a chunk by id, and validate archives. This repository's own
   [AGENTS.md](AGENTS.md) teaches coding agents the workflow.
 - **MCP server** — `vera mcp` exposes `vera_search`, `vera_corpus_search`,
   `vera_inspect`, `vera_validate`, `vera_figures`, `vera_get_figure`,
-  `vera_get_page`, and `vera_get_chunk_regions` as tools over stdio. Works with
-  any MCP client; see [Connect an MCP client](docs/mcp.md).
+  `vera_get_page`, `vera_get_chunk`, and `vera_get_chunk_regions` as tools over
+  stdio. Works with any MCP client; see [Connect an MCP client](docs/mcp.md).
 - **Agent Skill** — a portable [SKILL.md](skills/vera/SKILL.md) package with a
   complete [CLI reference](skills/vera/references/cli-reference.md) that drops
   into Agent-Skills-compatible tools (Cursor and others). See

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -6,6 +6,7 @@ parser.
 ```text
 vera convert
 vera inspect
+vera get
 vera search
 vera index build
 vera index update
@@ -93,6 +94,23 @@ OCR diagnostics, and attachment count when recorded. Normalization is `l2`,
 
 Options: `--json`. JSON includes `file` (the requested path) and `path` (the
 opened archive).
+
+## `vera get FILE CHUNK_ID`
+
+Fetch one stored chunk by exact id from a single `.vera` archive. `CHUNK_ID`
+is case-sensitive; there is no prefix match or directory/corpus lookup.
+
+Options:
+
+- `--json`
+- `--figures`
+- `--regions`
+
+JSON is one object with `ok`, `file`, `path`, `chunk_id`, `text`, and the same
+citation fields as a search hit (`page_start`, `page_end`, `heading_path`,
+`source_filename`, `document_id`). It does not include `score`. `--figures` and
+`--regions` add the same metadata shapes as `vera search`. An unknown or
+whitespace-only id exits 1 with `{"ok": false, "error": "chunk not found: ..."}`.
 
 ## `vera search FILE_OR_DIRECTORY QUERY`
 
@@ -242,6 +260,7 @@ Do not assume nonzero output is unstructured:
 - `export` returns an error object when no source is stored;
 - `figures` returns an error object when a requested `--asset-id` is missing
   or is not a figure attachment;
+- `get` returns an error object when the chunk id is missing from the archive;
 - `convert` returns `{"ok": false, "error": "..."}` when extraction or
   validation fails, the input path is missing, or an OpenAI embedder fails
   (missing `OPENAI_API_KEY`, HTTP errors) (exit 1), or `--parser` /

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,7 +10,8 @@ vera convert "ordinance.pdf" "ordinance.vera" --model hashing
 vera convert "notes.md" "notes.vera" --model hashing
 vera inspect "ordinance.vera"
 vera validate "ordinance.vera"
-vera search "ordinance.vera" "minimum parking required for restaurant" --mode hybrid --top-k 5
+vera search "ordinance.vera" "minimum parking required for restaurant" --mode hybrid --top-k 5 --json
+vera get "ordinance.vera" "chunk_0001" --json
 ```
 
 ## Convert a scanned PDF

--- a/docs/figures-and-regions.md
+++ b/docs/figures-and-regions.md
@@ -210,6 +210,7 @@ MCP clients can use:
 - `vera_figures` to list figures in an optional page range (metadata only);
 - `vera_get_figure` to fetch one stored raster as native image content by
   `asset_id`;
+- `vera_get_chunk` to fetch one stored chunk by id as citation-ready JSON;
 - `vera_get_chunk_regions` to resolve one chunk ID.
 
 See [MCP integration](mcp.md).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -149,6 +149,21 @@ Parameters:
 Returns the full stored page text and dimensions. A missing page returns an
 `error` object rather than `null`.
 
+### `vera_get_chunk`
+
+Parameters:
+
+- `file: str`
+- `chunk_id: str`
+- `include_figures: bool = false`
+- `include_regions: bool = false`
+
+Returns one stored chunk as citation-ready JSON, matching
+`vera get FILE CHUNK_ID --json` (`ok`, `file`, `path`, `chunk_id`, `text`,
+and citation fields; no `score`). A missing or whitespace-only id returns
+`{"ok": false, "error": "chunk not found: ..."}` rather than raising. This
+differs from `vera_get_page`, which returns `{"error": "..."}` without `ok`.
+
 ### `vera_get_chunk_regions`
 
 Parameters:
@@ -162,6 +177,8 @@ Returns block-granular source bounding boxes for visual grounding.
 
 - Start with hybrid search and five results.
 - Cite `source_filename`, page or page range, and heading path.
+- Reload a known `chunk_id` with `vera_get_chunk` when verifying a quote or
+  when you need the stored chunk body rather than a search hit.
 - Use context chunks when a result references nearby definitions or exceptions.
 - Request figures for charts, diagrams, maps, and captions (`include_figures`
   or `vera_figures`). Call `vera_get_figure` with an `asset_id` when you need
@@ -185,7 +202,8 @@ MCP focuses on read-only document access. It does not expose tools for:
 Use the CLI or Python API for those operations.
 
 MCP adds `vera_get_page` and `vera_get_chunk_regions`, which have no
-standalone CLI subcommands. `vera_figures` listing matches `vera figures`;
+standalone CLI subcommands. `vera_get_chunk` matches `vera get`.
+`vera_figures` listing matches `vera figures`;
 `vera_get_figure` is the MCP way to return image content (the CLI writes files
 with `vera figures --out-dir` instead).
 

--- a/docs/packages/vera-cli.md
+++ b/docs/packages/vera-cli.md
@@ -41,6 +41,7 @@ vera --help
 vera convert "manual.pdf" "manual.vera"
 vera validate "manual.vera"
 vera search "manual.vera" "detention requirements" --top-k 5 --json
+vera get "manual.vera" "chunk_0042" --json
 vera figures "manual.vera" --out-dir "./figures" --json
 ```
 

--- a/docs/packages/vera-mcp.md
+++ b/docs/packages/vera-mcp.md
@@ -35,7 +35,7 @@ output to stdout.
 
 - [MCP setup and client configuration](../mcp.md#configure-a-client).
 - [MCP tools](../mcp.md#tools) — search, corpus search, inspect, validate,
-  figures, figure image fetch, pages, and regions.
+  figures, figure image fetch, pages, chunk fetch, and regions.
 - [Recommended agent behavior](../mcp.md#recommended-agent-behavior).
 - [Portable Agent Skill](../agent-skills.md).
 - [MCP troubleshooting](../mcp.md#troubleshooting).

--- a/docs/reference/vera-ingest.md
+++ b/docs/reference/vera-ingest.md
@@ -38,6 +38,7 @@ conversion to `.vera` archives. PDF parsing/OCR live in plugins such as
         - get_blocks
         - get_chunk_regions
         - regions_for
+        - chunk_payload
         - result_payload
         - get_source_document
         - export_figures

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -97,6 +97,12 @@ source filename, page or page range, and heading when available:
 (manual.pdf, p. 117, Chapter 4 > Detention Design)
 ```
 
+To reload one stored chunk by id — for example to verify that a quoted span is
+still in the chunk body — use `vera get FILE CHUNK_ID --json` (MCP:
+`vera_get_chunk`). Searching again is not a substitute: rank can change, and
+keyword search can miss a short quote. `get` returns the same citation fields
+as a search hit, without `score`.
+
 ## Include neighboring chunks
 
 A result may begin after a definition or end before an exception. Include

--- a/packages/vera-cli/src/vera_cli/commands.py
+++ b/packages/vera-cli/src/vera_cli/commands.py
@@ -4,7 +4,7 @@ import json
 import sys
 from pathlib import Path
 
-from vera_doc import UnknownEmbeddingModelError
+from vera_doc import Citation, UnknownEmbeddingModelError
 from vera_doc.collection import build_library_index, library_index_status, update_library_index
 from vera_doc.corpus import VeraCorpus
 from vera_doc.document import VeraDocument
@@ -20,6 +20,7 @@ from vera_ingest import (
     convert,
 )
 from vera_ingest.viewer import (
+    chunk_payload,
     ensure_requested_figures,
     export_figures,
     export_source_document,
@@ -190,6 +191,56 @@ def cmd_inspect(args) -> int:
         print(f"Embedding normalization: {info.get('default_embedding_normalization', 'unknown')}")
         print(f"Parser: {info.get('parser_name')}")
         print(f"Created: {info.get('created_at')}")
+    finally:
+        doc.close()
+    return 0
+
+
+def _chunk_not_found_message(chunk_id: str) -> str:
+    return f"chunk not found: {chunk_id}"
+
+
+def _emit_get_error(args, message: str) -> int:
+    if args.json:
+        print(json.dumps({"ok": False, "error": message}))
+    else:
+        print(message, file=sys.stderr)
+    return 1
+
+
+def cmd_get(args) -> int:
+    chunk_id = args.chunk_id
+    if not str(chunk_id).strip():
+        return _emit_get_error(args, _chunk_not_found_message(chunk_id))
+
+    doc = VeraDocument.open(args.file)
+    try:
+        try:
+            records = doc.get(ids=[chunk_id])
+            if not records:
+                return _emit_get_error(args, _chunk_not_found_message(chunk_id))
+            payload = chunk_payload(
+                records[0],
+                document=doc,
+                include_figures=args.figures,
+                include_regions=args.regions,
+            )
+        except ValueError as exc:
+            return _emit_get_error(args, str(exc))
+        if args.json:
+            print(json.dumps({"ok": True, **_archive_locator(args.file, doc), **payload}))
+            return 0
+        citation = Citation.from_metadata(records[0].metadata)
+        print(f"Source: {citation.source_filename}")
+        page = (
+            citation.page_start
+            if citation.page_start == citation.page_end
+            else f"{citation.page_start}-{citation.page_end}"
+        )
+        print(f"Page: {page}")
+        print(f"Heading: {citation.heading_path or ''}")
+        print()
+        print(records[0].text)
     finally:
         doc.close()
     return 0

--- a/packages/vera-cli/src/vera_cli/main.py
+++ b/packages/vera-cli/src/vera_cli/main.py
@@ -7,6 +7,7 @@ from .commands import (
     cmd_eval,
     cmd_export,
     cmd_figures,
+    cmd_get,
     cmd_index_build,
     cmd_index_status,
     cmd_index_update,
@@ -185,6 +186,20 @@ def build_parser() -> argparse.ArgumentParser:
     inspect_p.add_argument("file")
     inspect_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     inspect_p.set_defaults(func=cmd_inspect)
+
+    get_p = sub.add_parser("get", help="Fetch one chunk by id from a VERA file")
+    get_p.add_argument("file", help="Path to a .vera file")
+    get_p.add_argument("chunk_id", help="Exact chunk id (case-sensitive)")
+    get_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    get_p.add_argument(
+        "--figures", action="store_true", help="Include figure metadata/captions in --json output"
+    )
+    get_p.add_argument(
+        "--regions",
+        action="store_true",
+        help="Include page/bbox highlight regions in --json output",
+    )
+    get_p.set_defaults(func=cmd_get)
 
     search_p = sub.add_parser(
         "search", help="Search a VERA file, or a directory of VERA files as one corpus"

--- a/packages/vera-cli/tests/test_cli.py
+++ b/packages/vera-cli/tests/test_cli.py
@@ -817,3 +817,176 @@ def test_cli_figures_missing_asset_id_exits_1(tmp_path):
         "ok": False,
         "error": "Figure 'image_block_missing' was not found",
     }
+
+
+def test_cli_get_round_trips_search_hit(tmp_path):
+    pdf = tmp_path / "manual.pdf"
+    out = tmp_path / "manual.vera"
+    make_pdf(pdf)
+    converted = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vera_cli",
+            "convert",
+            str(pdf),
+            str(out),
+            "--model",
+            "hashing",
+            "--json",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert json.loads(converted.stdout)["ok"] is True
+
+    searched = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vera_cli",
+            "search",
+            str(out),
+            "restaurant parking",
+            "--mode",
+            "keyword",
+            "--top-k",
+            "1",
+            "--json",
+            "--regions",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    hit = json.loads(searched.stdout)["results"][0]
+    chunk_id = hit["chunk_id"]
+    assert "parking" in hit["text"].lower()
+
+    fetched = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vera_cli",
+            "get",
+            str(out),
+            chunk_id,
+            "--json",
+            "--regions",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(fetched.stdout)
+    assert payload["ok"] is True
+    assert payload["file"] == str(out)
+    assert Path(payload["path"]).resolve() == out.resolve()
+    assert payload["chunk_id"] == chunk_id
+    assert payload["text"] == hit["text"]
+    assert "parking" in payload["text"].lower()
+    assert "score" not in payload
+    assert "semantic_score" not in payload
+    assert "keyword_score" not in payload
+    for key in ("page_start", "page_end", "heading_path", "source_filename", "document_id"):
+        assert payload.get(key) == hit.get(key)
+    assert payload.get("regions") == hit.get("regions")
+
+    human = subprocess.run(
+        [sys.executable, "-m", "vera_cli", "get", str(out), chunk_id],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "Score:" not in human.stdout
+    assert "parking" in human.stdout.lower()
+    assert "Source:" in human.stdout
+    assert "Page:" in human.stdout
+    assert "Heading:" in human.stdout
+
+
+def test_cli_get_unknown_id_exits_1(tmp_path):
+    pdf = tmp_path / "manual.pdf"
+    out = tmp_path / "manual.vera"
+    make_pdf(pdf)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vera_cli",
+            "convert",
+            str(pdf),
+            str(out),
+            "--model",
+            "hashing",
+            "--json",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    missing = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vera_cli",
+            "get",
+            str(out),
+            "chunk_zzzz",
+            "--json",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(missing.stdout)
+    assert missing.returncode == 1
+    assert payload == {"ok": False, "error": "chunk not found: chunk_zzzz"}
+    assert "Traceback" not in missing.stderr
+    assert missing.stderr == ""
+
+    human = subprocess.run(
+        [sys.executable, "-m", "vera_cli", "get", str(out), "chunk_zzzz"],
+        text=True,
+        capture_output=True,
+    )
+    assert human.returncode == 1
+    assert "chunk not found: chunk_zzzz" in human.stderr
+    assert "Traceback" not in human.stderr
+    assert human.stdout == ""
+
+
+def test_cli_get_directory_is_unsupported(tmp_path):
+    directory = tmp_path / "library"
+    directory.mkdir()
+    missing = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vera_cli",
+            "get",
+            str(directory),
+            "chunk_0001",
+            "--json",
+        ],
+        text=True,
+        capture_output=True,
+    )
+    assert missing.returncode == 1
+    assert "ok" not in (missing.stdout or "")
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(missing.stdout or "")
+    assert "FileNotFoundError" in missing.stderr or "Traceback" in missing.stderr
+
+
+def test_cli_get_whitespace_chunk_id_exits_1():
+    missing = subprocess.run(
+        [sys.executable, "-m", "vera_cli", "get", "missing.vera", "   ", "--json"],
+        text=True,
+        capture_output=True,
+    )
+    payload = json.loads(missing.stdout)
+    assert missing.returncode == 1
+    assert payload["ok"] is False
+    assert payload["error"].startswith("chunk not found:")
+    assert "Traceback" not in missing.stderr

--- a/packages/vera-ingest/src/vera_ingest/__init__.py
+++ b/packages/vera-ingest/src/vera_ingest/__init__.py
@@ -50,6 +50,7 @@ from .types import (
     ensure_ingest_request,
 )
 from .viewer import (
+    chunk_payload,
     export_figures,
     export_source_document,
     figures,
@@ -82,6 +83,7 @@ __all__ = [
     "batch_convert",
     "build_chunks_from_blocks",
     "chunk_pages",
+    "chunk_payload",
     "clear_ingest_pipeline_cache",
     "convert",
     "describe_ingest_pipeline",

--- a/packages/vera-ingest/src/vera_ingest/viewer.py
+++ b/packages/vera-ingest/src/vera_ingest/viewer.py
@@ -79,7 +79,8 @@ def result_payload(
 
     Optional figure and region enrichment uses ingest viewer helpers. Sidecar
     callers can set ``figure_data_urls`` to replace raw figure bytes with a
-    ``data_url`` instead of forking the serializer.
+    ``data_url`` instead of forking the serializer. Extra ``as_dict()`` keys such
+    as corpus ``file`` are preserved.
     """
     payload = chunk_payload(
         result.record,
@@ -89,18 +90,13 @@ def result_payload(
         include_figure_data=include_figure_data,
         figure_data_urls=figure_data_urls,
     )
-    payload["score"] = result.score
-    if result.semantic_score is not None:
-        payload["semantic_score"] = result.semantic_score
-    if result.keyword_score is not None:
-        payload["keyword_score"] = result.keyword_score
-    if result.before or result.after:
-        payload["before_chunks"] = [
-            {**item.pop("metadata", {}), **item} for item in result.before_chunks
-        ]
-        payload["after_chunks"] = [
-            {**item.pop("metadata", {}), **item} for item in result.after_chunks
-        ]
+    data = result.as_dict()
+    data.pop("metadata", None)
+    for key in ("before_chunks", "after_chunks"):
+        items = data.pop(key, None)
+        if items is not None:
+            payload[key] = [{**item.pop("metadata", {}), **item} for item in items]
+    payload.update(data)
     return payload
 
 

--- a/packages/vera-ingest/src/vera_ingest/viewer.py
+++ b/packages/vera-ingest/src/vera_ingest/viewer.py
@@ -18,7 +18,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
-from vera_doc import AttachmentRecord, QueryResult, VeraDocument
+from vera_doc import AttachmentRecord, ChunkRecord, QueryResult, VeraDocument
 from vera_doc.models import thaw_json
 
 
@@ -28,6 +28,42 @@ def get_source_document(document: VeraDocument) -> AttachmentRecord:
     if not attachment_id:
         raise ValueError("Original source document is not stored in this archive")
     return document.get_attachment(str(attachment_id))
+
+
+def chunk_payload(
+    record: ChunkRecord,
+    *,
+    document: VeraDocument | None = None,
+    include_figures: bool = False,
+    include_regions: bool = False,
+    include_figure_data: bool = False,
+    figure_data_urls: bool = False,
+) -> dict[str, Any]:
+    """Flatten a stored chunk for CLI/MCP JSON (metadata keys at the top level).
+
+    Citation fields such as ``page_start`` and ``heading_path`` sit beside
+    ``chunk_id`` and ``text``. The embedding vector and retrieval scores are
+    omitted. Optional figure and region enrichment matches
+    :func:`result_payload`.
+    """
+    metadata = thaw_json(record.metadata)
+    payload: dict[str, Any] = {**metadata, "chunk_id": record.id, "text": record.text}
+    if document is not None:
+        if include_regions:
+            payload["regions"] = get_chunk_regions(document, record.id)
+        if include_figures:
+            attachment_ids = sorted(
+                ref.attachment_id for ref in record.attachments if ref.role == "figure"
+            )
+            figures_list = figures(
+                document,
+                include_data=include_figure_data or figure_data_urls,
+                attachment_ids=attachment_ids,
+            )
+            if figure_data_urls:
+                figures_list = [figure_data_url(figure) for figure in figures_list]
+            payload["figures"] = figures_list
+    return payload
 
 
 def result_payload(
@@ -45,24 +81,26 @@ def result_payload(
     callers can set ``figure_data_urls`` to replace raw figure bytes with a
     ``data_url`` instead of forking the serializer.
     """
-    data = result.as_dict()
-    metadata = data.pop("metadata", {})
-    payload = {**metadata, **data}
-    for key in ("before_chunks", "after_chunks"):
-        if key in payload:
-            payload[key] = [{**item.pop("metadata", {}), **item} for item in payload[key]]
-    if document is not None:
-        if include_regions:
-            payload["regions"] = regions_for(document, result)
-        if include_figures:
-            figures_list = figures_for(
-                document,
-                result,
-                include_data=include_figure_data or figure_data_urls,
-            )
-            if figure_data_urls:
-                figures_list = [figure_data_url(figure) for figure in figures_list]
-            payload["figures"] = figures_list
+    payload = chunk_payload(
+        result.record,
+        document=document,
+        include_figures=include_figures,
+        include_regions=include_regions,
+        include_figure_data=include_figure_data,
+        figure_data_urls=figure_data_urls,
+    )
+    payload["score"] = result.score
+    if result.semantic_score is not None:
+        payload["semantic_score"] = result.semantic_score
+    if result.keyword_score is not None:
+        payload["keyword_score"] = result.keyword_score
+    if result.before or result.after:
+        payload["before_chunks"] = [
+            {**item.pop("metadata", {}), **item} for item in result.before_chunks
+        ]
+        payload["after_chunks"] = [
+            {**item.pop("metadata", {}), **item} for item in result.after_chunks
+        ]
     return payload
 
 

--- a/packages/vera-mcp/src/vera_mcp/server.py
+++ b/packages/vera-mcp/src/vera_mcp/server.py
@@ -23,6 +23,7 @@ from typing import Any
 from vera_doc.corpus import VeraCorpus
 from vera_doc.document import VeraDocument
 from vera_ingest.viewer import (
+    chunk_payload,
     figures,
     get_chunk_regions,
     get_page,
@@ -189,6 +190,34 @@ def build_server():
             if page is None:
                 return {"error": f"Page {page_number} not found"}
             return page
+        finally:
+            doc.close()
+
+    @server.tool()
+    def vera_get_chunk(
+        file: str,
+        chunk_id: str,
+        include_figures: bool = False,
+        include_regions: bool = False,
+    ) -> dict[str, Any]:
+        """Fetch one stored chunk by id as citation-ready JSON."""
+        if not str(chunk_id).strip():
+            return {"ok": False, "error": f"chunk not found: {chunk_id}"}
+        doc = _open(file)
+        try:
+            try:
+                records = doc.get(ids=[chunk_id])
+                if not records:
+                    return {"ok": False, "error": f"chunk not found: {chunk_id}"}
+                payload = chunk_payload(
+                    records[0],
+                    document=doc,
+                    include_figures=include_figures,
+                    include_regions=include_regions,
+                )
+            except ValueError as exc:
+                return {"ok": False, "error": str(exc)}
+            return {"ok": True, **_archive_locator(file, doc), **payload}
         finally:
             doc.close()
 

--- a/packages/vera-mcp/tests/test_mcp_server.py
+++ b/packages/vera-mcp/tests/test_mcp_server.py
@@ -37,6 +37,7 @@ async def test_tools_are_registered(server):
         "vera_figures",
         "vera_get_figure",
         "vera_get_page",
+        "vera_get_chunk",
     } <= names
 
 
@@ -135,6 +136,39 @@ async def test_get_chunk_regions_tool(server, vera_file):
     )
     assert regions
     assert regions[0]["page_number"] == search["results"][0]["page_start"]
+
+
+@pytest.mark.anyio
+async def test_get_chunk_tool_round_trips_search(server, vera_file):
+    search = _payload(
+        await server.call_tool(
+            "vera_search", {"file": str(vera_file), "query": "restaurant parking", "top_k": 1}
+        )
+    )
+    hit = search["results"][0]
+    payload = _payload(
+        await server.call_tool(
+            "vera_get_chunk", {"file": str(vera_file), "chunk_id": hit["chunk_id"]}
+        )
+    )
+    assert payload["ok"] is True
+    assert payload["chunk_id"] == hit["chunk_id"]
+    assert payload["text"] == hit["text"]
+    assert payload["file"] == str(vera_file)
+    assert Path(payload["path"]).resolve() == vera_file.resolve()
+    assert "score" not in payload
+    assert "semantic_score" not in payload
+    assert "keyword_score" not in payload
+    for key in ("page_start", "page_end", "heading_path", "source_filename", "document_id"):
+        assert payload.get(key) == hit.get(key)
+
+
+@pytest.mark.anyio
+async def test_get_chunk_missing_id_returns_error(server, vera_file):
+    payload = _payload(
+        await server.call_tool("vera_get_chunk", {"file": str(vera_file), "chunk_id": "chunk_zzzz"})
+    )
+    assert payload == {"ok": False, "error": "chunk not found: chunk_zzzz"}
 
 
 def _payload(call_result):

--- a/skills/vera/SKILL.md
+++ b/skills/vera/SKILL.md
@@ -46,9 +46,11 @@ workflows.
 3. Check the process exit code. On success, parse stdout as one JSON object.
 4. Read each result's `text`, `page_start`, `page_end`, `heading_path`, and
    `source_filename`. For directory searches, also retain each result's `file`.
-5. If the evidence does not directly answer the question, refine the query or
+5. When you need the stored chunk body or to verify a quote, reload that
+   `chunk_id` with `vera get FILE CHUNK_ID --json` instead of searching again.
+6. If the evidence does not directly answer the question, refine the query or
    switch modes. Do not treat rank or score as proof.
-6. Answer only from retrieved evidence and cite each substantive claim.
+7. Answer only from retrieved evidence and cite each substantive claim.
 
 Search a directory as one corpus by passing the directory instead of a file:
 
@@ -136,7 +138,7 @@ that no usable diagnostic exists.
 
 ## Commands that write files
 
-`search`, `inspect`, `validate`, and `eval` are read-only. The following
+`search`, `inspect`, `get`, `validate`, and `eval` are read-only. The following
 commands write or replace local files and require normal user authorization:
 
 - `convert` creates a validated `.vera` archive and publishes it atomically;
@@ -178,7 +180,7 @@ request that only asks to search or explain a document.
 
 - Always inspect the exit code before trusting output.
 - Do not assume all nonzero exits lack JSON. `validate`, `index status`, `eval`,
-  a failed `export`, a failed `figures`, and a failed `convert` can print useful JSON while returning 1.
+  a failed `export`, a failed `figures`, a failed `get`, and a failed `convert` can print useful JSON while returning 1.
   `convert --json` also prints `{"ok": false, "error": "..."}` and exits 2 for an
   unknown `--parser` / `--model`.
 - Most other missing-path and runtime failures are unstructured tracebacks on

--- a/skills/vera/references/cli-reference.md
+++ b/skills/vera/references/cli-reference.md
@@ -235,6 +235,69 @@ Metadata is extensible. `default_embedding_normalization` is `l2`, `none`, or
 Summary counts, embedding dimensions, attachment counts, and
 `archive_size_bytes` are integers.
 
+### `vera get FILE CHUNK_ID`
+
+Fetch one stored chunk by exact `chunks.chunk_id`. `FILE` is a single `.vera`
+archive, not a directory. `CHUNK_ID` is case-sensitive with no glob or prefix
+match. This command does not write files.
+
+Options:
+
+- `--json` emits one JSON object.
+- `--figures` adds figure metadata/captions (same shape as `vera search
+  --figures`; metadata only, not pixels).
+- `--regions` adds highlight regions (same shape as `vera search --regions`).
+
+Success JSON (exit 0):
+
+```json
+{
+  "ok": true,
+  "file": "manual.vera",
+  "path": "C:/docs/manual.vera",
+  "chunk_id": "chunk_0042",
+  "text": "Detention shall be provided...",
+  "page_start": 117,
+  "page_end": 117,
+  "heading_path": "Chapter 4 > Detention Design",
+  "source_filename": "manual.pdf",
+  "document_id": "document_0001"
+}
+```
+
+`file` is the requested path; `path` is the opened archive. `chunk_id` and
+`text` are always present; `text` is the stored chunk body, not a snippet.
+Citation fields come from chunk metadata and may be `null` when the
+extractor did not set them. Other metadata keys may appear at the top level
+(search already does this). Do not expect `score`, `semantic_score`,
+`keyword_score`, or the embedding vector. `--figures` / `--regions` add
+`figures` / `regions` only when requested.
+
+An unknown id, or a whitespace-only `CHUNK_ID` (rejected before the archive is
+opened), exits 1 with structured JSON and no traceback:
+
+```json
+{
+  "ok": false,
+  "error": "chunk not found: chunk_zzzz"
+}
+```
+
+Without `--json`, the same `chunk not found: ...` message is printed to
+stderr. A missing path or a directory target follows `inspect`: unstructured
+`FileNotFoundError` traceback on stderr, exit 1. Do not treat a directory as a
+corpus scan.
+
+Human output is a single search-style hit without a score:
+
+```text
+Source: manual.pdf
+Page: 117
+Heading: Chapter 4 > Detention Design
+
+Detention shall be provided...
+```
+
 ### `vera search FILE_OR_DIRECTORY QUERY`
 
 Options:
@@ -684,14 +747,17 @@ Runs the long-lived stdio MCP server. It does not accept `--json`; protocol
 messages use stdout, so do not mix ordinary output into that stream.
 
 MCP provides `vera_search`, `vera_corpus_search`, `vera_inspect`,
-`vera_validate`, `vera_figures`, `vera_get_figure`, `vera_get_page`, and
+`vera_validate`, `vera_figures`, `vera_get_figure`, `vera_get_page`,
+`vera_get_chunk`, and
 `vera_get_chunk_regions`. `vera_search` and `vera_corpus_search` default
 `top_k` to `10`, matching `vera search` and `VeraDocument.search`.
 `vera_inspect` and `vera_validate` include both `file` (requested) and
 `path` (opened). `vera_get_figure` returns native image content for one
 `asset_id` plus citation metadata; a missing id returns `{"error": "..."}`.
-`vera_get_page` and `vera_get_chunk_regions` have no direct standalone CLI
-equivalent. `vera figures` is the CLI equivalent of `vera_figures` listing.
+`vera_get_chunk` matches `vera get FILE CHUNK_ID --json`, including `ok: true`
+and locator fields; a missing chunk returns `{"ok": false, "error": "chunk not
+found: ..."}` rather than raising. `vera_get_page` and `vera_get_chunk_regions`
+have no direct standalone CLI equivalent. `vera figures` is the CLI equivalent of `vera_figures` listing.
 See the repository's agent-skills guide for MCP setup.
 
 ### `vera ocr-languages list [LANGUAGE]`
@@ -763,7 +829,8 @@ exit code before deciding how to interpret output:
 - Exit 0: parse stdout as JSON when `--json` was supplied.
 - Exit 1 with structured JSON: expected negative result from `validate`,
   `index status`, `eval`, `export` without an embedded source, `figures` when a
-  requested `--asset-id` is missing or is not a figure, or `convert`
+  requested `--asset-id` is missing or is not a figure, `get` when the chunk
+  id is missing, or `convert`
   when extraction/validation fails or the input path is missing (`{ok: false,
   error}`).
 - Exit 1 with stderr traceback: most path, dependency, or runtime failures.
@@ -781,7 +848,7 @@ negative-result cases.
 
 ## Filesystem effects
 
-- Read-only: `search`, `inspect`, `validate`, `eval`, `ocr-languages list`,
+- Read-only: `search`, `inspect`, `get`, `validate`, `eval`, `ocr-languages list`,
   and `figures` without `--out-dir`.
 - Writes archives: `convert`; existing single outputs can be replaced.
   `convert --ocr-allow-download` (and `ocr-languages download`) can also

--- a/skills/vera/references/retrieval-workflows.md
+++ b/skills/vera/references/retrieval-workflows.md
@@ -38,7 +38,9 @@ Examples:
    governing rule, rerun with `--context-chunks 1`.
 4. Run a second targeted query when the first result does not directly answer
    every part of the question.
-5. Answer with source, page, and heading citations.
+5. Answer with source, page, and heading citations. When verifying that a
+   quoted span is still in the stored chunk, reload it with
+   `vera get FILE CHUNK_ID --json` instead of searching again.
 
 Inspection is optional for simple Q&A. Use it first when the archive name is
 ambiguous or the user asks about document identity:

--- a/tests/test_agent_skill.py
+++ b/tests/test_agent_skill.py
@@ -174,6 +174,15 @@ def test_skill_inspect_json_example_includes_file_and_path():
     assert {"file", "path"} <= set(example)
 
 
+def test_skill_get_json_example_includes_citation_fields():
+    example = _first_json_fence_after(
+        CLI_REFERENCE.read_text(encoding="utf-8"),
+        "### `vera get FILE CHUNK_ID`",
+    )
+    assert {"ok", "file", "path", "chunk_id", "text"} <= set(example)
+    assert "score" not in example
+
+
 def test_skill_documents_mcp_search_default_top_k():
     reference = CLI_REFERENCE.read_text(encoding="utf-8")
     assert "`top_k` to `10`" in reference

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -155,6 +155,8 @@ def test_documented_cli_examples_parse():
             "--json",
         ],
         ["inspect", "output.vera", "--json"],
+        ["get", "output.vera", "chunk_0042", "--json"],
+        ["get", "output.vera", "chunk_0042", "--figures", "--regions", "--json"],
         [
             "search",
             "output.vera",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `vera get FILE CHUNK_ID` so agents can reload one stored chunk by id as citation-ready JSON (same citation fields as a search hit, without `score`).
- Add MCP `vera_get_chunk` with the same JSON object, including `ok` and archive locator fields.
- Share flatten/enrichment through `vera_ingest.viewer.chunk_payload()`; `result_payload()` layers retrieval scores and extra `as_dict()` keys (including corpus `file`) on top.
- Unknown or whitespace-only ids exit 1 with `{"ok": false, "error": "chunk not found: ..."}` and no traceback. Directory targets follow `inspect` (`FileNotFoundError`) and are not treated as a corpus.
- No format change, write APIs, or desktop UI.

## Test plan

- [x] CLI convert → keyword search → `get` round-trip (text and citation fields match; no `score`).
- [x] Unknown id and whitespace-only id: exit 1, structured JSON, no traceback.
- [x] Directory target is unsupported (non-JSON `FileNotFoundError`).
- [x] MCP `vera_get_chunk` is registered; search then get matches; missing id returns `{ok: false, error}`.
- [x] Documentation-contract tests cover the new command heading, parse examples, and skill JSON keys.
- [x] Full `uv run --extra dev --extra mcp pytest -q` passed after restoring corpus `file` on search JSON.

## Documentation

- [x] User-visible behavior is documented in the README or relevant `docs/` guide.
- [x] CLI/API/MCP references and examples reflect public contract changes.
- [x] `skills/vera/` reflects agent-facing behavior changes.
- [x] Documentation-contract tests were updated when commands, options, JSON, exit codes, links, or documented workflows changed.
- [ ] Not applicable: this change has no user-visible or agent-facing behavior.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-208a4efc-ecbc-4366-aa39-a4c64b3b2975?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-208a4efc-ecbc-4366-aa39-a4c64b3b2975&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

