### PR TITLE
Filter corpus search by path include and metadata where

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,14 @@ vera convert scan.pdf scan.vera --parser docling --pipeline-option pdf_backend=p
 # Provider-owned embedder options (hashing dimension; OpenAI batch_size)
 vera convert manual.pdf --model hashing --embedder-option dimension=256 --json
 vera convert manual.pdf --model openai:text-embedding-3-small --json
+vera convert filing.md out.vera --metadata company=GRID --metadata source_id=src_aaa --json
 
 # Batch-convert a nested PDF and Markdown library beside its source files
 vera convert ./proposals --recursive --json
+
+# Scope a library search by path include and stored metadata (filter before top_k)
+vera search ./archives "adding capacity" --where company=GRID --json
+vera search ./research --recursive --include "companies/GRID/archives/**" --json
 
 # List or fetch curated Tesseract OCR language data (non-English)
 vera ocr-languages list --json
@@ -152,6 +157,15 @@ dimension-incompatible. Result order is the rank; the CLI does not emit a
 8. **Reload a known `chunk_id` with `vera get`** when you need the stored chunk body
    or to verify that a quoted span is still in `text`. Searching again is not a
    substitute: rank can change, and keyword search can miss a short quote.
+9. **Filter with `--where` / `--include`, not by dropping search JSON.** `--where`
+   matches stored archive and chunk metadata and is applied before `top_k`.
+   Distinct keys are AND; `KEY=a,b` is IN. `--include` is directory discovery
+   (OR of patterns, then `--exclude`). Do not post-filter the `results` array
+   after a search — that under-fills `top_k` and makes rank lie. Convert stamps
+   caller tags with `--metadata KEY=VALUE` onto the archive and every chunk.
+   Reserved citation and format keys are rejected. When a metadata filter cannot
+   run inside a collection index, `index.used` is false and `index.reasons`
+   includes `chunk metadata filter not in collection index`.
 
 For the complete reusable workflow, load [skills/vera/SKILL.md](skills/vera/SKILL.md).
 Its [CLI reference](skills/vera/references/cli-reference.md) documents every flag,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ reconvert files created with 0.2 tooling in order to search or inspect them.
 
 ### Added
 
+- Convert `--metadata KEY=VALUE` stamps caller tags onto archive metadata and
+  every chunk. Search `--where KEY=VALUE` filters stored metadata before
+  `top_k` (AND across keys; comma-separated values are IN). Directory search
+  and `vera index build` accept `--include PATTERN`. Chunk-only `where` keys
+  that are not in the collection index fall back to per-file search with
+  `index.used=false` and `chunk metadata filter not in collection index`.
+  MCP `vera_search` / `vera_corpus_search` take the same `where` / `includes`
+  arguments.
+
 - `vera get FILE CHUNK_ID` fetches one stored chunk by id as citation-ready
   JSON (`ok`, locator fields, `chunk_id`, `text`, and the same citation keys
   as a search hit, without `score`). `--figures` and `--regions` match search

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pip install "vera-cli>=0.3.1"
 vera convert manual.pdf manual.vera
 vera convert notes.md notes.vera
 vera search manual.vera "when is stormwater detention required?" --json
+vera search ./archives "adding capacity" --where company=GRID --json
 ```
 
 ## The vision

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -64,6 +64,9 @@ Options:
   override compatibility aliases for the same key)
 - `--embedder-option KEY=VALUE` (repeatable; provider-owned embedding options
   forwarded to the selected embedding provider)
+- `--metadata KEY=VALUE` (repeatable; stamps the same keys onto archive
+  metadata and every chunk; reserved citation, ingest, and format keys are
+  rejected)
 - `--recursive`
 - `--overwrite`
 - `--json`
@@ -125,6 +128,10 @@ Options:
 - `--regions`
 - `--recursive`
 - `--exclude PATTERN` (repeatable)
+- `--include PATTERN` (repeatable; directory search only — error on a
+  single file)
+- `--where KEY=VALUE` (repeatable; stored metadata filter applied before
+  `top_k`; distinct keys are AND; comma-separated values are IN)
 - `--json`
 
 `--figures`, `--regions`, and context fields are exposed through JSON output.
@@ -135,6 +142,13 @@ name, indexed dimension, and loading or dimension error that prevented that
 group from participating in semantic or hybrid retrieval. Non-JSON output
 prints the same entries as warnings.
 
+`--where` filters stored archive and chunk metadata before `top_k`. Do not
+post-filter the JSON `results` array. `--include` and `--exclude` choose
+files during discovery. When a `--where` key is not archive metadata or an
+indexed citation column, directory search falls back to per-file search and
+sets `index.used` to false with `chunk metadata filter not in collection index`
+in `index.reasons`. `--include` on a single-file search exits 2.
+
 ## `vera index build DIRECTORY`
 
 Build a local collection index.
@@ -143,6 +157,7 @@ Options:
 
 - `--recursive`
 - `--exclude PATTERN` (repeatable)
+- `--include PATTERN` (repeatable; stored in index discovery settings)
 - `--json`
 
 Writes `.vera-index/` under the library root. Indexing uses a unique

--- a/docs/conversion.md
+++ b/docs/conversion.md
@@ -14,7 +14,21 @@ grounding are in
 ```bash
 vera convert "input.pdf" "output.vera"
 vera convert "notes.md" "notes.vera"
+vera convert "filing.md" "filing.vera" --metadata company=GRID --metadata source_id=src_aaa
 ```
+
+`--metadata KEY=VALUE` is repeatable. The same keys are written to archive
+metadata (visible in `vera inspect`) and every chunk, so `--where` can filter
+before `top_k`. Values coerce like `--pipeline-option` (digit-only integers,
+`true`/`false`/`yes`/`no`/`on`/`off` booleans, otherwise strings). Nested JSON
+is not accepted. Reserved keys are rejected: citation fields (`page_start`,
+`page_end`, `heading_path`, `source_filename`, `document_id`), ingest chunk
+internals (`token_count`, `regions`), format header keys
+(`format_name`, `format_version`, `default_embedding_*`, `_vera_*`, and the
+rest of the required archive header), and convert-owned archive fields such as
+`source_file_hash`. `title` may be overridden. Directory convert applies the
+same `--metadata` to every output in that run; hash-matched skips still skip,
+so reconvert or pass `--overwrite` to restamp.
 
 Omit the output to create a same-named archive:
 
@@ -438,6 +452,7 @@ path = convert(
     parser="pymupdf",
     pipeline_options={"chunk_size": 700, "ocr_mode": "force"},
     model="hashing",
+    metadata={"company": "GRID", "source_id": "src_aaa"},
     # embedder_options={"device": "cpu"},
     # Compatibility aliases (forwarded when the pipeline advertises them):
     # chunk_size=500, overlap=75, ocr_mode="auto", ocr_language="eng",

--- a/docs/document-libraries.md
+++ b/docs/document-libraries.md
@@ -43,6 +43,16 @@ vera search "./library" "termination clause" \
   --json
 ```
 
+Limit discovery to matching paths with `--include`. If any include is present,
+a file must match at least one include **and** no exclude:
+
+```bash
+vera search "./research" "adding capacity" \
+  --recursive \
+  --include "companies/GRID/archives/**" \
+  --json
+```
+
 Patterns are matched against forward-slash relative paths and individual path
 components. Directory symlinks and archive symlinks are not followed.
 
@@ -74,8 +84,11 @@ Use the same exclusion patterns while building:
 vera index build "./library" \
   --recursive \
   --exclude "archive/**" \
+  --include "companies/GRID/archives/**" \
   --json
 ```
+
+`vera index update` keeps the saved include and exclude patterns.
 
 ## Search an indexed library
 
@@ -149,6 +162,13 @@ search. The JSON response sets `index.used` to false and lists the reason:
 ```
 
 This preserves correctness while making the performance change visible.
+
+When `--where` uses a chunk-only metadata key that is not stored in the
+collection index, VERA also falls back to per-file search even if the index
+is otherwise fresh. `index.used` is false and `index.reasons` includes
+`chunk metadata filter not in collection index`. Archive-level keys stamped
+at convert time (and citation columns already in the index) can filter the
+indexed search before `top_k`. Do not post-filter the JSON `results` array.
 
 `vera index status --json` also reports the active generation and timestamps,
 database/vector/total storage, `indexed_chunks` versus `source_chunks`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -99,8 +99,8 @@ The returned top-left-origin bounding boxes can be scaled onto a page viewer.
 
 ```bash
 vera convert "./proposals" --recursive --json
-vera index build "./proposals" --recursive --exclude "archive/**" --json
-vera search "./proposals" "termination clause" --top-k 10 --json
+vera index build "./proposals" --recursive --exclude "archive/**" --include "active/**" --json
+vera search "./proposals" "termination clause" --where company=GRID --top-k 10 --json
 ```
 
 Check `malformed_existing` after conversion, then `skipped_files` and

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -69,8 +69,10 @@ Parameters:
 - `include_figures: bool = false`
 - `include_regions: bool = false`
 - `context_chunks: int = 0`
+- `where: dict[str, str | list[str]] | null = null`
 
-Returns `query`, `mode`, and citation-ready `results`.
+Returns `query`, `mode`, and citation-ready `results`. A list value is IN;
+distinct keys are AND. Filters stored metadata before `top_k`.
 
 The MCP search default is ten results, matching the CLI and
 `VeraDocument.search`.
@@ -90,6 +92,8 @@ Parameters:
 - `context_chunks: int = 0`
 - `recursive: bool | null = null`
 - `excludes: list[str] | null = null`
+- `includes: list[str] | null = null`
+- `where: dict[str, str | list[str]] | null = null`
 
 Returns the directory, query, mode, index status, `skipped_files`,
 `skipped_semantic_model_groups`, and results. Each result is attributed to its
@@ -99,8 +103,10 @@ paths and validation reasons. For indexed semantic and hybrid searches,
 query embedder was unavailable or had the wrong dimension; hybrid keyword
 matches may still be returned.
 
-When `recursive` and `excludes` are null and an index exists, the corpus uses
-the index's saved discovery settings.
+When `recursive`, `excludes`, and `includes` are null and an index exists, the
+corpus uses the index's saved discovery settings. `where` uses the same AND / IN
+semantics as the CLI. Chunk-only metadata filters that are not in the collection
+index set `index.used` to false.
 
 ### `vera_inspect`
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -197,7 +197,13 @@ Hybrid search defaults to equal semantic and keyword weights. Each hit
 exposes `result.citation` (`page_start`, `page_end`, `heading_path`,
 `source_filename`, `document_id`) derived from chunk metadata. Pass
 `vector=[...]` instead of text for vector-only semantic search. Portable
-metadata filtering currently supports exact equality on top-level keys.
+metadata filtering supports exact equality on top-level keys; a list, tuple,
+or set value is IN (OR within that key). Distinct keys are AND. List-valued
+*stored* metadata is not an IN clause.
+
+```python
+hits = document.search("detention", mode="hybrid", where={"company": ["GRID", "PWRX"]})
+```
 
 ## Database metadata, inspection, and validation
 
@@ -245,6 +251,7 @@ convert(
     parser="pymupdf",
     pipeline_options={"chunk_size": 700, "ocr_mode": "force"},
     model="hashing",
+    metadata={"company": "GRID", "source_id": "src_aaa"},
     # embedder_options={"device": "cpu"},
     # Legacy compatibility aliases (forwarded when advertised by the pipeline):
     # chunk_size=500, overlap=75, ocr_mode="auto", ocr_language="eng",
@@ -298,10 +305,14 @@ VERA (they need a query-versus-document hint on `EmbeddingFunction`). See
 ```python
 from vera_doc import VeraCorpus, build_library_index, update_library_index
 
-build_library_index("./library", recursive=True)
+build_library_index("./library", recursive=True, includes=["companies/GRID/archives/**"])
 
-with VeraCorpus.open("./library") as corpus:
-    results = corpus.search("detention requirements", top_k=5)
+with VeraCorpus.open("./library", includes=["companies/GRID/archives/**"]) as corpus:
+    results = corpus.search(
+        "detention requirements",
+        top_k=5,
+        where={"company": "GRID"},
+    )
 
 update_library_index("./library")
 ```

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -97,6 +97,28 @@ source filename, page or page range, and heading when available:
 (manual.pdf, p. 117, Chapter 4 > Detention Design)
 ```
 
+## Filter before top_k
+
+Scope a search with stored metadata rather than by dropping hits from JSON.
+`--where` is applied before `top_k`, so rank and result counts stay honest.
+
+```bash
+vera search "./library" "adding capacity" --where company=GRID --json
+vera search "./library" "adding capacity" --where company=GRID,PWRX --json
+vera search "./library" "adding capacity" \
+  --where company=GRID --where document_type=filings --json
+```
+
+Distinct `--where` keys are AND. Comma-separated values for one key are IN.
+Stamp those keys at convert time:
+
+```bash
+vera convert filing.md archives/src_aaa.vera --metadata company=GRID --json
+```
+
+`--include` and `--exclude` choose files by relative path (discovery), not
+metadata. `--include` on a single-file search exits 2.
+
 To reload one stored chunk by id — for example to verify that a quoted span is
 still in the chunk body — use `vera get FILE CHUNK_ID --json` (MCP:
 `vera_get_chunk`). Searching again is not a substitute: rank can change, and

--- a/packages/vera-app/src/vera_app/documents.py
+++ b/packages/vera-app/src/vera_app/documents.py
@@ -22,10 +22,17 @@ def open_corpus(path: str, request: Request) -> VeraCorpus:
         if isinstance(excludes_value, list)
         else None
     )
+    includes_value = request.get("includes")
+    includes = (
+        [str(value) for value in includes_value if str(value).strip()]
+        if isinstance(includes_value, list)
+        else None
+    )
     return VeraCorpus.open(
         path,
         recursive=recursive,
         excludes=excludes,
+        includes=includes,
         default_recursive=bool(request.get("default_recursive", False)),
         allow_empty=bool(request.get("allow_empty", False)),
     )

--- a/packages/vera-app/src/vera_app/library.py
+++ b/packages/vera-app/src/vera_app/library.py
@@ -21,10 +21,12 @@ def index_build(request: Request, write_event: WriteEvent | None = None) -> dict
             write_event({"event": "index_progress", **update})
 
     excludes = request.get("excludes")
+    includes = request.get("includes")
     return build_library_index(
         str(request["path"]),
         recursive=bool(request.get("recursive", True)),
         excludes=[str(value) for value in excludes] if isinstance(excludes, list) else (),
+        includes=[str(value) for value in includes] if isinstance(includes, list) else (),
         progress=report_progress,
     )
 

--- a/packages/vera-app/src/vera_app/search.py
+++ b/packages/vera-app/src/vera_app/search.py
@@ -20,11 +20,13 @@ def search_report(request: Request, cancel: CancellationToken | None = None) -> 
     # `file`; single-document results otherwise don't).
     scoped_file = scoped_single_file(request)
     try:
+        where = request.get("where")
         results = target.search(
             text=str(request.get("query", "")),
             mode=str(request.get("mode", "hybrid")),
             top_k=int(request.get("top_k", 10)),
             context_chunks=int(request.get("context_chunks", 0)),
+            where=where if isinstance(where, dict) else None,
         )
         if cancel:
             cancel.raise_if_cancelled()

--- a/packages/vera-app/src/vera_app/source.py
+++ b/packages/vera-app/src/vera_app/source.py
@@ -226,7 +226,11 @@ def source(
             cache_path = source_cache_path(cache_dir, digest, filename)
             if source_cache_hit(cache_path, size):
                 return source_result(filename, mime_type, digest, size, cache_path)
-            if sibling is not None and sibling[1] == mime_type and sibling[0].stat().st_size == size:
+            if (
+                sibling is not None
+                and sibling[1] == mime_type
+                and sibling[0].stat().st_size == size
+            ):
                 copied = copy_file_to_cache(sibling[0], cache_path, size, cancel)
                 return source_result(filename, mime_type, digest, size, copied)
             extracted = extract_attachment_to_cache(

--- a/packages/vera-app/tests/test_app_sidecar.py
+++ b/packages/vera-app/tests/test_app_sidecar.py
@@ -1101,27 +1101,6 @@ def test_source_action_uses_sibling_markdown_when_original_is_not_stored(tmp_pat
     assert Path(response["result"]["cache_path"]).read_text(encoding="utf-8") == body
 
 
-def test_source_action_uses_sibling_markdown_when_original_is_not_stored(tmp_path):
-    source = tmp_path / "notes.md"
-    out = tmp_path / "notes.vera"
-    cache_dir = tmp_path / "source-cache"
-    body = "# Detention\n\nPonds must detain the 25-year storm.\n"
-    source.write_text(body, encoding="utf-8")
-    convert(str(source), str(out), model="hashing", store_original=False)
-
-    response = handle(
-        {
-            "id": "1",
-            "action": "source",
-            "path": str(out),
-            "cache_dir": str(cache_dir),
-        }
-    )
-    assert response["ok"] is True
-    assert response["result"]["mime_type"] == "text/markdown"
-    assert Path(response["result"]["cache_path"]).read_text(encoding="utf-8") == body
-
-
 def test_source_action_extracts_embedded_pdf_when_sibling_is_missing(tmp_path):
     pdf = tmp_path / "manual.pdf"
     out = tmp_path / "manual.vera"

--- a/packages/vera-cli/src/vera_cli/commands.py
+++ b/packages/vera-cli/src/vera_cli/commands.py
@@ -15,6 +15,7 @@ from vera_embed_openai import (
     ensure_registered as ensure_openai_embedder_registered,
 )
 from vera_ingest import (
+    ReservedMetadataKeyError,
     UnknownIngestPipelineError,
     batch_convert,
     convert,
@@ -68,33 +69,63 @@ def _embedder_options_from_args(args) -> dict[str, object]:
     return _key_value_options_from_args(getattr(args, "embedder_options", []) or [])
 
 
-def _key_value_options_from_args(pairs) -> dict[str, object]:
-    """Coerce KEY=VALUE tokens without ``float()``.
+def _coerce_option_value(raw: str) -> object:
+    """Coerce a KEY=VALUE token without ``float()``.
 
     Dotted tokens such as ``3.10`` or ``ocr_language=1.0`` stay strings.
     Whole-digit tokens become ints; ``true``/``false``/``yes``/``no``/``on``/
-    ``off`` become bools. ``from_mapping`` then validates each typed field
-    (so ``ocr_download=1`` is int ``1``, accepted by ``require_bool``).
+    ``off`` become bools.
     """
+    text = str(raw).strip()
+    lowered = text.lower()
+    if lowered in {"true", "yes", "y", "on"}:
+        return True
+    if lowered in {"false", "no", "n", "off"}:
+        return False
+    if text.isdigit() or (text.startswith("-") and text[1:].isdigit()):
+        return int(text)
+    return text
+
+
+def _key_value_options_from_args(pairs) -> dict[str, object]:
     options: dict[str, object] = {}
     for key, raw in pairs:
-        text = str(raw).strip()
-        lowered = text.lower()
-        if lowered in {"true", "yes", "y", "on"}:
-            options[key] = True
-        elif lowered in {"false", "no", "n", "off"}:
-            options[key] = False
-        elif text.isdigit() or (text.startswith("-") and text[1:].isdigit()):
-            options[key] = int(text)
-        else:
-            options[key] = text
+        options[key] = _coerce_option_value(raw)
     return options
+
+
+def _metadata_from_args(args) -> dict[str, object] | None:
+    pairs = getattr(args, "metadata", None) or []
+    return _key_value_options_from_args(pairs) or None
+
+
+def _where_from_args(pairs) -> dict[str, object] | None:
+    """Parse ``--where KEY=VALUE`` pairs: AND across keys, comma IN, union repeats."""
+    if not pairs:
+        return None
+    where: dict[str, object] = {}
+    for key, raw in pairs:
+        parts = str(raw).split(",")
+        if any(not part.strip() for part in parts):
+            raise ValueError("where values must not be empty")
+        values = [_coerce_option_value(part.strip()) for part in parts]
+        existing = where.get(key)
+        if existing is None:
+            where[key] = values[0] if len(values) == 1 else values
+            continue
+        current = existing if isinstance(existing, list) else [existing]
+        for value in values:
+            if value not in current:
+                current.append(value)
+        where[key] = current[0] if len(current) == 1 else current
+    return where
 
 
 def cmd_convert(args) -> int:
     input_path = Path(args.input)
     pipeline_options = _pipeline_options_from_args(args)
     embedder_options = _embedder_options_from_args(args)
+    metadata = _metadata_from_args(args)
     try:
         if input_path.is_dir():
             if args.output:
@@ -122,6 +153,7 @@ def cmd_convert(args) -> int:
                 ocr_download=args.ocr_allow_download,
                 pipeline_options=pipeline_options or None,
                 embedder_options=embedder_options or None,
+                metadata=metadata,
             )
             unsuccessful = report["failed"] + report["malformed"]
             if args.json:
@@ -154,8 +186,9 @@ def cmd_convert(args) -> int:
             ocr_download=args.ocr_allow_download,
             pipeline_options=pipeline_options or None,
             embedder_options=embedder_options or None,
+            metadata=metadata,
         )
-    except (UnknownIngestPipelineError, UnknownEmbeddingModelError) as exc:
+    except (UnknownIngestPipelineError, UnknownEmbeddingModelError, ReservedMetadataKeyError) as exc:
         if args.json:
             print(json.dumps({"ok": False, "error": str(exc)}))
         else:
@@ -246,14 +279,31 @@ def cmd_get(args) -> int:
     return 0
 
 
+def _emit_cli_error(args, message: str, *, code: int = 1) -> int:
+    if getattr(args, "json", False):
+        print(json.dumps({"ok": False, "error": message}))
+    else:
+        print(message, file=sys.stderr)
+    return code
+
+
 def cmd_search(args) -> int:
+    target_path = Path(args.file)
+    includes = getattr(args, "include", None)
+    if includes and not target_path.is_dir():
+        return _emit_cli_error(args, "--include applies to directory search only", code=2)
+    try:
+        where = _where_from_args(getattr(args, "where", None) or [])
+    except ValueError as exc:
+        return _emit_cli_error(args, str(exc), code=2)
     target = (
         VeraCorpus.open(
             args.file,
             recursive=True if getattr(args, "recursive", False) else None,
             excludes=getattr(args, "exclude", None),
+            includes=includes,
         )
-        if Path(args.file).is_dir()
+        if target_path.is_dir()
         else VeraDocument.open(args.file)
     )
     try:
@@ -263,13 +313,10 @@ def cmd_search(args) -> int:
                 mode=args.mode,
                 top_k=args.top_k,
                 context_chunks=args.context_chunks,
+                where=where,
             )
         except OpenAIEmbedderError as exc:
-            if args.json:
-                print(json.dumps({"ok": False, "error": str(exc)}))
-            else:
-                print(str(exc), file=sys.stderr)
-            return 1
+            return _emit_cli_error(args, str(exc), code=1)
         if args.json:
             payload = []
             for result in results:
@@ -282,16 +329,17 @@ def cmd_search(args) -> int:
                 payload.append(entry)
             response = {"query": args.query, "mode": args.mode, "results": payload}
             if isinstance(target, VeraCorpus):
-                response["index"] = {"used": target.uses_index, **target.index_status}
+                response["index"] = target.index_search_report()
                 response["skipped_files"] = target.invalid_files
                 response["skipped_semantic_model_groups"] = target.skipped_semantic_model_groups
             print(json.dumps(response))
             return 0
         if isinstance(target, VeraCorpus):
-            if target.uses_index:
-                print(f"Index: {target.index_status.get('index')} (active)")
-            elif target.index_status.get("exists"):
-                reasons = "; ".join(target.index_status.get("reasons", []))
+            report = target.index_search_report()
+            if report.get("used"):
+                print(f"Index: {report.get('index')} (active)")
+            elif report.get("exists"):
+                reasons = "; ".join(report.get("reasons", []))
                 print(f"Index: fallback ({reasons})")
             for group in target.skipped_semantic_model_groups:
                 print(
@@ -346,6 +394,7 @@ def cmd_index_build(args) -> int:
         args.directory,
         recursive=args.recursive,
         excludes=args.exclude or (),
+        includes=args.include or (),
     )
     if args.json:
         print(json.dumps(report))

--- a/packages/vera-cli/src/vera_cli/commands.py
+++ b/packages/vera-cli/src/vera_cli/commands.py
@@ -188,7 +188,11 @@ def cmd_convert(args) -> int:
             embedder_options=embedder_options or None,
             metadata=metadata,
         )
-    except (UnknownIngestPipelineError, UnknownEmbeddingModelError, ReservedMetadataKeyError) as exc:
+    except (
+        UnknownIngestPipelineError,
+        UnknownEmbeddingModelError,
+        ReservedMetadataKeyError,
+    ) as exc:
         if args.json:
             print(json.dumps({"ok": False, "error": str(exc)}))
         else:

--- a/packages/vera-cli/src/vera_cli/main.py
+++ b/packages/vera-cli/src/vera_cli/main.py
@@ -170,6 +170,18 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     convert_p.add_argument(
+        "--metadata",
+        dest="metadata",
+        action="append",
+        type=pipeline_option,
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Caller metadata stamped onto the archive and every chunk "
+            "(repeatable). Reserved ingest, citation, and format keys are rejected."
+        ),
+    )
+    convert_p.add_argument(
         "--recursive",
         action="store_true",
         help="Discover supported source files recursively when input is a directory",
@@ -230,6 +242,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Exclude a relative path or name pattern (repeatable)",
     )
     search_p.add_argument(
+        "--include",
+        action="append",
+        default=None,
+        help="Include only relative paths matching this pattern (repeatable; directory search)",
+    )
+    search_p.add_argument(
+        "--where",
+        dest="where",
+        action="append",
+        type=pipeline_option,
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Filter stored metadata before top_k (repeatable). Distinct keys are AND; "
+            "comma-separated values are IN."
+        ),
+    )
+    search_p.add_argument(
         "--regions",
         action="store_true",
         help="Include page/bbox highlight regions for each result in --json output",
@@ -249,6 +279,12 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=None,
         help="Exclude a relative path or name pattern (repeatable)",
+    )
+    index_build_p.add_argument(
+        "--include",
+        action="append",
+        default=None,
+        help="Include only relative paths matching this pattern (repeatable)",
     )
     index_build_p.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     index_build_p.set_defaults(func=cmd_index_build)

--- a/packages/vera-cli/tests/test_cli.py
+++ b/packages/vera-cli/tests/test_cli.py
@@ -628,7 +628,7 @@ def test_cli_directory_convert_with_output_emits_json(tmp_path, capsys):
     assert "output path" in payload["error"]
 
 
-    def test_cli_index_exclude_defaults_to_none():
+def test_cli_index_exclude_defaults_to_none():
     args = build_parser().parse_args(["index", "build", "library"])
     assert args.exclude is None
     assert args.include is None

--- a/packages/vera-cli/tests/test_cli.py
+++ b/packages/vera-cli/tests/test_cli.py
@@ -628,9 +628,10 @@ def test_cli_directory_convert_with_output_emits_json(tmp_path, capsys):
     assert "output path" in payload["error"]
 
 
-def test_cli_index_exclude_defaults_to_none():
+    def test_cli_index_exclude_defaults_to_none():
     args = build_parser().parse_args(["index", "build", "library"])
     assert args.exclude is None
+    assert args.include is None
 
 
 @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes", "YES", "y", "on"])

--- a/packages/vera-doc/src/vera_doc/_document_records.py
+++ b/packages/vera-doc/src/vera_doc/_document_records.py
@@ -18,6 +18,7 @@ from ._util import (
     _embedding_normalization,
     _utc_now,
 )
+from ._where import metadata_matches
 from .embeddings import EmbeddingFunction, deserialize_vector, serialize_vector
 from .models import AttachmentRef, ChunkRecord, metadata_from_json, metadata_to_json, thaw_json
 
@@ -207,7 +208,9 @@ class _DocumentRecordsMixin:
         Args:
             ids: Specific chunk IDs to retrieve. When omitted, all matching
                 records are returned subject to ``where`` and ``limit``.
-            where: Exact equality filter on top-level metadata keys.
+            where: Filter on top-level metadata keys. Scalars are exact
+                equality; a list, tuple, or set value is IN. Distinct keys
+                are AND.
             limit: Maximum number of records to return.
 
         Returns:
@@ -255,7 +258,9 @@ class _DocumentRecordsMixin:
 
         Args:
             ids: Specific chunk IDs to delete.
-            where: Exact equality filter on top-level metadata keys.
+            where: Filter on top-level metadata keys. Scalars are exact
+                equality; a list, tuple, or set value is IN. Distinct keys
+                are AND.
             delete_all: Required to delete every chunk when ``ids`` and
                 ``where`` are omitted.
 
@@ -374,7 +379,4 @@ class _DocumentRecordsMixin:
         record: ChunkRecord,
         where: Mapping[str, Any] | None,
     ) -> bool:
-        if not where:
-            return True
-        metadata = thaw_json(record.metadata)
-        return all(metadata.get(key) == expected for key, expected in where.items())
+        return metadata_matches(thaw_json(record.metadata), where)

--- a/packages/vera-doc/src/vera_doc/_document_search.py
+++ b/packages/vera-doc/src/vera_doc/_document_search.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from ._fts import execute_fts, safe_fts_query
 from ._util import _MAX_TOP_K, SearchMode
+from ._where import metadata_matches
 from .embeddings import EmbeddingFunction, deserialize_vector, get_embedder
 from .models import ChunkRecord, QueryResult, metadata_from_json, thaw_json
 from .ranking import (
@@ -55,7 +56,9 @@ class _DocumentSearchMixin:
                 ``vector`` is supplied for semantic mode.
             vector: Pre-computed query vector for semantic search.
             mode: ``"hybrid"`` (default), ``"semantic"``, or ``"keyword"``.
-            where: Exact equality filter on top-level metadata keys.
+            where: Filter on top-level metadata keys, applied before
+                ``top_k``. Scalars are exact equality; a list, tuple, or set
+                value is IN. Distinct keys are AND.
             top_k: Maximum number of results to return.
             context_chunks: Number of adjacent stored chunks to include.
             semantic_weight: Hybrid blend weight for semantic scores.
@@ -220,7 +223,7 @@ class _DocumentSearchMixin:
         matching: set[str] = set()
         for row in self._conn.execute("SELECT chunk_id, metadata_json FROM chunks"):
             metadata = thaw_json(metadata_from_json(row["metadata_json"]))
-            if all(metadata.get(key) == expected for key, expected in where.items()):
+            if metadata_matches(metadata, where):
                 matching.add(str(row["chunk_id"]))
         return matching
 

--- a/packages/vera-doc/src/vera_doc/_index_build.py
+++ b/packages/vera-doc/src/vera_doc/_index_build.py
@@ -160,6 +160,7 @@ def build_library_index(
     *,
     recursive: bool = False,
     excludes: Iterable[str] = (),
+    includes: Iterable[str] = (),
     operation: str = "build",
     progress: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
@@ -173,6 +174,7 @@ def build_library_index(
     if not root.is_dir():
         raise NotADirectoryError(directory)
     exclude_patterns = tuple(dict.fromkeys(str(pattern) for pattern in excludes))
+    include_patterns = tuple(dict.fromkeys(str(pattern) for pattern in includes))
     if progress:
         progress(
             {
@@ -184,7 +186,12 @@ def build_library_index(
                 "skipped": 0,
             }
         )
-    paths = discover_vera_files(root, recursive=recursive, excludes=exclude_patterns)
+    paths = discover_vera_files(
+        root,
+        recursive=recursive,
+        excludes=exclude_patterns,
+        includes=include_patterns,
+    )
     if not paths:
         raise FileNotFoundError(f"No .vera files found in {directory}")
     if progress:
@@ -234,6 +241,7 @@ def build_library_index(
             "root": str(root),
             "recursive": recursive,
             "excludes": list(exclude_patterns),
+            "includes": list(include_patterns),
             "index_version": INDEX_VERSION,
         }
         metadata = {
@@ -485,6 +493,7 @@ def build_library_index(
         "created_at": metadata["created_at"],
         "recursive": recursive,
         "excludes": list(exclude_patterns),
+        "includes": list(include_patterns),
         "discovered": len(paths),
         "indexed": indexed_files,
         "chunks": indexed_chunks,
@@ -526,6 +535,7 @@ def update_library_index(
         str(root),
         recursive=bool(config.get("recursive", False)),
         excludes=config.get("excludes", ()),
+        includes=config.get("includes", ()),
         operation="update",
         progress=progress,
     )
@@ -617,6 +627,7 @@ def library_index_status(directory: str, *, verify_hashes: bool = True) -> dict[
         root,
         recursive=bool(config.get("recursive", False)),
         excludes=config.get("excludes", ()),
+        includes=config.get("includes", ()),
     )
     current_paths = {_relative(path, root): path for path in discovered}
     indexed_paths = set(indexed) | set(skipped)
@@ -672,6 +683,7 @@ def library_index_status(directory: str, *, verify_hashes: bool = True) -> dict[
         "vector_size_bytes": vector_size,
         "recursive": bool(config.get("recursive", False)),
         "excludes": list(config.get("excludes", ())),
+        "includes": list(config.get("includes", ())),
         "file_count": len(indexed),
         "skipped": len(skipped),
         "skipped_files": [

--- a/packages/vera-doc/src/vera_doc/_index_layout.py
+++ b/packages/vera-doc/src/vera_doc/_index_layout.py
@@ -114,9 +114,10 @@ def _gc_index_generations(target: Path, current: str) -> None:
         shutil.rmtree(child, ignore_errors=True)
 
 
-def _excluded(relative_path: str, excludes: tuple[str, ...]) -> bool:
+def _path_matches(relative_path: str, patterns: tuple[str, ...]) -> bool:
+    """Return True when ``relative_path`` matches any exclude/include pattern."""
     parts = relative_path.split("/")
-    for pattern in excludes:
+    for pattern in patterns:
         normalized = pattern.replace("\\", "/").strip("/")
         if not normalized:
             continue
@@ -131,17 +132,36 @@ def _excluded(relative_path: str, excludes: tuple[str, ...]) -> bool:
     return False
 
 
+def _excluded(relative_path: str, excludes: tuple[str, ...]) -> bool:
+    return _path_matches(relative_path, excludes)
+
+
+def _included(relative_path: str, includes: tuple[str, ...]) -> bool:
+    if not includes:
+        return True
+    return _path_matches(relative_path, includes)
+
+
 def discover_vera_files(
     directory: str | Path,
     *,
     recursive: bool = False,
     excludes: Iterable[str] = (),
+    includes: Iterable[str] = (),
 ) -> list[Path]:
-    """Discover unique .vera files without following directory symlinks."""
+    """Discover unique .vera files without following directory symlinks.
+
+    When ``includes`` is empty, every discovered archive is a candidate.
+    When any include is present, a file must match at least one include and
+    no exclude. Include matching uses the same glob / path-component / ``/**``
+    rules as excludes. Directory pruning still follows excludes only, so a
+    nested include can match under an unexcluded parent.
+    """
     root = Path(directory).resolve()
     if not root.is_dir():
         raise NotADirectoryError(str(directory))
-    patterns = tuple(excludes)
+    exclude_patterns = tuple(excludes)
+    include_patterns = tuple(includes)
     if recursive:
         candidates: list[Path] = []
         for current, directories, filenames in os.walk(root, followlinks=False):
@@ -150,7 +170,7 @@ def discover_vera_files(
             for name in directories:
                 child = current_path / name
                 relative_child = _relative(child, root)
-                if child.is_symlink() or _excluded(relative_child, patterns):
+                if child.is_symlink() or _excluded(relative_child, exclude_patterns):
                     continue
                 kept_directories.append(name)
             directories[:] = kept_directories
@@ -166,7 +186,9 @@ def discover_vera_files(
             if not candidate.is_file() or candidate.is_symlink():
                 continue
             relative_path = _relative(candidate, root)
-            if _excluded(relative_path, patterns):
+            if _excluded(relative_path, exclude_patterns):
+                continue
+            if not _included(relative_path, include_patterns):
                 continue
             resolved = candidate.resolve()
             key = os.path.normcase(str(resolved))

--- a/packages/vera-doc/src/vera_doc/_where.py
+++ b/packages/vera-doc/src/vera_doc/_where.py
@@ -46,6 +46,4 @@ def metadata_matches(
     if not where:
         return True
     data = metadata or {}
-    return all(
-        metadata_value_matches(data.get(key), expected) for key, expected in where.items()
-    )
+    return all(metadata_value_matches(data.get(key), expected) for key, expected in where.items())

--- a/packages/vera-doc/src/vera_doc/_where.py
+++ b/packages/vera-doc/src/vera_doc/_where.py
@@ -1,0 +1,51 @@
+"""Exact-equality and IN filters for top-level metadata keys."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .models import (
+    METADATA_DOCUMENT_ID,
+    METADATA_HEADING_PATH,
+    METADATA_PAGE_END,
+    METADATA_PAGE_START,
+    METADATA_SOURCE_FILENAME,
+)
+
+INDEX_CITATION_COLUMNS = frozenset(
+    {
+        METADATA_DOCUMENT_ID,
+        METADATA_SOURCE_FILENAME,
+        METADATA_PAGE_START,
+        METADATA_PAGE_END,
+        METADATA_HEADING_PATH,
+    }
+)
+
+CHUNK_METADATA_FILTER_REASON = "chunk metadata filter not in collection index"
+
+
+def metadata_value_matches(actual: Any, expected: Any) -> bool:
+    """Return whether ``actual`` satisfies a scalar equality or list IN clause."""
+    if isinstance(expected, (list, tuple, set)):
+        return any(actual == item for item in expected)
+    return actual == expected
+
+
+def metadata_matches(
+    metadata: Mapping[str, Any] | None,
+    where: Mapping[str, Any] | None,
+) -> bool:
+    """AND across keys; a list/tuple/set value is IN, a scalar is ``==``.
+
+    Missing keys fail the predicate (``dict.get`` yields ``None``). An empty
+    or omitted ``where`` matches every record. List-valued *stored* metadata
+    is not an IN clause; IN applies to the filter value only.
+    """
+    if not where:
+        return True
+    data = metadata or {}
+    return all(
+        metadata_value_matches(data.get(key), expected) for key, expected in where.items()
+    )

--- a/packages/vera-doc/src/vera_doc/collection.py
+++ b/packages/vera-doc/src/vera_doc/collection.py
@@ -463,13 +463,9 @@ class VeraCollectionIndex:
                 ]
             ]
         if mode == "semantic":
-            ranked = self._semantic_hits(
-                query, top_k, file_ids=file_ids, chunk_where=chunk_where
-            )
+            ranked = self._semantic_hits(query, top_k, file_ids=file_ids, chunk_where=chunk_where)
         else:
-            ranked = self._keyword_hits(
-                query, top_k, file_ids=file_ids, chunk_where=chunk_where
-            )
+            ranked = self._keyword_hits(query, top_k, file_ids=file_ids, chunk_where=chunk_where)
         if not ranked:
             return []
         references = self._rows_by_id([row_id for row_id, _ in ranked])

--- a/packages/vera-doc/src/vera_doc/collection.py
+++ b/packages/vera-doc/src/vera_doc/collection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -27,10 +28,16 @@ from ._index_layout import (
     discover_vera_files,
 )
 from ._util import _MAX_TOP_K
+from ._where import (
+    CHUNK_METADATA_FILTER_REASON,
+    INDEX_CITATION_COLUMNS,
+    metadata_matches,
+)
 from .embeddings import get_embedder
 from .ranking import reciprocal_rank_fusion
 
 __all__ = [
+    "CHUNK_METADATA_FILTER_REASON",
     "INDEX_DATABASE",
     "INDEX_DIRECTORY",
     "INDEX_GENERATIONS",
@@ -158,7 +165,96 @@ class VeraCollectionIndex:
             )
         return self._matrices[filename]
 
-    def _semantic_hits(self, query: str, limit: int) -> list[tuple[int, float]]:
+    def _archive_metadata_keys(self) -> set[str]:
+        keys: set[str] = set()
+        for row in self.conn.execute("SELECT metadata_json FROM files"):
+            try:
+                payload = json.loads(row["metadata_json"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if isinstance(payload, dict):
+                keys.update(payload)
+        return keys
+
+    def _partition_where(
+        self, where: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+        archive_keys = self._archive_metadata_keys()
+        file_where: dict[str, Any] = {}
+        chunk_where: dict[str, Any] = {}
+        unknown: list[str] = []
+        for key, value in where.items():
+            if key in INDEX_CITATION_COLUMNS:
+                chunk_where[key] = value
+            elif key in archive_keys:
+                file_where[key] = value
+            else:
+                unknown.append(key)
+        return file_where, chunk_where, unknown
+
+    def supports_where(self, where: Mapping[str, Any] | None) -> bool:
+        """Return True when every ``where`` key is archive metadata or a citation column."""
+        if not where:
+            return True
+        _, _, unknown = self._partition_where(where)
+        return not unknown
+
+    def _matching_file_ids(self, file_where: Mapping[str, Any]) -> list[int]:
+        ids: list[int] = []
+        for row in self.conn.execute("SELECT file_id, metadata_json FROM files"):
+            try:
+                metadata = json.loads(row["metadata_json"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                metadata = {}
+            if not isinstance(metadata, dict):
+                metadata = {}
+            if metadata_matches(metadata, file_where):
+                ids.append(int(row["file_id"]))
+        return ids
+
+    def _chunk_filter_sql(
+        self,
+        file_ids: list[int] | None,
+        chunk_where: Mapping[str, Any] | None,
+    ) -> tuple[list[str], list[Any]] | None:
+        """Return extra WHERE clauses, or None when unsatisfiable or unconstrained.
+
+        An empty list of clauses means no extra filter. Returning None means
+        the predicate matches nothing (empty IN list or no matching files).
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        if file_ids is not None:
+            if not file_ids:
+                return None
+            placeholders = ",".join("?" for _ in file_ids)
+            clauses.append(f"chunks.file_id IN ({placeholders})")
+            params.extend(file_ids)
+        if chunk_where:
+            for key, expected in chunk_where.items():
+                if key not in INDEX_CITATION_COLUMNS:
+                    raise ValueError(f"unsupported index filter key: {key}")
+                column = f"chunks.{key}"
+                if isinstance(expected, (list, tuple, set)):
+                    values = list(expected)
+                    if not values:
+                        return None
+                    placeholders = ",".join("?" for _ in values)
+                    clauses.append(f"{column} IN ({placeholders})")
+                    params.extend(values)
+                else:
+                    clauses.append(f"{column} = ?")
+                    params.append(expected)
+        return clauses, params
+
+    def _semantic_hits(
+        self,
+        query: str,
+        limit: int,
+        *,
+        file_ids: list[int] | None = None,
+        chunk_where: Mapping[str, Any] | None = None,
+    ) -> list[tuple[int, float]]:
         per_group: list[list[tuple[int, float]]] = []
         for group in self.conn.execute(
             "SELECT * FROM vector_groups ORDER BY model_name, dimension"
@@ -193,8 +289,29 @@ class VeraCollectionIndex:
             if norm:
                 query_vector /= norm
             matrix = self._matrix(group["filename"])
-            scores = np.asarray(matrix @ query_vector)
-            take = min(limit, scores.size)
+            scores = np.asarray(matrix @ query_vector, dtype=np.float64)
+            extra = self._chunk_filter_sql(file_ids, chunk_where)
+            if extra is None:
+                continue
+            extra_sql, extra_params = extra
+            if extra_sql:
+                allowed_rows = {
+                    int(row["vector_row"])
+                    for row in self.conn.execute(
+                        "SELECT vector_row FROM chunks WHERE model_name = ? AND dimension = ? AND "
+                        + " AND ".join(extra_sql),
+                        (group["model_name"], group["dimension"], *extra_params),
+                    )
+                }
+                if not allowed_rows:
+                    continue
+                masked = np.full(scores.shape, -np.inf, dtype=np.float64)
+                for position in allowed_rows:
+                    if 0 <= position < scores.size:
+                        masked[position] = scores[position]
+                scores = masked
+            finite_count = int(np.isfinite(scores).sum())
+            take = min(limit, finite_count)
             if take == 0:
                 continue
             if take == scores.size:
@@ -202,7 +319,9 @@ class VeraCollectionIndex:
             else:
                 positions = np.argpartition(scores, -take)[-take:]
                 positions = positions[np.argsort(scores[positions])[::-1]]
-            vector_rows = [int(position) for position in positions]
+            vector_rows = [int(position) for position in positions if np.isfinite(scores[position])]
+            if not vector_rows:
+                continue
             placeholders = ",".join("?" for _ in vector_rows)
             rows = self.conn.execute(
                 f"""
@@ -229,18 +348,41 @@ class VeraCollectionIndex:
         )
         return fused[:limit]
 
-    def _keyword_hits(self, query: str, limit: int) -> list[tuple[int, float]]:
-        sql = """
-            SELECT row_id, bm25(chunks_fts) AS rank
-            FROM chunks_fts WHERE chunks_fts MATCH ?
-            ORDER BY rank LIMIT ?
-        """
-        rows = execute_fts(self.conn, sql, query, limit)
+    def _keyword_hits(
+        self,
+        query: str,
+        limit: int,
+        *,
+        file_ids: list[int] | None = None,
+        chunk_where: Mapping[str, Any] | None = None,
+    ) -> list[tuple[int, float]]:
+        extra = self._chunk_filter_sql(file_ids, chunk_where)
+        if extra is None:
+            return []
+        extra_sql, extra_params = extra
+        if extra_sql:
+            sql = f"""
+                SELECT chunks.row_id AS row_id, bm25(chunks_fts) AS rank
+                FROM chunks_fts
+                INNER JOIN chunks ON chunks.row_id = chunks_fts.row_id
+                WHERE chunks_fts MATCH ?
+                  AND {" AND ".join(extra_sql)}
+                ORDER BY rank LIMIT ?
+            """
+            params: tuple[Any, ...] = (*extra_params, limit)
+        else:
+            sql = """
+                SELECT row_id, bm25(chunks_fts) AS rank
+                FROM chunks_fts WHERE chunks_fts MATCH ?
+                ORDER BY rank LIMIT ?
+            """
+            params = (limit,)
+        rows = execute_fts(self.conn, sql, query, *params)
         if not rows:
             fallback = safe_fts_query(query)
             if not fallback:
                 return []
-            rows = execute_fts(self.conn, sql, fallback, limit)
+            rows = execute_fts(self.conn, sql, fallback, *params)
         hits = []
         for row in rows:
             rank = float(row["rank"])
@@ -263,7 +405,14 @@ class VeraCollectionIndex:
         ).fetchall()
         return {int(row["row_id"]): row for row in rows}
 
-    def search(self, query: str, mode: str = "hybrid", top_k: int = 10) -> list[IndexHit]:
+    def search(
+        self,
+        query: str,
+        mode: str = "hybrid",
+        top_k: int = 10,
+        *,
+        where: Mapping[str, Any] | None = None,
+    ) -> list[IndexHit]:
         mode = mode.lower()
         if mode not in {"semantic", "keyword", "hybrid"}:
             raise ValueError("mode must be semantic, keyword, or hybrid")
@@ -274,10 +423,25 @@ class VeraCollectionIndex:
             raise ValueError(f"top_k must be at most {_MAX_TOP_K}")
         if top_k == 0:
             return []
+        file_where: dict[str, Any] = {}
+        chunk_where: dict[str, Any] = {}
+        if where:
+            file_where, chunk_where, unknown = self._partition_where(where)
+            if unknown:
+                raise ValueError(CHUNK_METADATA_FILTER_REASON)
+        file_ids: list[int] | None = None
+        if file_where:
+            file_ids = self._matching_file_ids(file_where)
+            if not file_ids:
+                return []
         candidate_limit = max(top_k * 5, 50)
         if mode == "hybrid":
-            semantic = self._semantic_hits(query, candidate_limit)
-            keyword = self._keyword_hits(query, candidate_limit)
+            semantic = self._semantic_hits(
+                query, candidate_limit, file_ids=file_ids, chunk_where=chunk_where
+            )
+            keyword = self._keyword_hits(
+                query, candidate_limit, file_ids=file_ids, chunk_where=chunk_where
+            )
             references = self._rows_by_id(
                 [row_id for row_id, _ in semantic] + [row_id for row_id, _ in keyword]
             )
@@ -299,9 +463,13 @@ class VeraCollectionIndex:
                 ]
             ]
         if mode == "semantic":
-            ranked = self._semantic_hits(query, top_k)
+            ranked = self._semantic_hits(
+                query, top_k, file_ids=file_ids, chunk_where=chunk_where
+            )
         else:
-            ranked = self._keyword_hits(query, top_k)
+            ranked = self._keyword_hits(
+                query, top_k, file_ids=file_ids, chunk_where=chunk_where
+            )
         if not ranked:
             return []
         references = self._rows_by_id([row_id for row_id, _ in ranked])

--- a/packages/vera-doc/src/vera_doc/corpus.py
+++ b/packages/vera-doc/src/vera_doc/corpus.py
@@ -502,14 +502,15 @@ class VeraCorpus:
             self._search_used_index = False
             return []
         self.skipped_semantic_model_groups = []
-        use_index = self._collection_index is not None
-        if use_index and where and not self._collection_index.supports_where(where):
-            use_index = False
+        collection_index = self._collection_index
+        if collection_index is not None and where and not collection_index.supports_where(where):
+            collection_index = None
+        use_index = collection_index is not None
         self._search_used_index = use_index
-        if use_index:
+        if collection_index is not None:
             final = self._search_index(text, mode, top_k, where=where)
             self.skipped_semantic_model_groups = list(
-                self._collection_index.skipped_semantic_model_groups
+                collection_index.skipped_semantic_model_groups
             )
         elif mode == "hybrid":
             candidate_limit = max(top_k * 5, 50)

--- a/packages/vera-doc/src/vera_doc/corpus.py
+++ b/packages/vera-doc/src/vera_doc/corpus.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import os
 from collections import OrderedDict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
 from ._util import _MAX_TOP_K
+from ._where import CHUNK_METADATA_FILTER_REASON, metadata_matches
 from .collection import (
     VeraCollectionIndex,
     discover_vera_files,
@@ -29,6 +30,15 @@ class CorpusSearchResult(QueryResult):
 
     def as_dict(self) -> dict[str, Any]:
         return {"file": self.file, **super().as_dict()}
+
+
+def _archive_where_skips(doc: VeraDocument, where: Mapping[str, Any] | None) -> bool:
+    """Skip a file when archive-level ``where`` keys fail the predicate."""
+    if not where:
+        return False
+    combined = {**doc.format_metadata(), **dict(doc.metadata)}
+    applicable = {key: value for key, value in where.items() if key in combined}
+    return bool(applicable) and not metadata_matches(combined, applicable)
 
 
 def _with_file(result: QueryResult, file: str) -> CorpusSearchResult:
@@ -142,6 +152,7 @@ class VeraCorpus:
         *,
         recursive: bool = False,
         excludes: tuple[str, ...] = (),
+        includes: tuple[str, ...] = (),
         max_open_documents: int = 16,
         collection_index: VeraCollectionIndex | None = None,
         index_status: dict[str, Any] | None = None,
@@ -151,9 +162,11 @@ class VeraCorpus:
         self.paths = paths
         self.recursive = recursive
         self.excludes = excludes
+        self.includes = includes
         self.max_open_documents = max(1, max_open_documents)
         self._docs: OrderedDict[str, VeraDocument] = OrderedDict()
         self._collection_index = collection_index
+        self._search_used_index: bool | None = None
         self.index_status = index_status or {
             "exists": False,
             "fresh": False,
@@ -169,6 +182,7 @@ class VeraCorpus:
         *,
         recursive: bool | None = None,
         excludes: list[str] | tuple[str, ...] | None = None,
+        includes: list[str] | tuple[str, ...] | None = None,
         max_open_documents: int = 16,
         use_index: bool = True,
         default_recursive: bool = False,
@@ -181,6 +195,8 @@ class VeraCorpus:
             recursive: When ``True``, include nested directories. When ``None``,
                 use persisted index settings when an index exists.
             excludes: Glob patterns to skip.
+            includes: Glob patterns that a relative path must match when
+                provided. Omitted includes keep every discovered file.
             max_open_documents: LRU cache size for opened documents.
             use_index: When ``True``, use a fresh local index when available.
             default_recursive: Default recursion when no index exists.
@@ -207,9 +223,16 @@ class VeraCorpus:
             if excludes is None and status.get("exists")
             else tuple(excludes or ())
         )
-        config_matches = effective_recursive == bool(
-            status.get("recursive", False)
-        ) and effective_excludes == tuple(status.get("excludes", ()))
+        effective_includes = (
+            tuple(status.get("includes", ()))
+            if includes is None and status.get("exists")
+            else tuple(includes or ())
+        )
+        config_matches = (
+            effective_recursive == bool(status.get("recursive", False))
+            and effective_excludes == tuple(status.get("excludes", ()))
+            and effective_includes == tuple(status.get("includes", ()))
+        )
         collection_index = None
         if use_index and status.get("fresh") and config_matches:
             collection_index = VeraCollectionIndex.open(str(root), check_status=False)
@@ -224,6 +247,7 @@ class VeraCorpus:
                     root,
                     recursive=effective_recursive,
                     excludes=effective_excludes,
+                    includes=effective_includes,
                 )
             ]
         if not paths and not allow_empty:
@@ -245,6 +269,7 @@ class VeraCorpus:
             paths,
             recursive=effective_recursive,
             excludes=effective_excludes,
+            includes=effective_includes,
             max_open_documents=max_open_documents,
             collection_index=collection_index,
             index_status=status,
@@ -294,8 +319,23 @@ class VeraCorpus:
 
     @property
     def uses_index(self) -> bool:
-        """Whether searches are currently served by the local collection index."""
+        """Whether the most recent search used the local collection index.
+
+        Before the first search, this is whether an index is attached.
+        """
+        if self._search_used_index is not None:
+            return self._search_used_index
         return self._collection_index is not None
+
+    def index_search_report(self) -> dict[str, Any]:
+        """Index status for the most recent search, including fallback reasons."""
+        status = dict(self.index_status)
+        if self._search_used_index is False and self._collection_index is not None:
+            reasons = list(status.get("reasons") or [])
+            if CHUNK_METADATA_FILTER_REASON not in reasons:
+                reasons.append(CHUNK_METADATA_FILTER_REASON)
+            status["reasons"] = reasons
+        return {"used": self.uses_index, **status}
 
     def inspect(
         self,
@@ -442,8 +482,12 @@ class VeraCorpus:
         mode: str = "hybrid",
         top_k: int = 10,
         context_chunks: int = 0,
+        where: Mapping[str, Any] | None = None,
     ) -> list[CorpusSearchResult]:
-        """Search every file in the corpus and return the fused top_k results."""
+        """Search every file in the corpus and return the fused top_k results.
+
+        ``where`` filters stored archive and chunk metadata before ``top_k``.
+        """
         mode = mode.lower()
         if mode not in {"semantic", "keyword", "hybrid"}:
             raise ValueError("mode must be semantic, keyword, or hybrid")
@@ -455,19 +499,26 @@ class VeraCorpus:
             raise ValueError("context_chunks must be non-negative")
         if top_k == 0:
             self.skipped_semantic_model_groups = []
+            self._search_used_index = False
             return []
         self.skipped_semantic_model_groups = []
-        if self._collection_index is not None:
-            final = self._search_index(text, mode, top_k)
+        use_index = self._collection_index is not None
+        if use_index and where and not self._collection_index.supports_where(where):
+            use_index = False
+        self._search_used_index = use_index
+        if use_index:
+            final = self._search_index(text, mode, top_k, where=where)
             self.skipped_semantic_model_groups = list(
                 self._collection_index.skipped_semantic_model_groups
             )
         elif mode == "hybrid":
             candidate_limit = max(top_k * 5, 50)
-            semantic_files, keyword_files, models = self._search_files_hybrid(text, candidate_limit)
+            semantic_files, keyword_files, models = self._search_files_hybrid(
+                text, candidate_limit, where=where
+            )
             final = self._fuse_hybrid(semantic_files, keyword_files, models, top_k)
         else:
-            per_file, models = self._search_files(text, mode, top_k)
+            per_file, models = self._search_files(text, mode, top_k, where=where)
             if mode == "semantic":
                 final = self._fuse_semantic(per_file, models, top_k)
             else:
@@ -491,6 +542,8 @@ class VeraCorpus:
         query: str,
         mode: str,
         top_k: int,
+        *,
+        where: Mapping[str, Any] | None = None,
     ) -> tuple[dict[str, list[QueryResult]], dict[str, str]]:
         """Search files in parallel using short-lived, thread-local connections."""
 
@@ -502,11 +555,14 @@ class VeraCorpus:
                 validation = doc.validate()
                 if not validation["ok"]:
                     return path, [], "", "; ".join(validation["issues"])
+                if _archive_where_skips(doc, where):
+                    return path, [], "", None
                 model = str(doc.inspect().get("embedding_model") or "")
                 results = doc.search(
                     text=query,
                     mode=mode,  # type: ignore[arg-type]
                     top_k=top_k,
+                    where=where,
                 )
                 return path, results, model, None
             except Exception as exc:
@@ -545,6 +601,8 @@ class VeraCorpus:
         self,
         query: str,
         top_k: int,
+        *,
+        where: Mapping[str, Any] | None = None,
     ) -> tuple[dict[str, list[QueryResult]], dict[str, list[QueryResult]], dict[str, str]]:
         """Search each file once for semantic and keyword hits."""
 
@@ -556,9 +614,11 @@ class VeraCorpus:
                 validation = doc.validate()
                 if not validation["ok"]:
                     return path, [], [], "", "; ".join(validation["issues"])
+                if _archive_where_skips(doc, where):
+                    return path, [], [], "", None
                 model = str(doc.inspect().get("embedding_model") or "")
-                semantic = doc.search(text=query, mode="semantic", top_k=top_k)
-                keyword = doc.search(text=query, mode="keyword", top_k=top_k)
+                semantic = doc.search(text=query, mode="semantic", top_k=top_k, where=where)
+                keyword = doc.search(text=query, mode="keyword", top_k=top_k, where=where)
                 return path, semantic, keyword, model, None
             except Exception as exc:
                 return path, [], [], "", str(exc)
@@ -673,10 +733,17 @@ class VeraCorpus:
             if key in lookup
         ]
 
-    def _search_index(self, query: str, mode: str, top_k: int) -> list[CorpusSearchResult]:
+    def _search_index(
+        self,
+        query: str,
+        mode: str,
+        top_k: int,
+        *,
+        where: Mapping[str, Any] | None = None,
+    ) -> list[CorpusSearchResult]:
         assert self._collection_index is not None
         final: list[CorpusSearchResult] = []
-        for hit in self._collection_index.search(query, mode=mode, top_k=top_k):
+        for hit in self._collection_index.search(query, mode=mode, top_k=top_k, where=where):
             path = str((Path(self.directory) / Path(hit.relative_path)).resolve())
             doc = self.document(path)
             records = doc.get([hit.chunk_id])

--- a/packages/vera-doc/tests/test_database.py
+++ b/packages/vera-doc/tests/test_database.py
@@ -36,6 +36,15 @@ def test_database_chunk_crud_and_search(tmp_path: Path) -> None:
         )
         assert database.metadata == {"project": "test"}
         assert [item.id for item in database.get(where={"kind": "design"})] == ["one"]
+        assert [item.id for item in database.get(where={"kind": ["design", "landscape"]})] == [
+            "one",
+            "two",
+        ]
+        assert database.search(
+            text="detention requirements",
+            where={"kind": ["design"]},
+            top_k=1,
+        )[0].record.id == "one"
         assert database.search(text="detention requirements", top_k=1)[0].record.id == "one"
 
         database.upsert(

--- a/packages/vera-doc/tests/test_database.py
+++ b/packages/vera-doc/tests/test_database.py
@@ -40,11 +40,14 @@ def test_database_chunk_crud_and_search(tmp_path: Path) -> None:
             "one",
             "two",
         ]
-        assert database.search(
-            text="detention requirements",
-            where={"kind": ["design"]},
-            top_k=1,
-        )[0].record.id == "one"
+        assert (
+            database.search(
+                text="detention requirements",
+                where={"kind": ["design"]},
+                top_k=1,
+            )[0].record.id
+            == "one"
+        )
         assert database.search(text="detention requirements", top_k=1)[0].record.id == "one"
 
         database.upsert(

--- a/packages/vera-ingest/src/vera_ingest/__init__.py
+++ b/packages/vera-ingest/src/vera_ingest/__init__.py
@@ -6,7 +6,7 @@ from .chunking import (
     chunk_pages,
     detect_heading,
 )
-from .convert import batch_convert, convert
+from .convert import ReservedMetadataKeyError, batch_convert, convert
 from .descriptors import (
     PipelineCapabilities,
     PipelineDescriptor,
@@ -80,6 +80,7 @@ __all__ = [
     "PipelineFieldChoice",
     "PipelineOptions",
     "UnknownIngestPipelineError",
+    "ReservedMetadataKeyError",
     "batch_convert",
     "build_chunks_from_blocks",
     "chunk_pages",

--- a/packages/vera-ingest/src/vera_ingest/convert.py
+++ b/packages/vera-ingest/src/vera_ingest/convert.py
@@ -19,7 +19,6 @@ from vera_doc import (
     VeraDocument,
     get_embedder,
 )
-from vera_doc._schema import REQUIRED_METADATA_KEYS
 from vera_doc.models import (
     METADATA_DOCUMENT_ID,
     METADATA_HEADING_PATH,
@@ -51,6 +50,19 @@ class ReservedMetadataKeyError(ValueError):
     """Caller ``metadata`` collided with a reserved convert or format key."""
 
 
+_FORMAT_HEADER_KEYS = frozenset(
+    {
+        "format_name",
+        "format_version",
+        "created_at",
+        "created_by",
+        "creator_library",
+        "default_embedding_model",
+        "default_embedding_dimension",
+        "archive_metadata",
+        "default_embedding_normalization",
+    }
+)
 _CONVERT_OWNED_ARCHIVE_KEYS = frozenset(
     {
         "source_file_hash",
@@ -68,8 +80,7 @@ _CONVERT_OWNED_ARCHIVE_KEYS = frozenset(
 )
 _RESERVED_CALLER_METADATA_KEYS = frozenset(
     {
-        *REQUIRED_METADATA_KEYS,
-        "default_embedding_normalization",
+        *_FORMAT_HEADER_KEYS,
         METADATA_PAGE_START,
         METADATA_PAGE_END,
         METADATA_HEADING_PATH,

--- a/packages/vera-ingest/src/vera_ingest/convert.py
+++ b/packages/vera-ingest/src/vera_ingest/convert.py
@@ -5,8 +5,9 @@ import json
 import os
 import sqlite3
 import tempfile
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
+from math import isfinite
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,14 @@ from vera_doc import (
     EmbeddingFunction,
     VeraDocument,
     get_embedder,
+)
+from vera_doc._schema import REQUIRED_METADATA_KEYS
+from vera_doc.models import (
+    METADATA_DOCUMENT_ID,
+    METADATA_HEADING_PATH,
+    METADATA_PAGE_END,
+    METADATA_PAGE_START,
+    METADATA_SOURCE_FILENAME,
 )
 from vera_doc.validation import validate_document
 
@@ -36,6 +45,80 @@ from .pipeline import (
 )
 from .timing import timed_step
 from .types import IngestBlock, IngestRequest, IngestResult
+
+
+class ReservedMetadataKeyError(ValueError):
+    """Caller ``metadata`` collided with a reserved convert or format key."""
+
+
+_CONVERT_OWNED_ARCHIVE_KEYS = frozenset(
+    {
+        "source_file_hash",
+        "source_file_name",
+        "source_mime_type",
+        "chunking_strategy",
+        "parser_name",
+        "parser_version",
+        "ocr",
+        "page_count",
+        "viewer_pages_attachment_id",
+        "viewer_blocks_attachment_id",
+        "source_attachment_id",
+    }
+)
+_RESERVED_CALLER_METADATA_KEYS = frozenset(
+    {
+        *REQUIRED_METADATA_KEYS,
+        "default_embedding_normalization",
+        METADATA_PAGE_START,
+        METADATA_PAGE_END,
+        METADATA_HEADING_PATH,
+        METADATA_SOURCE_FILENAME,
+        METADATA_DOCUMENT_ID,
+        "token_count",
+        "regions",
+        *_CONVERT_OWNED_ARCHIVE_KEYS,
+    }
+)
+
+
+def _is_reserved_metadata_key(key: str) -> bool:
+    return (
+        key in _RESERVED_CALLER_METADATA_KEYS
+        or key.startswith("_vera_")
+        or key.startswith("default_embedding_")
+    )
+
+
+def _assert_scalar_metadata_value(key: str, value: Any) -> None:
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float) and isfinite(value):
+        return
+    raise ValueError(
+        f"metadata {key!r} must be a JSON scalar (string, int, bool, or finite float), "
+        f"not {type(value).__name__}"
+    )
+
+
+def _validated_caller_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return caller tags after rejecting reserved keys and nested values."""
+    if not metadata:
+        return {}
+    reserved = []
+    validated: dict[str, Any] = {}
+    for key, value in metadata.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError("metadata keys must be non-empty strings")
+        if _is_reserved_metadata_key(key):
+            reserved.append(key)
+            continue
+        _assert_scalar_metadata_value(key, value)
+        validated[key] = value
+    if reserved:
+        names = ", ".join(sorted(reserved))
+        raise ReservedMetadataKeyError(f"Reserved metadata key(s): {names}")
+    return validated
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -86,6 +169,7 @@ class _ConvertSettings:
     pipeline_options: dict[str, Any] | None = None
     embedder_options: dict[str, Any] | None = None
     cancel: Any | None = None
+    metadata: dict[str, Any] | None = None
 
     def resolve_embedder(self) -> EmbeddingFunction:
         if self.embedding_function is not None:
@@ -126,6 +210,7 @@ class _ConvertSettings:
             "pipeline_options": self.pipeline_options,
             "embedder_options": self.embedder_options,
             "cancel": self.cancel,
+            "metadata": self.metadata,
         }
 
 
@@ -216,6 +301,7 @@ def convert(
     pipeline_options: dict[str, Any] | None = None,
     embedder_options: dict[str, Any] | None = None,
     cancel: Any | None = None,
+    metadata: Mapping[str, Any] | None = None,
 ) -> str:
     """Convert a source document into a validated ``.vera`` archive.
 
@@ -270,6 +356,8 @@ def convert(
         embedder_options: Explicit provider-owned embedding options forwarded
             to :func:`~vera_doc.get_embedder` when ``embedding_function`` is omitted.
         cancel: Optional cancellation token with ``raise_if_cancelled()``.
+        metadata: Extra keys stamped onto archive metadata and every chunk.
+            Reserved ingest, citation, and format keys are rejected.
 
     Returns:
         The ``output_path`` string.
@@ -278,6 +366,7 @@ def convert(
         FileNotFoundError: When ``input_path`` does not exist.
         ValueError: When no searchable text is extracted, or ``parser`` does
             not support the source file type.
+        ReservedMetadataKeyError: When ``metadata`` uses a reserved key.
         UnknownIngestPipelineError: When ``parser`` cannot be resolved.
         UnknownEmbeddingModelError: When ``model`` cannot be resolved.
     """
@@ -300,6 +389,7 @@ def convert(
         pipeline_options=pipeline_options,
         embedder_options=embedder_options,
         cancel=cancel,
+        metadata=_validated_caller_metadata(metadata) or None,
     )
     resolved_parser = resolve_ingest_parser(source, settings.parser)
     settings = replace(settings, parser=resolved_parser)
@@ -422,6 +512,7 @@ def convert(
                 )
             )
 
+        caller_metadata = settings.metadata or {}
         archive_metadata = {
             "title": source.stem,
             "source_file_name": source.name,
@@ -435,6 +526,7 @@ def convert(
             "viewer_pages_attachment_id": "viewer_pages",
             "viewer_blocks_attachment_id": "viewer_blocks",
             "source_attachment_id": source_attachment_id,
+            **caller_metadata,
         }
         contextualized_indices = [
             index for index, chunk in enumerate(chunks) if chunk.embedding_text is not None
@@ -474,6 +566,7 @@ def convert(
                         "heading_path": chunk.heading_path,
                         "token_count": chunk.token_count,
                         "regions": regions,
+                        **caller_metadata,
                     },
                     attachments=tuple(references),
                     vector=contextualized_vectors.get(index),
@@ -586,6 +679,7 @@ def batch_convert(
     embedder_options: dict[str, Any] | None = None,
     progress: Callable[[int, int, str], None] | None = None,
     cancel: Any | None = None,
+    metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Convert source files from a directory scan or an explicit path list.
 
@@ -622,6 +716,7 @@ def batch_convert(
             :func:`convert`.
         progress: Optional ``(current, total, filename)`` callback.
         cancel: Optional cancellation token.
+        metadata: Extra keys stamped onto every archive and chunk in this run.
 
     Returns:
         A report dict with ``converted``, ``skipped``, ``failed``, and related
@@ -632,6 +727,7 @@ def batch_convert(
         NotADirectoryError: When ``directory`` is not a directory.
         FileNotFoundError: When a path in ``paths`` is missing.
         ValueError: When neither ``directory`` nor ``paths`` is usable.
+        ReservedMetadataKeyError: When ``metadata`` uses a reserved key.
         UnknownEmbeddingModelError: When ``model`` cannot be resolved.
     """
     settings = _ConvertSettings(
@@ -648,6 +744,7 @@ def batch_convert(
         pipeline_options=pipeline_options,
         embedder_options=embedder_options,
         cancel=cancel,
+        metadata=_validated_caller_metadata(metadata) or None,
     )
     # Resolve an explicit parser up front so a bad provider fails before discovery.
     if settings.parser:

--- a/packages/vera-ingest/src/vera_ingest/convert.py
+++ b/packages/vera-ingest/src/vera_ingest/convert.py
@@ -619,9 +619,7 @@ def _resolve_batch_sources(
     cancel: Any | None,
 ) -> tuple[Path, list[Path]]:
     """Return ``(report_root, sources)`` for directory discovery or an explicit list."""
-    suffixes = (
-        set(pipeline_source_formats(parser)) if parser else set(installed_source_formats())
-    )
+    suffixes = set(pipeline_source_formats(parser)) if parser else set(installed_source_formats())
     if not suffixes:
         raise ValueError("No installed ingest pipeline advertises source formats to convert.")
 
@@ -662,7 +660,9 @@ def _resolve_batch_sources(
                 name for name in directories if not (Path(current) / name).is_symlink()
             )
             sources.extend(
-                Path(current) / name for name in sorted(filenames) if is_source(Path(current) / name)
+                Path(current) / name
+                for name in sorted(filenames)
+                if is_source(Path(current) / name)
             )
     else:
         raise_if_cancelled(cancel)

--- a/packages/vera-ingest/src/vera_ingest/markdown/parser.py
+++ b/packages/vera-ingest/src/vera_ingest/markdown/parser.py
@@ -189,7 +189,11 @@ def parse_markdown(text: str) -> tuple[list[ParsedPage], list[MarkdownBlock]]:
             index += 1
             continue
 
-        if _looks_like_table_row(line) and index + 1 < total and _is_table_delimiter(lines[index + 1]):
+        if (
+            _looks_like_table_row(line)
+            and index + 1 < total
+            and _is_table_delimiter(lines[index + 1])
+        ):
             start = index
             index += 2
             while index < total and _looks_like_table_row(lines[index]):
@@ -228,8 +232,10 @@ def parse_markdown(text: str) -> tuple[list[ParsedPage], list[MarkdownBlock]]:
                 break
             if index + 1 < total and _setext_level(lines[index + 1]) and not _is_list_item(nxt):
                 break
-            if _looks_like_table_row(nxt) and index + 1 < total and _is_table_delimiter(
-                lines[index + 1]
+            if (
+                _looks_like_table_row(nxt)
+                and index + 1 < total
+                and _is_table_delimiter(lines[index + 1])
             ):
                 break
             collected.append(nxt)

--- a/packages/vera-mcp/src/vera_mcp/server.py
+++ b/packages/vera-mcp/src/vera_mcp/server.py
@@ -68,13 +68,18 @@ def build_server():
         include_figures: bool = False,
         include_regions: bool = False,
         context_chunks: int = 0,
+        where: dict[str, str | list[str]] | None = None,
     ) -> dict[str, Any]:
         """Search a VERA file and return citation-ready chunks."""
         doc = _open(file)
         try:
             results = []
             for result in doc.search(
-                text=query, mode=mode, top_k=top_k, context_chunks=context_chunks
+                text=query,
+                mode=mode,
+                top_k=top_k,
+                context_chunks=context_chunks,
+                where=where,
             ):
                 results.append(
                     result_payload(
@@ -99,13 +104,21 @@ def build_server():
         context_chunks: int = 0,
         recursive: bool | None = None,
         excludes: list[str] | None = None,
+        includes: list[str] | None = None,
+        where: dict[str, str | list[str]] | None = None,
     ) -> dict[str, Any]:
         """Search a VERA library, automatically using its fresh local index when available."""
-        corpus = VeraCorpus.open(directory, recursive=recursive, excludes=excludes)
+        corpus = VeraCorpus.open(
+            directory, recursive=recursive, excludes=excludes, includes=includes
+        )
         try:
             results = []
             for result in corpus.search(
-                text=query, mode=mode, top_k=top_k, context_chunks=context_chunks
+                text=query,
+                mode=mode,
+                top_k=top_k,
+                context_chunks=context_chunks,
+                where=where,
             ):
                 results.append(
                     result_payload(
@@ -119,7 +132,7 @@ def build_server():
                 "directory": directory,
                 "query": query,
                 "mode": mode,
-                "index": {"used": corpus.uses_index, **corpus.index_status},
+                "index": corpus.index_search_report(),
                 "skipped_files": corpus.invalid_files,
                 "skipped_semantic_model_groups": corpus.skipped_semantic_model_groups,
                 "results": results,

--- a/skills/vera/SKILL.md
+++ b/skills/vera/SKILL.md
@@ -58,6 +58,14 @@ Search a directory as one corpus by passing the directory instead of a file:
 vera search "./library" "stormwater detention requirements" --top-k 5 --json
 ```
 
+Filter a corpus with stored metadata or path includes instead of post-filtering
+JSON:
+
+```bash
+vera search "./archives" "adding capacity" --where company=GRID --json
+vera search "./research" "adding capacity" --recursive --include "companies/GRID/archives/**" --json
+```
+
 Use `--recursive` for a nested, unindexed directory. A fresh local index is used
 automatically when one exists; inspect the top-level `index.used` and
 `index.reasons` fields instead of assuming the index was active. Also inspect
@@ -90,6 +98,9 @@ rollback history. `vera eval` opens one `.vera` archive, not a directory.
 - Add `--regions` only when page bounding boxes are needed for visual grounding.
 - Increase `--top-k` to 10 for broad coverage; split compound questions into
   separate searches.
+- Scope a library with `--where KEY=VALUE` (stored metadata, before `top_k`)
+  or `--include PATTERN` (path discovery). Do not drop hits from JSON after
+  search. Stamp keys at convert time with `--metadata KEY=VALUE`.
 
 ## Citations and evidence
 

--- a/skills/vera/references/cli-reference.md
+++ b/skills/vera/references/cli-reference.md
@@ -101,6 +101,14 @@ Options:
   `embedder_options` entries (for example `--embedder-option batch_size=64`
   or `--embedder-option dimension=256`). Values coerce the same way as
   `--pipeline-option`.
+- `--metadata KEY=VALUE` is repeatable. Stamps the same keys onto archive
+  metadata and every chunk so `--where` can filter before `top_k`. Values
+  coerce like `--pipeline-option`. Nested JSON is rejected. Reserved keys
+  (`page_start`, `page_end`, `heading_path`, `source_filename`, `document_id`,
+  `token_count`, `regions`, required format header keys, `default_embedding_*`,
+  `_vera_*`, and convert-owned fields such as `source_file_hash`) exit 2.
+  `title` may be overridden. Directory convert applies the same tags to every
+  output; hash-matched skips do not restamp.
 - `--recursive` recursively discovers PDFs in directory mode.
 - `--overwrite` replaces existing outputs in directory mode. Without it,
   a sibling `.vera` is skipped only when it validates and its stored
@@ -310,6 +318,15 @@ Options:
 - `--recursive` discovers nested archives for an unindexed directory.
 - `--exclude PATTERN` excludes a relative path or name pattern and is
   repeatable.
+- `--include PATTERN` includes only matching relative paths and is
+  repeatable. If any include is present, a file must match at least one
+  include and no exclude. Directory search only; a single-file target
+  exits 2 with `{"ok": false, "error": "--include applies to directory search only"}`.
+- `--where KEY=VALUE` filters stored archive and chunk metadata before
+  `top_k` and is repeatable. Distinct keys are AND. Comma-separated values
+  are IN. Repeated flags for the same key union the IN set. Values coerce
+  like `--pipeline-option`. Empty comma tokens are an error (exit 2).
+  Do not post-filter the JSON `results` array.
 - `--json` emits one JSON object.
 
 Single-archive JSON:
@@ -447,6 +464,8 @@ Options:
 
 - `--recursive` discovers nested archives.
 - `--exclude PATTERN` is repeatable.
+- `--include PATTERN` is repeatable and is stored in index discovery
+  settings like excludes. `vera index update` keeps saved includes.
 - `--json` emits one JSON object.
 
 This command creates or replaces the hidden `.vera-index/` collection index.
@@ -463,6 +482,7 @@ An empty discovery set raises unstructured `No .vera files found in ...`
   "index": "C:/library/.vera-index",
   "recursive": true,
   "excludes": ["archive/**"],
+  "includes": [],
   "discovered": 12,
   "indexed": 11,
   "chunks": 4200,

--- a/skills/vera/references/retrieval-workflows.md
+++ b/skills/vera/references/retrieval-workflows.md
@@ -179,6 +179,7 @@ For a nested library without an index:
 
 ```bash
 vera search "./library" "insurance requirements" --recursive --exclude "archive/**" --json
+vera search "./library" "insurance requirements" --where company=GRID --json
 ```
 
 When sources disagree:

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -133,7 +133,14 @@ def test_human_cli_reference_covers_parser_commands_and_options():
 def test_documented_cli_examples_parse():
     parser = build_parser()
     examples = [
-        ["convert", "input.pdf", "output.vera", "--model", "hashing", "--json"],
+        [
+            "convert",
+            "input.pdf",
+            "output.vera",
+            "--metadata",
+            "company=GRID",
+            "--json",
+        ],
         [
             "convert",
             "input.pdf",
@@ -171,7 +178,26 @@ def test_documented_cli_examples_parse():
             "--regions",
             "--json",
         ],
+        [
+            "search",
+            "./library",
+            "adding capacity",
+            "--where",
+            "company=GRID,PWRX",
+            "--include",
+            "companies/GRID/archives/**",
+            "--json",
+        ],
         ["index", "build", "library", "--recursive", "--exclude", "archive/**", "--json"],
+        [
+            "index",
+            "build",
+            "library",
+            "--recursive",
+            "--include",
+            "companies/GRID/archives/**",
+            "--json",
+        ],
         ["index", "update", "library", "--json"],
         ["index", "status", "library", "--json"],
         ["validate", "output.vera", "--json"],

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -10,9 +10,8 @@ from pathlib import Path
 import pytest
 
 from vera_cli.main import build_parser
-from vera_doc import VeraCorpus, VeraDocument, build_library_index
+from vera_doc import ChunkRecord, VeraCorpus, VeraDocument, build_library_index
 from vera_doc.collection import CHUNK_METADATA_FILTER_REASON, discover_vera_files
-from vera_doc.document import ChunkRecord
 from vera_ingest import ReservedMetadataKeyError, convert
 
 

--- a/tests/test_search_filters.py
+++ b/tests/test_search_filters.py
@@ -1,0 +1,334 @@
+"""Convert metadata stamps and search --where / --include filters."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vera_cli.main import build_parser
+from vera_doc import VeraCorpus, VeraDocument, build_library_index
+from vera_doc.collection import CHUNK_METADATA_FILTER_REASON, discover_vera_files
+from vera_doc.document import ChunkRecord
+from vera_ingest import ReservedMetadataKeyError, convert
+
+
+def _run_cli(*argv: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "vera_cli", *argv],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _write_capacity_markdown(path: Path, company: str, sections: int = 8) -> None:
+    blocks = [
+        f"# {company} capacity {index}\n\n"
+        f"{company} adding capacity discussion {index} unique_{company}_{index}.\n"
+        for index in range(sections)
+    ]
+    path.write_text("\n".join(blocks), encoding="utf-8")
+
+
+def _convert_company(path: Path, company: str, sections: int = 8) -> Path:
+    source = path.with_suffix(".md")
+    _write_capacity_markdown(source, company, sections=sections)
+    convert(
+        str(source),
+        str(path),
+        model="hashing",
+        metadata={"company": company, "document_type": "filings"},
+    )
+    return path
+
+
+def test_convert_stamps_archive_and_chunk_metadata(tmp_path: Path) -> None:
+    source = tmp_path / "notes.md"
+    source.write_text("# Detention\n\nPonds must detain the 25-year storm.\n", encoding="utf-8")
+    out = tmp_path / "notes.vera"
+    convert(str(source), str(out), metadata={"company": "GRID", "source_id": "src_aaa"})
+    with VeraDocument.open(str(out)) as document:
+        assert document.metadata["company"] == "GRID"
+        assert document.metadata["source_id"] == "src_aaa"
+        inspect = document.inspect()
+        assert inspect["company"] == "GRID"
+        chunks = document.get()
+        assert chunks
+        assert all(chunk.metadata["company"] == "GRID" for chunk in chunks)
+        hits = document.search("detain", mode="keyword", where={"company": "GRID"})
+        assert hits
+        assert document.search("detain", mode="keyword", where={"company": "PWRX"}) == []
+
+
+def test_convert_rejects_reserved_metadata_keys(tmp_path: Path) -> None:
+    source = tmp_path / "notes.md"
+    source.write_text("# Detention\n\nPonds must detain the 25-year storm.\n", encoding="utf-8")
+    out = tmp_path / "notes.vera"
+    with pytest.raises(ReservedMetadataKeyError, match="page_start"):
+        convert(str(source), str(out), metadata={"page_start": 1})
+    with pytest.raises(ReservedMetadataKeyError, match="source_file_hash"):
+        convert(str(source), str(out), metadata={"source_file_hash": "abc"})
+
+
+def test_cli_convert_metadata_and_where(tmp_path: Path) -> None:
+    source = tmp_path / "notes.md"
+    source.write_text("# Detention\n\nPonds must detain the 25-year storm.\n", encoding="utf-8")
+    out = tmp_path / "notes.vera"
+    converted = _run_cli(
+        "convert",
+        str(source),
+        str(out),
+        "--metadata",
+        "company=GRID",
+        "--json",
+    )
+    assert converted.returncode == 0, converted.stderr
+    inspected = _run_cli("inspect", str(out), "--json")
+    info = json.loads(inspected.stdout)
+    assert info["company"] == "GRID"
+    hit = _run_cli("search", str(out), "detain", "--where", "company=GRID", "--json")
+    assert hit.returncode == 0, hit.stderr
+    assert json.loads(hit.stdout)["results"]
+    miss = _run_cli("search", str(out), "detain", "--where", "company=PWRX", "--json")
+    assert miss.returncode == 0, miss.stderr
+    assert json.loads(miss.stdout)["results"] == []
+
+
+def test_cli_reserved_metadata_exits_2(tmp_path: Path) -> None:
+    source = tmp_path / "notes.md"
+    source.write_text("# Detention\n\nPonds.\n", encoding="utf-8")
+    out = tmp_path / "notes.vera"
+    proc = _run_cli(
+        "convert",
+        str(source),
+        str(out),
+        "--metadata",
+        "page_start=1",
+        "--json",
+    )
+    assert proc.returncode == 2
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is False
+    assert "page_start" in payload["error"]
+
+
+def test_cli_include_on_file_exits_2(tmp_path: Path) -> None:
+    source = tmp_path / "notes.md"
+    out = tmp_path / "notes.vera"
+    source.write_text("# Detention\n\nPonds.\n", encoding="utf-8")
+    convert(str(source), str(out))
+    proc = _run_cli(
+        "search",
+        str(out),
+        "Ponds",
+        "--include",
+        "notes.vera",
+        "--json",
+    )
+    assert proc.returncode == 2
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is False
+    assert "--include" in payload["error"]
+
+
+def test_cli_where_without_equals_exits_2() -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["search", "library", "query", "--where", "company"])
+    assert exc.value.code == 2
+
+
+def test_corpus_where_fills_top_k_from_matching_files(tmp_path: Path) -> None:
+    library = tmp_path / "archives"
+    library.mkdir()
+    _convert_company(library / "grid.vera", "GRID", sections=8)
+    _convert_company(library / "pwrx.vera", "PWRX", sections=8)
+    with VeraCorpus.open(str(library), use_index=False) as corpus:
+        mixed = corpus.search("adding capacity", mode="keyword", top_k=6)
+        assert {Path(hit.file).name for hit in mixed} == {"grid.vera", "pwrx.vera"}
+        grid = corpus.search(
+            "adding capacity",
+            mode="keyword",
+            top_k=5,
+            where={"company": "GRID"},
+        )
+        assert len(grid) == 5
+        assert all(Path(hit.file).name == "grid.vera" for hit in grid)
+        both = corpus.search(
+            "adding capacity",
+            mode="keyword",
+            top_k=6,
+            where={"company": ["GRID", "PWRX"]},
+        )
+        assert {Path(hit.file).name for hit in both} == {"grid.vera", "pwrx.vera"}
+        and_filter = corpus.search(
+            "adding capacity",
+            mode="keyword",
+            top_k=5,
+            where={"company": "GRID", "document_type": "filings"},
+        )
+        assert and_filter
+        assert all(Path(hit.file).name == "grid.vera" for hit in and_filter)
+        miss = corpus.search(
+            "adding capacity",
+            mode="keyword",
+            top_k=5,
+            where={"company": "GRID", "document_type": "slides"},
+        )
+        assert miss == []
+
+
+def test_include_exclude_discovery_matrix(tmp_path: Path) -> None:
+    root = tmp_path / "proposals"
+    (root / "utilities" / "2023").mkdir(parents=True)
+    (root / "transportation" / "2024").mkdir(parents=True)
+    (root / "archive").mkdir()
+    _convert_company(root / "utilities" / "2023" / "water.vera", "WATER", sections=2)
+    _convert_company(root / "transportation" / "2024" / "roadway.vera", "ROAD", sections=2)
+    _convert_company(root / "archive" / "old.vera", "OLD", sections=2)
+
+    all_recursive = discover_vera_files(root, recursive=True)
+    assert len(all_recursive) == 3
+
+    utilities = discover_vera_files(root, recursive=True, includes=["utilities/**"])
+    assert [path.name for path in utilities] == ["water.vera"]
+
+    included_then_excluded = discover_vera_files(
+        root,
+        recursive=True,
+        includes=["archive"],
+        excludes=["archive"],
+    )
+    assert included_then_excluded == []
+
+    mixed = discover_vera_files(
+        root,
+        recursive=True,
+        includes=["utilities/**", "archive"],
+        excludes=["archive"],
+    )
+    assert [path.name for path in mixed] == ["water.vera"]
+
+    no_includes = discover_vera_files(root, recursive=True, excludes=["archive"])
+    assert {path.name for path in no_includes} == {"water.vera", "roadway.vera"}
+
+
+def test_indexed_archive_where_and_chunk_fallback(tmp_path: Path) -> None:
+    library = tmp_path / "library"
+    library.mkdir()
+    _convert_company(library / "grid.vera", "GRID", sections=6)
+    _convert_company(library / "pwrx.vera", "PWRX", sections=6)
+    build_library_index(str(library))
+
+    with VeraCorpus.open(str(library)) as corpus:
+        results = corpus.search(
+            "adding capacity",
+            mode="keyword",
+            top_k=4,
+            where={"company": "GRID"},
+        )
+        assert corpus.uses_index is True
+        assert all(Path(hit.file).name == "grid.vera" for hit in results)
+        assert len(results) == 4
+
+    civil = library / "civil.vera"
+    electrical = library / "electrical.vera"
+    _chunk_only_archive(civil, "civil", "Civil adding capacity for the pond.")
+    _chunk_only_archive(electrical, "electrical", "Electrical adding capacity for the feeder.")
+    build_library_index(str(library))
+
+    with VeraCorpus.open(str(library)) as corpus:
+        results = corpus.search(
+            "adding capacity",
+            mode="keyword",
+            top_k=4,
+            where={"discipline": "civil"},
+        )
+        report = corpus.index_search_report()
+        assert report["used"] is False
+        assert CHUNK_METADATA_FILTER_REASON in report["reasons"]
+        assert results
+        assert all(hit.record.metadata.get("discipline") == "civil" for hit in results)
+
+
+def _chunk_only_archive(path: Path, discipline: str, text: str) -> None:
+    with VeraDocument.create(path) as document:
+        document.add(
+            [
+                ChunkRecord(
+                    id="chunk_0001",
+                    text=text,
+                    metadata={
+                        "document_id": "document_0001",
+                        "source_filename": path.name,
+                        "page_start": 1,
+                        "page_end": 1,
+                        "heading_path": "Notes",
+                        "discipline": discipline,
+                    },
+                )
+            ]
+        )
+
+
+@pytest.mark.anyio
+async def test_mcp_search_where_and_corpus_include(tmp_path: Path) -> None:
+    from vera_mcp import build_server
+
+    library = tmp_path / "library"
+    nested = library / "companies" / "GRID" / "archives"
+    nested.mkdir(parents=True)
+    other = library / "companies" / "PWRX" / "archives"
+    other.mkdir(parents=True)
+    _convert_company(nested / "grid.vera", "GRID", sections=3)
+    _convert_company(other / "pwrx.vera", "PWRX", sections=3)
+
+    server = build_server()
+
+    def payload(result):
+        if isinstance(result, tuple):
+            content, structured = result
+            if structured is not None:
+                return structured.get("result", structured)
+            return json.loads(content[0].text)
+        return result
+
+    single = payload(
+        await server.call_tool(
+            "vera_search",
+            {
+                "file": str(nested / "grid.vera"),
+                "query": "adding capacity",
+                "mode": "keyword",
+                "where": {"company": "GRID"},
+                "top_k": 2,
+            },
+        )
+    )
+    assert single["results"]
+
+    corpus = payload(
+        await server.call_tool(
+            "vera_corpus_search",
+            {
+                "directory": str(library),
+                "query": "adding capacity",
+                "mode": "keyword",
+                "recursive": True,
+                "includes": ["companies/GRID/archives/**"],
+                "where": {"company": "GRID"},
+                "top_k": 3,
+            },
+        )
+    )
+    assert corpus["results"]
+    assert all(hit["file"].endswith("grid.vera") for hit in corpus["results"])
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Convert `--metadata KEY=VALUE` stamps the same caller tags onto archive metadata and every chunk (reserved citation/format/ingest keys are rejected).
- Search `--where KEY=VALUE` filters stored metadata **before** `top_k` (AND across keys; comma-separated values are IN). Directory `--include PATTERN` composes with `--exclude`.
- Collection-index search applies archive-level `where` (and indexed citation columns) before scoring. Chunk-only keys that are not in the index fall back to per-file search with `index.used=false` and `chunk metadata filter not in collection index`.
- MCP `vera_search` / `vera_corpus_search` and the Python `convert` / `VeraCorpus` APIs take the same arguments. Format stays 0.2; no merge/upsert APIs.

## Test plan

- [x] Relevant automated tests pass. Full `uv run --extra dev python -m pytest -q` is green locally (including `tests/test_search_filters.py`, documentation contracts, collection index, CLI, and MCP).
- [x] Retrieval behavior checked with an end-to-end CLI demo: convert two archives with `--metadata company=GRID|PWRX`, corpus `--where company=GRID` fills `top_k` from GRID only, reserved `--metadata page_start=1` exits 2, `--include` on a file exits 2, and indexed search reports `index.used=true` for archive-level `where`.

## Documentation

- [x] User-visible behavior is documented in the README or relevant `docs/` guide.
- [x] CLI/API/MCP references and examples reflect public contract changes.
- [x] `skills/vera/` reflects agent-facing behavior changes.
- [x] Documentation-contract tests were updated when commands, options, JSON, exit codes, links, or documented workflows changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4a4038d-077d-4f8c-88f6-31ec396e6e72?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4a4038d-077d-4f8c-88f6-31ec396e6e72&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

